### PR TITLE
Add /browse + llms.txt so LLMs can answer questions from the dashboard

### DIFF
--- a/app/src/app/browse/__tests__/browse.test.ts
+++ b/app/src/app/browse/__tests__/browse.test.ts
@@ -2,9 +2,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // Mock the data store so the route logic can be tested without CSV data.
+// isOutdated keeps its real >10-year rule (it's a pure function).
 vi.mock("@/lib/data/species-store", () => ({
   getSpecies: vi.fn(() => []),
   searchSpecies: vi.fn(() => []),
+  isOutdated: (date: string | null) => {
+    if (!date) return true;
+    const year = parseInt(date.slice(0, 4), 10);
+    return Number.isNaN(year) ? true : new Date().getFullYear() - year > 10;
+  },
 }));
 
 import { getSpecies, searchSpecies } from "@/lib/data/species-store";
@@ -22,9 +28,12 @@ function row(overrides: Record<string, unknown> = {}) {
     category: "CR", threat_codes: ["11.1", "11.4", "5.4"],
     countries: ["US"], systems: ["Marine"], population_trend: "Decreasing",
     movement_pattern: null, growth_forms: [], has_map: true,
+    gbif_occurrence_count: 50, assessment_date: "2018-06-01",
     ...overrides,
   };
 }
+
+const RECENT_YEAR = `${new Date().getFullYear()}-01-01`; // never outdated (>10yr rule)
 
 function get(qs: string) {
   return GET(new NextRequest(`https://red.cst.cam.ac.uk/browse${qs}`));
@@ -101,6 +110,35 @@ describe("/browse", () => {
     expect(data.total).toBe(1);
     expect(data.species[0].scientific_name).toBe("Panthera tigris");
     expect(mSearch).toHaveBeenCalled();
+  });
+
+  it("reports outdated stats for percentage questions", async () => {
+    mGetSpecies.mockReturnValue([
+      row({ taxon_group: "mammalia", assessment_date: "1990-01-01" }),
+      row({ taxon_group: "mammalia", assessment_date: "1995-01-01" }),
+      row({ taxon_group: "mammalia", assessment_date: RECENT_YEAR }),
+      row({ taxon_group: "mammalia", assessment_date: RECENT_YEAR }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    const data = await (await get("?taxa=mammalia&format=json")).json();
+    expect(data.stats.assessed).toBe(4);
+    expect(data.stats.outdated).toBe(2);
+    expect(data.stats.outdated_pct).toBe(50);
+  });
+
+  it("filters by outdated, minObs and country together", async () => {
+    mGetSpecies.mockReturnValue([
+      row({ scientific_name: "Match sp", taxon_group: "insecta", category: "DD", countries: ["IN"], gbif_occurrence_count: 150, assessment_date: "2005-01-01" }),
+      row({ scientific_name: "TooFewObs sp", taxon_group: "insecta", category: "DD", countries: ["IN"], gbif_occurrence_count: 5, assessment_date: "2005-01-01" }),
+      row({ scientific_name: "Recent sp", taxon_group: "insecta", category: "DD", countries: ["IN"], gbif_occurrence_count: 150, assessment_date: RECENT_YEAR }),
+      row({ scientific_name: "WrongCountry sp", taxon_group: "insecta", category: "DD", countries: ["US"], gbif_occurrence_count: 150, assessment_date: "2005-01-01" }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    const data = await (await get("?taxa=insecta&categories=DD&minObs=100&outdated=yes&countries=India&format=json")).json();
+    expect(data.total).toBe(1);
+    expect(data.species[0].scientific_name).toBe("Match sp");
+    expect(data.interpreted.join(" | ")).toMatch(/India \(IN\)/);
+    expect(data.interpreted.join(" | ")).toMatch(/Outdated/);
   });
 
   it("serves an HTML index for a bare request", async () => {

--- a/app/src/app/browse/__tests__/browse.test.ts
+++ b/app/src/app/browse/__tests__/browse.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Mock the data store so the route logic can be tested without CSV data.
+vi.mock("@/lib/data/species-store", () => ({
+  getSpecies: vi.fn(() => []),
+  searchSpecies: vi.fn(() => []),
+}));
+
+import { getSpecies, searchSpecies } from "@/lib/data/species-store";
+import { GET } from "@/app/browse/route";
+
+const mGetSpecies = vi.mocked(getSpecies);
+const mSearch = vi.mocked(searchSpecies);
+
+// Minimal SpeciesRow-shaped fixture (only fields the route touches).
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1, sis_taxon_id: 1, taxon_group: "corals",
+    class_name: null, order_name: null, family: null,
+    scientific_name: "Acropora cervicornis", common_name: "Staghorn coral",
+    category: "CR", threat_codes: ["11.1", "11.4", "5.4"],
+    countries: ["US"], systems: ["Marine"], population_trend: "Decreasing",
+    movement_pattern: null, growth_forms: [], has_map: true,
+    ...overrides,
+  };
+}
+
+function get(qs: string) {
+  return GET(new NextRequest(`https://red.cst.cam.ac.uk/browse${qs}`));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mGetSpecies.mockReturnValue([] as any);
+  mSearch.mockReturnValue([]);
+});
+
+describe("/browse", () => {
+  it("filters corals to the climate-change subset", async () => {
+    mGetSpecies.mockReturnValue([
+      row(),
+      row({ scientific_name: "Montastraea cavernosa", threat_codes: ["5.4"], category: "EN" }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    const res = await get("?taxa=corals&threats=climate-change&format=json");
+    const data = await res.json();
+    expect(data.total).toBe(1);
+    expect(data.species[0].scientific_name).toBe("Acropora cervicornis");
+    expect(data.breakdown).toEqual({ CR: 1 });
+    expect(data.interpreted.join(" ")).toMatch(/Climate change/);
+  });
+
+  it("returns the whole taxon when only taxa is given", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mGetSpecies.mockReturnValue([row(), row({ scientific_name: "X", category: "EN" })] as any);
+    const data = await (await get("?taxa=corals&format=json")).json();
+    expect(data.total).toBe(2);
+  });
+
+  it("caps results at 200 but reports the true total", async () => {
+    const many = Array.from({ length: 201 }, (_, i) => row({ scientific_name: `Coral ${i}`, sis_taxon_id: i }));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mGetSpecies.mockReturnValue(many as any);
+    const data = await (await get("?taxa=corals&threats=11&format=json")).json();
+    expect(data.total).toBe(201);
+    expect(data.shown).toBe(200);
+    expect(data.capped).toBe(true);
+  });
+
+  it("reports no matches clearly", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mGetSpecies.mockReturnValue([row()] as any);
+    const data = await (await get("?taxa=corals&categories=extinct&format=json")).json();
+    expect(data.total).toBe(0);
+  });
+
+  it("shows a self-describing index (no data scan) when nothing is selected", async () => {
+    const data = await (await get("?format=json")).json();
+    expect(data.params.threats.some((t: { code: string }) => t.code === "11")).toBe(true);
+    expect(mGetSpecies).not.toHaveBeenCalled();
+  });
+
+  it("echoes unresolved taxa instead of scanning", async () => {
+    const data = await (await get("?taxa=dinosaurs&format=json")).json();
+    expect(data.unresolved).toContain("taxa=dinosaurs");
+    expect(mGetSpecies).not.toHaveBeenCalled();
+  });
+
+  it("supports name search across taxa via the search index", async () => {
+    mSearch.mockReturnValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { taxon_group: "mammalia" } as any,
+    ]);
+    mGetSpecies.mockReturnValue([
+      row({ taxon_group: "mammalia", scientific_name: "Panthera tigris", common_name: "Tiger", threat_codes: ["5.1"], category: "EN" }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    const data = await (await get("?search=tiger&format=json")).json();
+    expect(data.total).toBe(1);
+    expect(data.species[0].scientific_name).toBe("Panthera tigris");
+    expect(mSearch).toHaveBeenCalled();
+  });
+
+  it("serves an HTML index for a bare request", async () => {
+    const res = await get("");
+    expect(res.headers.get("content-type")).toMatch(/text\/html/);
+    const body = await res.text();
+    expect(body).toMatch(/Browse/);
+    expect(body).toMatch(/llms\.txt/);
+  });
+});

--- a/app/src/app/browse/route.ts
+++ b/app/src/app/browse/route.ts
@@ -1,0 +1,295 @@
+/**
+ * /browse — server-rendered, LLM- and human-readable view of the dashboard's
+ * base filters. The main dashboard is a client-rendered SPA (empty HTML to a
+ * crawler), so this route returns real content for a pasted URL.
+ *
+ * Mirrors the dashboard's own filter-param vocabulary, accepts plain-English
+ * values (threats=climate-change, categories=endangered, taxa=birds,
+ * countries=Brazil), renders codes back as labels, and is capped (never a bulk
+ * dump). Add ?format=json for agentic clients.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getSpecies, searchSpecies, type SpeciesRow } from "@/lib/data/species-store";
+import { getCsvGroupsForNode, speciesMatchesNode } from "@/lib/taxonomy-utils";
+import { matchesSpeciesFilter, type SpeciesFilterCriteria } from "@/lib/species-filter";
+import { CATEGORY_ORDER } from "@/config/taxa";
+import { CACHE_1H } from "@/lib/cache-headers";
+import {
+  resolveTaxa, resolveThreats, resolveCategories, resolveCountries,
+  taxonLabel, categoryLabel, countryLabel, threatDisplay,
+  THREAT_LABEL, THREAT_CATEGORIES, FEATURED_TAXA, ALL_CATEGORIES,
+  SYSTEMS, POPULATION_TRENDS,
+} from "@/lib/filter-vocab";
+
+export const revalidate = 3600;
+
+const RESULT_CAP = 200;
+const BASE = "/browse";
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+const esc = (s: string) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+const setOrUndef = (a: string[]) => (a.length ? new Set(a) : undefined);
+
+function parseList(sp: URLSearchParams, key: string): string[] {
+  return (sp.getAll(key).join(",") || "").split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+/** Match free-text values case-insensitively against a fixed option list. */
+function normalizeOneOf(values: string[], options: string[]): { values: string[]; unresolved: string[] } {
+  const out: string[] = [];
+  const unresolved: string[] = [];
+  for (const v of values) {
+    const hit = options.find((o) => o.toLowerCase() === v.toLowerCase());
+    if (hit) out.push(hit);
+    else unresolved.push(v);
+  }
+  return { values: out, unresolved };
+}
+
+function threatLabel(code: string): string {
+  return THREAT_LABEL[code] ? `${THREAT_LABEL[code]} (${code})` : code;
+}
+
+// ─── route ───────────────────────────────────────────────────────────────
+
+export async function GET(req: NextRequest) {
+  const sp = req.nextUrl.searchParams;
+  const format = sp.get("format");
+
+  const taxa = resolveTaxa(parseList(sp, "taxa"));
+  const threats = resolveThreats(parseList(sp, "threats"));
+  const categories = resolveCategories(parseList(sp, "categories"));
+  const countries = resolveCountries(parseList(sp, "countries"));
+  const systems = normalizeOneOf(parseList(sp, "systems"), SYSTEMS);
+  const trends = normalizeOneOf(parseList(sp, "trends"), POPULATION_TRENDS);
+  const movement = parseList(sp, "movement");
+  const growthForms = parseList(sp, "growthForms");
+  const hasMapRaw = sp.get("hasMap");
+  const hasMap: "yes" | "no" | null = hasMapRaw === "yes" ? "yes" : hasMapRaw === "no" ? "no" : null;
+  const search = (sp.get("search") ?? "").trim();
+
+  const unresolved = [
+    ...taxa.unresolved.map((v) => `taxa=${v}`),
+    ...threats.unresolved.map((v) => `threats=${v}`),
+    ...categories.unresolved.map((v) => `categories=${v}`),
+    ...countries.unresolved.map((v) => `countries=${v}`),
+    ...systems.unresolved.map((v) => `systems=${v}`),
+    ...trends.unresolved.map((v) => `trends=${v}`),
+  ];
+
+  // No actionable selector → self-describing index (never a 280k scan).
+  if (taxa.ids.length === 0 && !search) {
+    return format === "json"
+      ? NextResponse.json(indexData(unresolved), { headers: CACHE_1H })
+      : html(indexHtml(unresolved));
+  }
+
+  // Resolve which CSV groups to load.
+  let groups: string[];
+  if (taxa.ids.length) {
+    groups = [...new Set(taxa.ids.flatMap(getCsvGroupsForNode))];
+  } else {
+    // Search-only: narrow to the taxon groups the search index says contain hits.
+    // Use a generous limit since we only need the distinct groups, not the rows.
+    const hits = searchSpecies(search, 1000);
+    groups = [...new Set(hits.map((h) => h.taxon_group))];
+  }
+
+  const includeNE = categories.codes.includes("NE");
+  let rows: SpeciesRow[] = groups.length ? getSpecies(groups, includeNE) : [];
+  // When specific taxa nodes were requested, narrow to them (no-op for top-level
+  // groups; correctly narrows subgroups like sharks-rays).
+  if (taxa.ids.length) {
+    rows = rows.filter((r) => taxa.ids.some((id) => speciesMatchesNode(r, id)));
+  }
+
+  const criteria: SpeciesFilterCriteria = {
+    categories: setOrUndef(categories.codes),
+    threats: setOrUndef(threats.codes),
+    countries: setOrUndef(countries.codes),
+    systems: setOrUndef(systems.values),
+    populationTrends: setOrUndef(trends.values),
+    movementPatterns: setOrUndef(movement),
+    growthForms: setOrUndef(growthForms),
+    hasMap,
+    search: search ? search.toLowerCase() : undefined,
+  };
+
+  const matched = rows.filter((r) => matchesSpeciesFilter(r, criteria));
+  matched.sort((a, b) => {
+    const ca = CATEGORY_ORDER[a.category] ?? 99;
+    const cb = CATEGORY_ORDER[b.category] ?? 99;
+    return ca !== cb ? ca - cb : a.scientific_name.localeCompare(b.scientific_name);
+  });
+
+  const total = matched.length;
+  const shown = matched.slice(0, RESULT_CAP);
+
+  const breakdown: Record<string, number> = {};
+  for (const r of matched) breakdown[r.category] = (breakdown[r.category] ?? 0) + 1;
+
+  const interpreted = describeFilters({ taxa, threats, categories, countries, systems, trends, movement, growthForms, hasMap, search });
+
+  if (format === "json") {
+    return NextResponse.json(
+      {
+        query: req.nextUrl.search,
+        interpreted,
+        unresolved,
+        total,
+        shown: shown.length,
+        capped: total > RESULT_CAP,
+        breakdown,
+        species: shown.map((s) => ({
+          scientific_name: s.scientific_name,
+          common_name: s.common_name,
+          category: s.category,
+          category_label: categoryLabel(s.category),
+          threats: (s.threat_codes ?? []).map((c) => ({ code: c, label: threatDisplay(c) })),
+          countries: s.countries,
+          systems: s.systems,
+          population_trend: s.population_trend,
+        })),
+      },
+      { headers: CACHE_1H },
+    );
+  }
+
+  return html(resultsHtml({ interpreted, unresolved, total, shown, breakdown }));
+}
+
+// ─── rendering ─────────────────────────────────────────────────────────────
+
+function html(body: string): NextResponse {
+  return new NextResponse(body, {
+    headers: { "Content-Type": "text/html; charset=utf-8", ...CACHE_1H },
+  });
+}
+
+type Resolved = {
+  taxa: ReturnType<typeof resolveTaxa>;
+  threats: ReturnType<typeof resolveThreats>;
+  categories: ReturnType<typeof resolveCategories>;
+  countries: ReturnType<typeof resolveCountries>;
+  systems: { values: string[]; unresolved: string[] };
+  trends: { values: string[]; unresolved: string[] };
+  movement: string[];
+  growthForms: string[];
+  hasMap: "yes" | "no" | null;
+  search: string;
+};
+
+function describeFilters(r: Resolved): string[] {
+  const parts: string[] = [];
+  if (r.taxa.ids.length) parts.push(`Taxa: ${r.taxa.ids.map(taxonLabel).join(", ")}`);
+  if (r.threats.codes.length) parts.push(`Threats: ${r.threats.codes.map(threatLabel).join(", ")}`);
+  if (r.categories.codes.length) parts.push(`Categories: ${r.categories.codes.map(categoryLabel).join(", ")}`);
+  if (r.countries.codes.length) parts.push(`Countries: ${r.countries.codes.map(countryLabel).join(", ")}`);
+  if (r.systems.values.length) parts.push(`Systems: ${r.systems.values.join(", ")}`);
+  if (r.trends.values.length) parts.push(`Population trend: ${r.trends.values.join(", ")}`);
+  if (r.movement.length) parts.push(`Movement: ${r.movement.join(", ")}`);
+  if (r.growthForms.length) parts.push(`Growth forms: ${r.growthForms.join(", ")}`);
+  if (r.hasMap) parts.push(`Has range map: ${r.hasMap}`);
+  if (r.search) parts.push(`Name search: "${r.search}"`);
+  return parts;
+}
+
+const PAGE_HEAD = `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Red List Dashboard — Browse</title>
+<style>
+body{font-family:system-ui,-apple-system,sans-serif;max-width:60rem;margin:2rem auto;padding:0 1rem;line-height:1.5;color:#1a1a1a}
+table{border-collapse:collapse;width:100%;margin:1rem 0}
+th,td{border:1px solid #ddd;padding:.35rem .55rem;text-align:left;font-size:.9rem;vertical-align:top}
+th{background:#f5f5f5}
+code{background:#f0f0f0;padding:0 .25rem;border-radius:3px}
+.summary{font-size:1.05rem}
+.warn{color:#a33;background:#fee;padding:.5rem .75rem;border-radius:4px}
+a{color:#0b6}
+footer{margin-top:2rem;font-size:.85rem;color:#666}
+</style></head><body>`;
+const PAGE_FOOT = `<footer>Data: IUCN Red List + GBIF. See <a href="/llms.txt">/llms.txt</a> for the full query vocabulary. Results are capped at ${RESULT_CAP}; this view is for browsing, not bulk download.</footer></body></html>`;
+
+function unresolvedBlock(unresolved: string[]): string {
+  if (!unresolved.length) return "";
+  return `<p class="warn">Couldn't interpret: ${unresolved.map((u) => `<code>${esc(u)}</code>`).join(", ")}. See <a href="/llms.txt">/llms.txt</a> for valid values.</p>`;
+}
+
+function resultsHtml(a: { interpreted: string[]; unresolved: string[]; total: number; shown: SpeciesRow[]; breakdown: Record<string, number> }): string {
+  const { interpreted, unresolved, total, shown, breakdown } = a;
+  const filterDesc = interpreted.length ? esc(interpreted.join("; ")) : "no filters";
+  const breakdownStr = Object.entries(breakdown)
+    .sort((x, y) => (CATEGORY_ORDER[x[0]] ?? 99) - (CATEGORY_ORDER[y[0]] ?? 99))
+    .map(([c, n]) => `${esc(categoryLabel(c))}: ${n}`)
+    .join(" · ");
+
+  let summary: string;
+  if (total === 0) {
+    summary = `<p class="summary"><strong>No species match</strong> — ${filterDesc}.</p>
+      <p>Try removing a filter, or see <a href="/llms.txt">/llms.txt</a> for valid values.</p>`;
+  } else {
+    summary = `<p class="summary"><strong>${total.toLocaleString()}</strong> species match — ${filterDesc}.${total > shown.length ? ` Showing the first ${shown.length}.` : ""}</p>`;
+    if (breakdownStr) summary += `<p>By category: ${breakdownStr}</p>`;
+  }
+
+  const rows = shown
+    .map((s) => {
+      const threats = [...new Set((s.threat_codes ?? []).map(threatDisplay))].map(esc).join(", ");
+      return `<tr><td><em>${esc(s.scientific_name)}</em></td><td>${esc(s.common_name ?? "")}</td><td>${esc(categoryLabel(s.category))}</td><td>${threats}</td></tr>`;
+    })
+    .join("");
+  const table = shown.length
+    ? `<table><thead><tr><th>Scientific name</th><th>Common name</th><th>IUCN category</th><th>Threats</th></tr></thead><tbody>${rows}</tbody></table>`
+    : "";
+
+  return `${PAGE_HEAD}<h1>Red List — filtered species</h1>${unresolvedBlock(unresolved)}${summary}${table}${PAGE_FOOT}`;
+}
+
+function indexData(unresolved: string[]) {
+  return {
+    description: "Server-rendered view of the Red List dashboard's base filters. Combine query params on /browse; values may be codes or plain-English names. Results capped, with a total count. Pick at least one `taxa` (or a `search` term).",
+    unresolved,
+    params: {
+      taxa: FEATURED_TAXA.map((id) => ({ id, label: taxonLabel(id) })),
+      threats: THREAT_CATEGORIES.map((t) => ({ code: t.code, label: t.label })),
+      categories: ALL_CATEGORIES.map((c) => ({ code: c, label: categoryLabel(c) })),
+      systems: SYSTEMS,
+      trends: POPULATION_TRENDS,
+      hasMap: ["yes", "no"],
+      search: "free-text scientific or common name",
+    },
+    examples: EXAMPLES,
+  };
+}
+
+const EXAMPLES: { url: string; desc: string }[] = [
+  { url: `${BASE}?taxa=corals&threats=climate-change`, desc: "Coral species threatened by climate change" },
+  { url: `${BASE}?taxa=corals&threats=11&categories=CR,EN`, desc: "Critically endangered / endangered corals hit by climate change" },
+  { url: `${BASE}?taxa=amphibia&threats=invasive-species`, desc: "Amphibians threatened by invasive species & disease" },
+  { url: `${BASE}?taxa=mammalia&categories=critically-endangered&trends=Decreasing`, desc: "Critically endangered mammals with declining populations" },
+  { url: `${BASE}?taxa=fishes&systems=Freshwater&threats=dams`, desc: "Freshwater fish threatened by dams & water management" },
+  { url: `${BASE}?search=tiger`, desc: "Look up a species by name" },
+];
+
+function indexHtml(unresolved: string[]): string {
+  const taxaList = FEATURED_TAXA.map((id) => `<code>${esc(id)}</code> (${esc(taxonLabel(id))})`).join(", ");
+  const threatList = THREAT_CATEGORIES.map((t) => `<code>${t.code}</code> ${esc(t.label)}`).join(", ");
+  const catList = ALL_CATEGORIES.map((c) => `<code>${c}</code> ${esc(categoryLabel(c))}`).join(", ");
+  const examples = EXAMPLES.map((e) => `<li><a href="${esc(e.url)}">${esc(e.url)}</a> — ${esc(e.desc)}</li>`).join("");
+
+  return `${PAGE_HEAD}<h1>Red List Dashboard — Browse</h1>
+${unresolvedBlock(unresolved)}
+<p>Filter IUCN Red List species (with GBIF links) by combining query parameters on <code>/browse</code>. Values can be codes <em>or</em> plain-English names. Pick at least one <code>taxa</code> value (or a <code>search</code> term). Add <code>&amp;format=json</code> for JSON.</p>
+<p>Within one filter, multiple comma-separated values are OR; across filters they are AND. Threats match by prefix (<code>11</code> covers <code>11.1</code>, <code>11.4</code>, …).</p>
+<h2>Filters</h2>
+<p><strong>taxa</strong>: ${taxaList}</p>
+<p><strong>threats</strong>: ${threatList} — plus aliases like <code>climate-change</code>, <code>pollution</code>, <code>overfishing</code>.</p>
+<p><strong>categories</strong>: ${catList} — plus <code>threatened</code> (= CR, EN, VU).</p>
+<p><strong>systems</strong>: ${SYSTEMS.map((s) => `<code>${s}</code>`).join(", ")}. <strong>trends</strong>: ${POPULATION_TRENDS.map((s) => `<code>${s}</code>`).join(", ")}. <strong>hasMap</strong>: <code>yes</code>/<code>no</code>. <strong>search</strong>: name text.</p>
+<h2>Examples</h2><ul>${examples}</ul>
+${PAGE_FOOT}`;
+}

--- a/app/src/app/browse/route.ts
+++ b/app/src/app/browse/route.ts
@@ -10,7 +10,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { getSpecies, searchSpecies, type SpeciesRow } from "@/lib/data/species-store";
+import { getSpecies, searchSpecies, isOutdated, type SpeciesRow } from "@/lib/data/species-store";
 import { getCsvGroupsForNode, speciesMatchesNode } from "@/lib/taxonomy-utils";
 import { matchesSpeciesFilter, type SpeciesFilterCriteria } from "@/lib/species-filter";
 import { CATEGORY_ORDER } from "@/config/taxa";
@@ -72,6 +72,19 @@ export async function GET(req: NextRequest) {
   const hasMap: "yes" | "no" | null = hasMapRaw === "yes" ? "yes" : hasMapRaw === "no" ? "no" : null;
   const search = (sp.get("search") ?? "").trim();
 
+  const intParam = (k: string): number | undefined => {
+    const v = sp.get(k);
+    if (v == null) return undefined;
+    const n = parseInt(v, 10);
+    return Number.isNaN(n) ? undefined : n;
+  };
+  const minObs = intParam("minObs");
+  const maxObs = intParam("maxObs");
+  const minAssessmentYear = intParam("minAssessmentYear");
+  const maxAssessmentYear = intParam("maxAssessmentYear");
+  const outdatedRaw = sp.get("outdated");
+  const outdated: "yes" | "no" | null = outdatedRaw === "yes" ? "yes" : outdatedRaw === "no" ? "no" : null;
+
   const unresolved = [
     ...taxa.unresolved.map((v) => `taxa=${v}`),
     ...threats.unresolved.map((v) => `threats=${v}`),
@@ -117,9 +130,15 @@ export async function GET(req: NextRequest) {
     growthForms: setOrUndef(growthForms),
     hasMap,
     search: search ? search.toLowerCase() : undefined,
+    minObs,
+    maxObs,
+    minAssessmentYear,
+    maxAssessmentYear,
   };
 
-  const matched = rows.filter((r) => matchesSpeciesFilter(r, criteria));
+  let matched = rows.filter((r) => matchesSpeciesFilter(r, criteria));
+  // "outdated" uses the same >10-year rule as the dashboard / taxa-summary.
+  if (outdated) matched = matched.filter((r) => isOutdated(r.assessment_date) === (outdated === "yes"));
   matched.sort((a, b) => {
     const ca = CATEGORY_ORDER[a.category] ?? 99;
     const cb = CATEGORY_ORDER[b.category] ?? 99;
@@ -132,7 +151,18 @@ export async function GET(req: NextRequest) {
   const breakdown: Record<string, number> = {};
   for (const r of matched) breakdown[r.category] = (breakdown[r.category] ?? 0) + 1;
 
+  // Outdated stats (over assessed species only — NE has no assessment date).
+  const assessed = matched.filter((r) => r.category !== "NE");
+  const outdatedCount = assessed.filter((r) => isOutdated(r.assessment_date)).length;
+  const outdatedPct = assessed.length ? Math.round((outdatedCount / assessed.length) * 100) : null;
+  const stats = { assessed: assessed.length, outdated: outdatedCount, outdated_pct: outdatedPct };
+
   const interpreted = describeFilters({ taxa, threats, categories, countries, systems, trends, movement, growthForms, hasMap, search });
+  if (minObs != null) interpreted.push(`GBIF observations ≥ ${minObs.toLocaleString()}`);
+  if (maxObs != null) interpreted.push(`GBIF observations ≤ ${maxObs.toLocaleString()}`);
+  if (minAssessmentYear != null) interpreted.push(`Assessed in or after ${minAssessmentYear}`);
+  if (maxAssessmentYear != null) interpreted.push(`Assessed in or before ${maxAssessmentYear}`);
+  if (outdated) interpreted.push(outdated === "yes" ? "Outdated assessments (>10 yrs old)" : "Current assessments (≤10 yrs old)");
 
   if (format === "json") {
     return NextResponse.json(
@@ -144,6 +174,7 @@ export async function GET(req: NextRequest) {
         shown: shown.length,
         capped: total > RESULT_CAP,
         breakdown,
+        stats,
         species: shown.map((s) => ({
           scientific_name: s.scientific_name,
           common_name: s.common_name,
@@ -153,13 +184,16 @@ export async function GET(req: NextRequest) {
           countries: s.countries,
           systems: s.systems,
           population_trend: s.population_trend,
+          assessment_date: s.assessment_date,
+          outdated: isOutdated(s.assessment_date),
+          gbif_occurrence_count: s.gbif_occurrence_count,
         })),
       },
       { headers: CACHE_1H },
     );
   }
 
-  return html(resultsHtml({ interpreted, unresolved, total, shown, breakdown }));
+  return html(resultsHtml({ interpreted, unresolved, total, shown, breakdown, stats }));
 }
 
 // ─── rendering ─────────────────────────────────────────────────────────────
@@ -219,8 +253,10 @@ function unresolvedBlock(unresolved: string[]): string {
   return `<p class="warn">Couldn't interpret: ${unresolved.map((u) => `<code>${esc(u)}</code>`).join(", ")}. See <a href="/llms.txt">/llms.txt</a> for valid values.</p>`;
 }
 
-function resultsHtml(a: { interpreted: string[]; unresolved: string[]; total: number; shown: SpeciesRow[]; breakdown: Record<string, number> }): string {
-  const { interpreted, unresolved, total, shown, breakdown } = a;
+type Stats = { assessed: number; outdated: number; outdated_pct: number | null };
+
+function resultsHtml(a: { interpreted: string[]; unresolved: string[]; total: number; shown: SpeciesRow[]; breakdown: Record<string, number>; stats: Stats }): string {
+  const { interpreted, unresolved, total, shown, breakdown, stats } = a;
   const filterDesc = interpreted.length ? esc(interpreted.join("; ")) : "no filters";
   const breakdownStr = Object.entries(breakdown)
     .sort((x, y) => (CATEGORY_ORDER[x[0]] ?? 99) - (CATEGORY_ORDER[y[0]] ?? 99))
@@ -234,16 +270,21 @@ function resultsHtml(a: { interpreted: string[]; unresolved: string[]; total: nu
   } else {
     summary = `<p class="summary"><strong>${total.toLocaleString()}</strong> species match — ${filterDesc}.${total > shown.length ? ` Showing the first ${shown.length}.` : ""}</p>`;
     if (breakdownStr) summary += `<p>By category: ${breakdownStr}</p>`;
+    if (stats.assessed > 0 && stats.outdated_pct != null) {
+      summary += `<p>Assessments outdated (>10 yrs old): <strong>${stats.outdated.toLocaleString()}</strong> of ${stats.assessed.toLocaleString()} (<strong>${stats.outdated_pct}%</strong>).</p>`;
+    }
   }
 
   const rows = shown
     .map((s) => {
       const threats = [...new Set((s.threat_codes ?? []).map(threatDisplay))].map(esc).join(", ");
-      return `<tr><td><em>${esc(s.scientific_name)}</em></td><td>${esc(s.common_name ?? "")}</td><td>${esc(categoryLabel(s.category))}</td><td>${threats}</td></tr>`;
+      const year = s.assessment_date ? esc(s.assessment_date.slice(0, 4)) : "—";
+      const obs = s.gbif_occurrence_count != null ? s.gbif_occurrence_count.toLocaleString() : "—";
+      return `<tr><td><em>${esc(s.scientific_name)}</em></td><td>${esc(s.common_name ?? "")}</td><td>${esc(categoryLabel(s.category))}</td><td>${year}</td><td>${obs}</td><td>${threats}</td></tr>`;
     })
     .join("");
   const table = shown.length
-    ? `<table><thead><tr><th>Scientific name</th><th>Common name</th><th>IUCN category</th><th>Threats</th></tr></thead><tbody>${rows}</tbody></table>`
+    ? `<table><thead><tr><th>Scientific name</th><th>Common name</th><th>IUCN category</th><th>Assessed</th><th>GBIF obs.</th><th>Threats</th></tr></thead><tbody>${rows}</tbody></table>`
     : "";
 
   return `${PAGE_HEAD}<h1>Red List — filtered species</h1>${unresolvedBlock(unresolved)}${summary}${table}${PAGE_FOOT}`;
@@ -261,7 +302,13 @@ function indexData(unresolved: string[]) {
       trends: POPULATION_TRENDS,
       hasMap: ["yes", "no"],
       search: "free-text scientific or common name",
+      outdated: "yes | no (assessment >10 years old)",
+      minObs: "min GBIF occurrence count (e.g. 100)",
+      maxObs: "max GBIF occurrence count",
+      minAssessmentYear: "earliest assessment year (e.g. 2015)",
+      maxAssessmentYear: "latest assessment year",
     },
+    note: "Every response includes a `stats` object: assessed count, outdated count, and outdated_pct (>10-yr rule) — use it for percentage questions.",
     examples: EXAMPLES,
   };
 }
@@ -269,9 +316,9 @@ function indexData(unresolved: string[]) {
 const EXAMPLES: { url: string; desc: string }[] = [
   { url: `${BASE}?taxa=corals&threats=climate-change`, desc: "Coral species threatened by climate change" },
   { url: `${BASE}?taxa=corals&threats=11&categories=CR,EN`, desc: "Critically endangered / endangered corals hit by climate change" },
-  { url: `${BASE}?taxa=amphibia&threats=invasive-species`, desc: "Amphibians threatened by invasive species & disease" },
+  { url: `${BASE}?taxa=mammalia`, desc: "All mammals — read stats.outdated_pct for % of outdated assessments" },
+  { url: `${BASE}?taxa=insecta&categories=DD&minObs=100&outdated=yes&countries=India`, desc: "Data-deficient insects in India with >100 GBIF records, assessed over 10 years ago" },
   { url: `${BASE}?taxa=mammalia&categories=critically-endangered&trends=Decreasing`, desc: "Critically endangered mammals with declining populations" },
-  { url: `${BASE}?taxa=fishes&systems=Freshwater&threats=dams`, desc: "Freshwater fish threatened by dams & water management" },
   { url: `${BASE}?search=tiger`, desc: "Look up a species by name" },
 ];
 
@@ -290,6 +337,8 @@ ${unresolvedBlock(unresolved)}
 <p><strong>threats</strong>: ${threatList} — plus aliases like <code>climate-change</code>, <code>pollution</code>, <code>overfishing</code>.</p>
 <p><strong>categories</strong>: ${catList} — plus <code>threatened</code> (= CR, EN, VU).</p>
 <p><strong>systems</strong>: ${SYSTEMS.map((s) => `<code>${s}</code>`).join(", ")}. <strong>trends</strong>: ${POPULATION_TRENDS.map((s) => `<code>${s}</code>`).join(", ")}. <strong>hasMap</strong>: <code>yes</code>/<code>no</code>. <strong>search</strong>: name text.</p>
+<p><strong>outdated</strong>: <code>yes</code>/<code>no</code> (assessment &gt;10 yrs old). <strong>minObs</strong>/<strong>maxObs</strong>: GBIF occurrence count bounds. <strong>minAssessmentYear</strong>/<strong>maxAssessmentYear</strong>: assessment year bounds. <strong>countries</strong>: ISO code or name.</p>
+<p>Every response leads with a total, a by-category breakdown, and an outdated count + %, so percentage questions (e.g. "% of mammals outdated") are answered in one request.</p>
 <h2>Examples</h2><ul>${examples}</ul>
 ${PAGE_FOOT}`;
 }

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -40,6 +40,13 @@ export default function RootLayout({
         <PostHogProvider>
           <ThemeProvider>{children}</ThemeProvider>
         </PostHogProvider>
+        {/* Server-rendered footer: gives crawlers & LLMs (which see only this
+            shell, not the client-rendered app) a path into the data. */}
+        <footer style={{ textAlign: "center", padding: "1rem", fontSize: "0.8rem", opacity: 0.6 }}>
+          <a href="/browse">Text / no-JS view (for LLMs &amp; crawlers)</a>
+          {" · "}
+          <a href="/llms.txt">llms.txt</a>
+        </footer>
         <Analytics />
         <SpeedInsights />
       </body>

--- a/app/src/app/llms.txt/route.ts
+++ b/app/src/app/llms.txt/route.ts
@@ -1,0 +1,80 @@
+/**
+ * /llms.txt — concise, machine-readable guide so an LLM can answer questions
+ * from the dashboard's base filters via /browse. Generated from filter-vocab so
+ * it can never drift from what /browse actually accepts.
+ */
+
+import { NextResponse } from "next/server";
+import { CACHE_1H } from "@/lib/cache-headers";
+import {
+  THREAT_CATEGORIES, FEATURED_TAXA, ALL_CATEGORIES,
+  SYSTEMS, POPULATION_TRENDS, taxonLabel, categoryLabel,
+} from "@/lib/filter-vocab";
+
+export const revalidate = 3600;
+
+export function GET() {
+  const taxa = FEATURED_TAXA.map((id) => `  - ${id} (${taxonLabel(id)})`).join("\n");
+  const threats = THREAT_CATEGORIES.map((t) => `  - ${t.code} = ${t.label}`).join("\n");
+  const cats = ALL_CATEGORIES.map((c) => `  - ${categoryLabel(c)}`).join("\n");
+
+  const body = `# Red List Dashboard
+
+> Explore IUCN Red List assessments (linked to GBIF occurrence data) for ~280,000
+> species across 21 taxonomic groups. The main site (red.cst.cam.ac.uk) is an
+> interactive app that renders in the browser. To read data programmatically or
+> answer questions, use the /browse endpoint below, which returns server-rendered
+> HTML (or JSON).
+
+## Querying /browse
+
+Base: https://red.cst.cam.ac.uk/browse
+Combine query parameters; comma-separate multiple values. Values may be codes OR
+plain-English names (e.g. threats=climate-change, categories=endangered,
+taxa=birds, countries=Brazil). Add &format=json for a JSON response.
+
+Rules:
+- Pick at least one \`taxa\` value (or a \`search\` term). Cross-taxa listings are
+  not supported in one call — query each taxon and combine.
+- Within one filter, multiple values are OR; across filters they are AND.
+- Threats match by prefix: threats=11 covers 11.1, 11.4, ... ("Climate change").
+- Results are capped at 200 rows; the total count is always shown.
+
+## Parameters
+
+taxa (taxonomic group):
+${taxa}
+  (subgroups also work, e.g. sharks-rays, beetles)
+
+threats (IUCN threat class; sub-codes like 11.4 work too):
+${threats}
+  aliases: climate-change, pollution, invasive-species, overfishing, logging, hunting, dams ...
+
+categories (IUCN Red List status):
+${cats}
+  aliases: threatened (= CR, EN, VU), extinct (= EX, EW)
+
+systems: ${SYSTEMS.join(", ")}
+trends:  ${POPULATION_TRENDS.join(", ")}
+hasMap:  yes | no
+countries: ISO alpha-2 code or country name (e.g. BR or Brazil)
+search:  free-text scientific or common name
+
+## Examples
+
+- https://red.cst.cam.ac.uk/browse?taxa=corals&threats=climate-change
+    Which coral species are threatened by climate change
+- https://red.cst.cam.ac.uk/browse?taxa=corals&threats=11&categories=CR,EN
+    Critically endangered / endangered corals affected by climate change
+- https://red.cst.cam.ac.uk/browse?taxa=amphibia&threats=invasive-species
+    Amphibians threatened by invasive species & disease
+- https://red.cst.cam.ac.uk/browse?taxa=mammalia&categories=critically-endangered&trends=Decreasing
+    Critically endangered mammals with declining populations
+- https://red.cst.cam.ac.uk/browse?search=tiger
+    Look up a species by name
+`;
+
+  return new NextResponse(body, {
+    headers: { "Content-Type": "text/plain; charset=utf-8", ...CACHE_1H },
+  });
+}

--- a/app/src/app/llms.txt/route.ts
+++ b/app/src/app/llms.txt/route.ts
@@ -39,6 +39,9 @@ Rules:
 - Within one filter, multiple values are OR; across filters they are AND.
 - Threats match by prefix: threats=11 covers 11.1, 11.4, ... ("Climate change").
 - Results are capped at 200 rows; the total count is always shown.
+- Every response includes a "stats" object (and an HTML line): assessed count,
+  outdated count, and outdated_pct — the % of assessments older than 10 years.
+  Use it for percentage questions; no need to list species.
 
 ## Parameters
 
@@ -57,17 +60,20 @@ ${cats}
 systems: ${SYSTEMS.join(", ")}
 trends:  ${POPULATION_TRENDS.join(", ")}
 hasMap:  yes | no
-countries: ISO alpha-2 code or country name (e.g. BR or Brazil)
+countries: ISO alpha-2 code or country name (e.g. IN or India)
 search:  free-text scientific or common name
+outdated: yes | no  (assessment more than 10 years old)
+minObs / maxObs: GBIF occurrence-count bounds (e.g. minObs=100)
+minAssessmentYear / maxAssessmentYear: assessment-year bounds (e.g. minAssessmentYear=2015)
 
 ## Examples
 
 - https://red.cst.cam.ac.uk/browse?taxa=corals&threats=climate-change
     Which coral species are threatened by climate change
-- https://red.cst.cam.ac.uk/browse?taxa=corals&threats=11&categories=CR,EN
-    Critically endangered / endangered corals affected by climate change
-- https://red.cst.cam.ac.uk/browse?taxa=amphibia&threats=invasive-species
-    Amphibians threatened by invasive species & disease
+- https://red.cst.cam.ac.uk/browse?taxa=mammalia
+    What % of mammal assessments are outdated → read stats.outdated_pct
+- https://red.cst.cam.ac.uk/browse?taxa=insecta&categories=DD&minObs=100&outdated=yes&countries=India
+    Data-deficient insects in India with >100 GBIF records, assessed over 10 years ago
 - https://red.cst.cam.ac.uk/browse?taxa=mammalia&categories=critically-endangered&trends=Decreasing
     Critically endangered mammals with declining populations
 - https://red.cst.cam.ac.uk/browse?search=tiger

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -9,86 +9,13 @@ import {
 } from "react-simple-maps";
 import { geoCentroid } from "d3-geo";
 import { IUCN_REGION_ORDER, countryToIucnRegion, iucnRegionCountries } from "@/lib/regions";
+import { NAME_TO_ALPHA2, ALPHA2_TO_NAME } from "@/lib/countries";
+
+// Re-exported for existing importers (RedListView, cites-utils, TradeFlowMap, AssessorCandidatesTable)
+export { ALPHA2_TO_NAME };
 
 // Using the recommended TopoJSON from react-simple-maps
 const GEO_URL = "https://cdn.jsdelivr.net/npm/world-atlas@2/countries-50m.json";
-
-// Country name (from TopoJSON) to ISO 3166-1 alpha-2 mapping for GBIF
-const NAME_TO_ALPHA2: Record<string, string> = {
-  "Afghanistan": "AF", "Albania": "AL", "Algeria": "DZ", "Angola": "AO", "Argentina": "AR",
-  "Armenia": "AM", "Australia": "AU", "Austria": "AT", "Azerbaijan": "AZ", "Bangladesh": "BD",
-  "Belarus": "BY", "Belgium": "BE", "Benin": "BJ", "Bhutan": "BT", "Bolivia": "BO",
-  "Bosnia and Herz.": "BA", "Botswana": "BW", "Brazil": "BR", "Brunei": "BN", "Bulgaria": "BG",
-  "Burkina Faso": "BF", "Burundi": "BI", "Cambodia": "KH", "Cameroon": "CM", "Canada": "CA",
-  "Central African Rep.": "CF", "Chad": "TD", "Chile": "CL", "China": "CN", "Colombia": "CO",
-  "Congo": "CG", "Dem. Rep. Congo": "CD", "Costa Rica": "CR", "Côte d'Ivoire": "CI",
-  "Croatia": "HR", "Cuba": "CU", "Cyprus": "CY", "Czechia": "CZ", "Denmark": "DK",
-  "Djibouti": "DJ", "Dominican Rep.": "DO", "Ecuador": "EC", "Egypt": "EG", "El Salvador": "SV",
-  "Eq. Guinea": "GQ", "Eritrea": "ER", "Estonia": "EE", "eSwatini": "SZ", "Ethiopia": "ET",
-  "Fiji": "FJ", "Finland": "FI", "France": "FR", "Gabon": "GA", "Gambia": "GM", "Georgia": "GE",
-  "Germany": "DE", "Ghana": "GH", "Greece": "GR", "Greenland": "GL", "Guatemala": "GT",
-  "Guinea": "GN", "Guinea-Bissau": "GW", "Guyana": "GY", "Haiti": "HT", "Honduras": "HN",
-  "Hungary": "HU", "Iceland": "IS", "India": "IN", "Indonesia": "ID", "Iran": "IR", "Iraq": "IQ",
-  "Ireland": "IE", "Israel": "IL", "Italy": "IT", "Jamaica": "JM", "Japan": "JP", "Jordan": "JO",
-  "Kazakhstan": "KZ", "Kenya": "KE", "North Korea": "KP", "South Korea": "KR", "Kuwait": "KW",
-  "Kyrgyzstan": "KG", "Laos": "LA", "Latvia": "LV", "Lebanon": "LB", "Lesotho": "LS",
-  "Liberia": "LR", "Libya": "LY", "Lithuania": "LT", "Luxembourg": "LU", "Madagascar": "MG",
-  "Malawi": "MW", "Malaysia": "MY", "Mali": "ML", "Mauritania": "MR", "Mexico": "MX",
-  "Moldova": "MD", "Mongolia": "MN", "Montenegro": "ME", "Morocco": "MA", "Mozambique": "MZ",
-  "Myanmar": "MM", "Namibia": "NA", "Nepal": "NP", "Netherlands": "NL", "New Zealand": "NZ",
-  "Nicaragua": "NI", "Niger": "NE", "Nigeria": "NG", "Norway": "NO", "Oman": "OM",
-  "Pakistan": "PK", "Panama": "PA", "Papua New Guinea": "PG", "Paraguay": "PY", "Peru": "PE",
-  "Philippines": "PH", "Poland": "PL", "Portugal": "PT", "Puerto Rico": "PR", "Qatar": "QA",
-  "Romania": "RO", "Russia": "RU", "Rwanda": "RW", "Saudi Arabia": "SA", "Senegal": "SN",
-  "Serbia": "RS", "Sierra Leone": "SL", "Singapore": "SG", "Slovakia": "SK", "Slovenia": "SI",
-  "Solomon Is.": "SB", "Somalia": "SO", "South Africa": "ZA", "S. Sudan": "SS", "Spain": "ES",
-  "Sri Lanka": "LK", "Sudan": "SD", "Suriname": "SR", "Sweden": "SE", "Switzerland": "CH",
-  "Syria": "SY", "Taiwan": "TW", "Tajikistan": "TJ", "Tanzania": "TZ", "Thailand": "TH",
-  "Timor-Leste": "TL", "Togo": "TG", "Trinidad and Tobago": "TT", "Tunisia": "TN",
-  "Turkey": "TR", "Turkmenistan": "TM", "Uganda": "UG", "Ukraine": "UA",
-  "United Arab Emirates": "AE", "United Kingdom": "GB", "United States of America": "US",
-  "Uruguay": "UY", "Uzbekistan": "UZ", "Vanuatu": "VU", "Venezuela": "VE", "Vietnam": "VN",
-  "Yemen": "YE", "Zambia": "ZM", "Zimbabwe": "ZW", "Palestine": "PS", "Kosovo": "XK",
-  "North Macedonia": "MK", "New Caledonia": "NC", "W. Sahara": "EH", "Fr. S. Antarctic Lands": "TF",
-  "Falkland Is.": "FK",
-  // Small/micro nations not in 110m TopoJSON but useful for search
-  "Andorra": "AD", "Antigua and Barbuda": "AG", "Bahamas": "BS", "Bahrain": "BH", "Barbados": "BB",
-  "Belize": "BZ", "Cape Verde": "CV", "Comoros": "KM", "Dominica": "DM", "Grenada": "GD",
-  "Kiribati": "KI", "Liechtenstein": "LI", "Maldives": "MV", "Malta": "MT", "Marshall Islands": "MH",
-  "Mauritius": "MU", "Micronesia": "FM", "Monaco": "MC", "Nauru": "NR", "Palau": "PW",
-  "Samoa": "WS", "San Marino": "SM", "São Tomé and Príncipe": "ST", "Seychelles": "SC",
-  "Saint Kitts and Nevis": "KN", "Saint Lucia": "LC", "Saint Vincent and the Grenadines": "VC",
-  "Tonga": "TO", "Tuvalu": "TV", "Vatican City": "VA",
-};
-
-// Complete ISO 3166-1 alpha-2 to country name mapping (for display)
-// Includes all countries, territories, and small island nations
-export const ALPHA2_TO_NAME: Record<string, string> = {
-  // From TopoJSON (use these names for map consistency)
-  ...Object.fromEntries(Object.entries(NAME_TO_ALPHA2).map(([name, code]) => [code, name])),
-  // Additional countries and territories not in TopoJSON
-  "AD": "Andorra", "AG": "Antigua and Barbuda", "AI": "Anguilla", "AQ": "Antarctica",
-  "AS": "American Samoa", "AW": "Aruba", "AX": "Åland Islands", "BB": "Barbados",
-  "BH": "Bahrain", "BL": "Saint Barthélemy", "BM": "Bermuda", "BQ": "Bonaire",
-  "BS": "Bahamas", "BV": "Bouvet Island", "BZ": "Belize", "CC": "Cocos Islands",
-  "CK": "Cook Islands", "CV": "Cape Verde", "CW": "Curaçao", "CX": "Christmas Island",
-  "DM": "Dominica", "FK": "Falkland Islands", "FM": "Micronesia", "FO": "Faroe Islands",
-  "GD": "Grenada", "GF": "French Guiana", "GG": "Guernsey", "GI": "Gibraltar",
-  "GP": "Guadeloupe", "GS": "South Georgia", "GU": "Guam", "HK": "Hong Kong",
-  "HM": "Heard Island", "IM": "Isle of Man", "IO": "British Indian Ocean Territory",
-  "JE": "Jersey", "KI": "Kiribati", "KM": "Comoros", "KN": "Saint Kitts and Nevis",
-  "KY": "Cayman Islands", "LC": "Saint Lucia", "LI": "Liechtenstein", "MC": "Monaco",
-  "MF": "Saint Martin", "MH": "Marshall Islands", "MO": "Macao", "MP": "Northern Mariana Islands",
-  "MQ": "Martinique", "MS": "Montserrat", "MT": "Malta", "MU": "Mauritius", "MV": "Maldives",
-  "NF": "Norfolk Island", "NR": "Nauru", "NU": "Niue", "PF": "French Polynesia",
-  "PM": "Saint Pierre and Miquelon", "PN": "Pitcairn", "PW": "Palau", "RE": "Réunion",
-  "SC": "Seychelles", "SH": "Saint Helena", "SJ": "Svalbard", "SM": "San Marino",
-  "ST": "São Tomé and Príncipe", "SV": "El Salvador", "SX": "Sint Maarten",
-  "TC": "Turks and Caicos", "TK": "Tokelau", "TO": "Tonga", "TV": "Tuvalu",
-  "UM": "U.S. Minor Outlying Islands", "VA": "Vatican City", "VC": "Saint Vincent and the Grenadines",
-  "VG": "British Virgin Islands", "VI": "U.S. Virgin Islands", "WF": "Wallis and Futuna",
-  "WS": "Samoa", "YT": "Mayotte",
-};
 
 // Sorted list of country names for search
 const COUNTRY_NAMES_SORTED = Object.keys(NAME_TO_ALPHA2).sort();

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -17,6 +17,8 @@ import { parseAssessors } from "@/lib/parseAssessors";
 import { iucnRegionCountries, countryToIucnRegion } from "@/lib/regions";
 import { useFilterParams } from "@/hooks/useFilterParams";
 import { type RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
+import { THREAT_CATEGORIES } from "@/lib/filter-vocab";
+import { matchesSpeciesFilter } from "@/lib/species-filter";
 
 import AssessorCandidatesTable from "../AssessorCandidatesTable";
 import { getLastSearchResult, clearLastSearchResult } from "../SpeciesSearchBar";
@@ -63,46 +65,6 @@ function Spinner({ className = "" }: { className?: string }) {
 // Use RedListSpecies from the hook; alias for convenience
 type Species = RedListSpecies;
 
-/** IUCN threat classification hierarchy */
-const THREAT_CATEGORIES: { code: string; label: string; children: { code: string; label: string }[] }[] = [
-  { code: "1", label: "Development", children: [
-    { code: "1.1", label: "Housing & urban areas" }, { code: "1.2", label: "Commercial & industrial areas" }, { code: "1.3", label: "Tourism & recreation areas" },
-  ]},
-  { code: "2", label: "Agriculture", children: [
-    { code: "2.1", label: "Crops" }, { code: "2.2", label: "Wood & pulp plantations" }, { code: "2.3", label: "Livestock farming & ranching" }, { code: "2.4", label: "Aquaculture" },
-  ]},
-  { code: "3", label: "Energy & Mining", children: [
-    { code: "3.1", label: "Oil & gas drilling" }, { code: "3.2", label: "Mining & quarrying" }, { code: "3.3", label: "Renewable energy" },
-  ]},
-  { code: "4", label: "Transport", children: [
-    { code: "4.1", label: "Roads & railroads" }, { code: "4.2", label: "Utility & service lines" }, { code: "4.3", label: "Shipping lanes" }, { code: "4.4", label: "Flight paths" },
-  ]},
-  { code: "5", label: "Harvesting", children: [
-    { code: "5.1", label: "Hunting & trapping" }, { code: "5.2", label: "Gathering plants" }, { code: "5.3", label: "Logging & wood harvesting" }, { code: "5.4", label: "Fishing & harvesting" },
-  ]},
-  { code: "6", label: "Disturbance", children: [
-    { code: "6.1", label: "Recreational activities" }, { code: "6.2", label: "War & military" }, { code: "6.3", label: "Work & other activities" },
-  ]},
-  { code: "7", label: "System modifications", children: [
-    { code: "7.1", label: "Fire & fire suppression" }, { code: "7.2", label: "Dams & water management" }, { code: "7.3", label: "Other modifications" },
-  ]},
-  { code: "8", label: "Invasive species", children: [
-    { code: "8.1", label: "Invasive non-native species" }, { code: "8.2", label: "Problematic native species" }, { code: "8.3", label: "Introduced genetic material" }, { code: "8.4", label: "Unknown origin species" }, { code: "8.5", label: "Viral/prion diseases" }, { code: "8.6", label: "Diseases of unknown cause" },
-  ]},
-  { code: "9", label: "Pollution", children: [
-    { code: "9.1", label: "Domestic & urban waste water" }, { code: "9.2", label: "Industrial & military effluents" }, { code: "9.3", label: "Agricultural & forestry effluents" },
-    { code: "9.4", label: "Garbage & solid waste" }, { code: "9.5", label: "Air-borne pollutants" }, { code: "9.6", label: "Excess energy (light, thermal, noise)" },
-  ]},
-  { code: "10", label: "Geological events", children: [
-    { code: "10.1", label: "Volcanoes" }, { code: "10.2", label: "Earthquakes/tsunamis" }, { code: "10.3", label: "Avalanches/landslides" },
-  ]},
-  { code: "11", label: "Climate change", children: [
-    { code: "11.1", label: "Habitat shifting & alteration" }, { code: "11.2", label: "Droughts" }, { code: "11.3", label: "Temperature extremes" }, { code: "11.4", label: "Storms & flooding" }, { code: "11.5", label: "Other impacts" },
-  ]},
-  { code: "12", label: "Other", children: [
-    { code: "12.1", label: "Other threat" },
-  ]},
-];
 
 interface InatDefaultImage {
   squareUrl: string | null;
@@ -1356,26 +1318,28 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     const CATEGORY_ORDER: Record<string, number> = {
       EX: 0, EW: 1, CR: 2, EN: 3, VU: 4, NT: 5, LC: 6, DD: 7, NE: 8,
     };
+    // Base filters (category, country, system, trend, movement, threat, map,
+    // growth, search) share one predicate with the /browse endpoint.
+    const baseCriteria = {
+      categories: selectedCategories,
+      threats: selectedThreats,
+      countries: selectedCountries,
+      systems: selectedSystems,
+      populationTrends: selectedPopulationTrends,
+      movementPatterns: selectedMovementPatterns,
+      growthForms: selectedGrowthForms,
+      hasMap: hasMapFilter,
+      search: searchFilter,
+    };
     const filtered = taxaFilteredSpecies.filter((s) => {
-      const matchesCategory = selectedCategories.size === 0 || selectedCategories.has(s.category);
+      // Time-relative / GBIF / assessor / starred checks stay local to the SPA.
       const matchesYear = s.category === "NE" || (matchesYearRangeFilter(s.assessment_date) && matchesAssessmentYearFilter(s.assessment_date));
       const matchesObs = matchesObsRangeFilter(s.gbif_occurrence_count);
-      const matchesCountry = selectedCountries.size === 0 || s.countries.some(c => selectedCountries.has(c));
-      const matchesSystem = selectedSystems.size === 0 || s.systems?.some(sys => selectedSystems.has(sys));
-      const matchesTrend = selectedPopulationTrends.size === 0 || (s.population_trend != null && selectedPopulationTrends.has(s.population_trend));
-      const matchesMovement = selectedMovementPatterns.size === 0 || (s.movement_pattern != null && selectedMovementPatterns.has(s.movement_pattern));
-      const matchesThreat = selectedThreats.size === 0 || s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")));
-      const matchesMap = !hasMapFilter || (hasMapFilter === "yes" ? s.has_map : !s.has_map);
-      const matchesGrowth = selectedGrowthForms.size === 0 || s.growth_forms?.some(gf => selectedGrowthForms.has(gf));
-      const matchesSearch =
-        !searchFilter ||
-        s.scientific_name.toLowerCase().includes(searchFilter) ||
-        s.common_name?.toLowerCase().includes(searchFilter);
       const matchesAssessor = matchesAssessorsFilter(s);
       const matchesReviewer = matchesReviewersFilter(s);
       const pinnedKey = isNewAssessments ? Math.abs(s.id) : s.sis_taxon_id;
       const matchesStarred = !showOnlyStarred || (pinnedKey != null && pinnedSet.has(pinnedKey));
-      return matchesCategory && matchesYear && matchesObs && matchesCountry && matchesSystem && matchesTrend && matchesMovement && matchesThreat && matchesMap && matchesGrowth && matchesSearch && matchesAssessor && matchesReviewer && matchesStarred;
+      return matchesSpeciesFilter(s, baseCriteria) && matchesYear && matchesObs && matchesAssessor && matchesReviewer && matchesStarred;
     });
 
     const sorted = [...filtered].sort((a, b) => {

--- a/app/src/lib/__tests__/filter-vocab.test.ts
+++ b/app/src/lib/__tests__/filter-vocab.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveThreats, resolveCategories, resolveTaxa, resolveCountries,
+  categoryLabel, taxonLabel, threatDisplay, THREAT_LABEL,
+} from "@/lib/filter-vocab";
+
+describe("resolveThreats", () => {
+  it("accepts codes, sub-codes, slugs and labels", () => {
+    expect(resolveThreats(["climate-change"]).codes).toEqual(["11"]);
+    expect(resolveThreats(["global warming"]).codes).toEqual(["11"]);
+    expect(resolveThreats(["11"]).codes).toEqual(["11"]);
+    expect(resolveThreats(["11.4"]).codes).toEqual(["11.4"]);
+    expect(resolveThreats(["pollution"]).codes).toEqual(["9"]);
+    expect(resolveThreats(["overfishing"]).codes).toEqual(["5.4"]);
+    expect(resolveThreats(["Climate change"]).codes).toEqual(["11"]);
+  });
+  it("reports unresolved values but keeps the rest", () => {
+    const r = resolveThreats(["climate-change", "asteroids"]);
+    expect(r.codes).toEqual(["11"]);
+    expect(r.unresolved).toEqual(["asteroids"]);
+  });
+});
+
+describe("resolveCategories", () => {
+  it("accepts codes, slugs, names, and expands groups", () => {
+    expect(resolveCategories(["EN"]).codes).toEqual(["EN"]);
+    expect(resolveCategories(["endangered"]).codes).toEqual(["EN"]);
+    expect(resolveCategories(["Critically Endangered"]).codes).toEqual(["CR"]);
+    expect(resolveCategories(["threatened"]).codes).toEqual(["CR", "EN", "VU"]);
+    expect(resolveCategories(["extinct"]).codes).toEqual(["EX", "EW"]);
+  });
+  it("reports unresolved", () => {
+    expect(resolveCategories(["doomed"]).unresolved).toEqual(["doomed"]);
+  });
+});
+
+describe("resolveTaxa", () => {
+  it("accepts node ids and common names", () => {
+    expect(resolveTaxa(["corals"]).ids).toEqual(["corals"]);
+    expect(resolveTaxa(["birds"]).ids).toEqual(["aves"]);
+    expect(resolveTaxa(["frogs"]).ids).toEqual(["amphibia"]);
+    expect(resolveTaxa(["mammals"]).ids).toEqual(["mammalia"]);
+    expect(resolveTaxa(["sharks"]).ids).toEqual(["sharks-rays"]);
+  });
+  it("treats 'all' and unknowns as unresolved", () => {
+    expect(resolveTaxa(["all"]).ids).toEqual([]);
+    expect(resolveTaxa(["dinosaurs"]).unresolved).toEqual(["dinosaurs"]);
+  });
+});
+
+describe("resolveCountries", () => {
+  it("accepts codes and names, case-insensitive", () => {
+    expect(resolveCountries(["BR"]).codes).toEqual(["BR"]);
+    expect(resolveCountries(["Brazil"]).codes).toEqual(["BR"]);
+    expect(resolveCountries(["brazil"]).codes).toEqual(["BR"]);
+    expect(resolveCountries(["USA"]).codes).toEqual(["US"]);
+  });
+  it("reports unresolved", () => {
+    expect(resolveCountries(["Atlantis"]).unresolved).toEqual(["Atlantis"]);
+  });
+});
+
+describe("labels", () => {
+  it("renders human-readable labels", () => {
+    expect(THREAT_LABEL["11"]).toBe("Climate change");
+    expect(categoryLabel("EN")).toContain("Endangered");
+    expect(taxonLabel("corals")).toMatch(/coral/i);
+    // deep sub-codes walk up to the nearest known label (no bare numbers)
+    expect(threatDisplay("11.4")).toBe("Storms & flooding");
+    expect(threatDisplay("5.4.1")).toBe("Fishing & harvesting");
+    expect(threatDisplay("11")).toBe("Climate change");
+  });
+});

--- a/app/src/lib/__tests__/species-filter.test.ts
+++ b/app/src/lib/__tests__/species-filter.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { matchesSpeciesFilter, type FilterableSpecies } from "@/lib/species-filter";
+
+function sp(overrides: Partial<FilterableSpecies> = {}): FilterableSpecies {
+  return {
+    category: "VU",
+    countries: ["BR"],
+    systems: ["Marine"],
+    population_trend: "Decreasing",
+    movement_pattern: null,
+    threat_codes: ["11.4"],
+    has_map: true,
+    growth_forms: [],
+    scientific_name: "Acropora cervicornis",
+    common_name: "Staghorn coral",
+    ...overrides,
+  };
+}
+
+describe("matchesSpeciesFilter", () => {
+  it("matches everything with empty criteria", () => {
+    expect(matchesSpeciesFilter(sp(), {})).toBe(true);
+  });
+
+  it("matches category exactly", () => {
+    expect(matchesSpeciesFilter(sp({ category: "CR" }), { categories: new Set(["CR"]) })).toBe(true);
+    expect(matchesSpeciesFilter(sp({ category: "EN" }), { categories: new Set(["CR"]) })).toBe(false);
+  });
+
+  it("matches threats by prefix", () => {
+    expect(matchesSpeciesFilter(sp({ threat_codes: ["11.4"] }), { threats: new Set(["11"]) })).toBe(true);
+    expect(matchesSpeciesFilter(sp({ threat_codes: ["11"] }), { threats: new Set(["11"]) })).toBe(true);
+    expect(matchesSpeciesFilter(sp({ threat_codes: ["5.4"] }), { threats: new Set(["11"]) })).toBe(false);
+    // prefix must be on a dot boundary, not a substring
+    expect(matchesSpeciesFilter(sp({ threat_codes: ["110"] }), { threats: new Set(["11"]) })).toBe(false);
+  });
+
+  it("ORs multiple values within one filter", () => {
+    const f = { threats: new Set(["11", "9"]) };
+    expect(matchesSpeciesFilter(sp({ threat_codes: ["9.1"] }), f)).toBe(true);
+    expect(matchesSpeciesFilter(sp({ threat_codes: ["11.2"] }), f)).toBe(true);
+    expect(matchesSpeciesFilter(sp({ threat_codes: ["2.1"] }), f)).toBe(false);
+  });
+
+  it("ANDs across different filters", () => {
+    const f = { threats: new Set(["11"]), categories: new Set(["CR"]) };
+    expect(matchesSpeciesFilter(sp({ threat_codes: ["11.1"], category: "CR" }), f)).toBe(true);
+    expect(matchesSpeciesFilter(sp({ threat_codes: ["11.1"], category: "EN" }), f)).toBe(false);
+    expect(matchesSpeciesFilter(sp({ threat_codes: ["5.4"], category: "CR" }), f)).toBe(false);
+  });
+
+  it("matches countries (OR) and systems", () => {
+    expect(matchesSpeciesFilter(sp({ countries: ["US", "MX"] }), { countries: new Set(["MX"]) })).toBe(true);
+    expect(matchesSpeciesFilter(sp({ countries: ["US"] }), { countries: new Set(["MX"]) })).toBe(false);
+    expect(matchesSpeciesFilter(sp({ systems: ["Freshwater"] }), { systems: new Set(["Marine"]) })).toBe(false);
+  });
+
+  it("matches population trend and movement", () => {
+    expect(matchesSpeciesFilter(sp({ population_trend: "Decreasing" }), { populationTrends: new Set(["Decreasing"]) })).toBe(true);
+    expect(matchesSpeciesFilter(sp({ population_trend: null }), { populationTrends: new Set(["Decreasing"]) })).toBe(false);
+  });
+
+  it("matches hasMap", () => {
+    expect(matchesSpeciesFilter(sp({ has_map: true }), { hasMap: "yes" })).toBe(true);
+    expect(matchesSpeciesFilter(sp({ has_map: true }), { hasMap: "no" })).toBe(false);
+    expect(matchesSpeciesFilter(sp({ has_map: false }), { hasMap: "no" })).toBe(true);
+  });
+
+  it("matches name search (scientific or common), needle pre-lowercased", () => {
+    expect(matchesSpeciesFilter(sp(), { search: "acropora" })).toBe(true);
+    expect(matchesSpeciesFilter(sp(), { search: "staghorn" })).toBe(true);
+    expect(matchesSpeciesFilter(sp(), { search: "tiger" })).toBe(false);
+    expect(matchesSpeciesFilter(sp({ common_name: null }), { search: "staghorn" })).toBe(false);
+  });
+
+  it("handles missing optional arrays safely", () => {
+    expect(matchesSpeciesFilter(sp({ threat_codes: null }), { threats: new Set(["11"]) })).toBe(false);
+    expect(matchesSpeciesFilter(sp({ systems: null }), { systems: new Set(["Marine"]) })).toBe(false);
+  });
+});

--- a/app/src/lib/__tests__/species-filter.test.ts
+++ b/app/src/lib/__tests__/species-filter.test.ts
@@ -13,6 +13,8 @@ function sp(overrides: Partial<FilterableSpecies> = {}): FilterableSpecies {
     growth_forms: [],
     scientific_name: "Acropora cervicornis",
     common_name: "Staghorn coral",
+    gbif_occurrence_count: 50,
+    assessment_date: "2018-06-01",
     ...overrides,
   };
 }
@@ -76,5 +78,20 @@ describe("matchesSpeciesFilter", () => {
   it("handles missing optional arrays safely", () => {
     expect(matchesSpeciesFilter(sp({ threat_codes: null }), { threats: new Set(["11"]) })).toBe(false);
     expect(matchesSpeciesFilter(sp({ systems: null }), { systems: new Set(["Marine"]) })).toBe(false);
+  });
+
+  it("matches GBIF observation bounds (null counts as 0)", () => {
+    expect(matchesSpeciesFilter(sp({ gbif_occurrence_count: 150 }), { minObs: 100 })).toBe(true);
+    expect(matchesSpeciesFilter(sp({ gbif_occurrence_count: 50 }), { minObs: 100 })).toBe(false);
+    expect(matchesSpeciesFilter(sp({ gbif_occurrence_count: null }), { minObs: 1 })).toBe(false);
+    expect(matchesSpeciesFilter(sp({ gbif_occurrence_count: 5 }), { maxObs: 10 })).toBe(true);
+    expect(matchesSpeciesFilter(sp({ gbif_occurrence_count: 500 }), { minObs: 100, maxObs: 1000 })).toBe(true);
+  });
+
+  it("matches assessment-year bounds (inclusive)", () => {
+    expect(matchesSpeciesFilter(sp({ assessment_date: "2015-01-01" }), { minAssessmentYear: 2015 })).toBe(true);
+    expect(matchesSpeciesFilter(sp({ assessment_date: "2014-12-31" }), { minAssessmentYear: 2015 })).toBe(false);
+    expect(matchesSpeciesFilter(sp({ assessment_date: "2010-01-01" }), { maxAssessmentYear: 2012 })).toBe(true);
+    expect(matchesSpeciesFilter(sp({ assessment_date: null }), { minAssessmentYear: 2000 })).toBe(false);
   });
 });

--- a/app/src/lib/countries.ts
+++ b/app/src/lib/countries.ts
@@ -1,0 +1,107 @@
+// ISO 3166-1 alpha-2 country code mappings.
+// Extracted from WorldMap.tsx so server-side code (e.g. /browse) can import
+// these maps without pulling in the client-only map rendering deps.
+
+// Country name (from TopoJSON) to ISO 3166-1 alpha-2 mapping for GBIF
+export const NAME_TO_ALPHA2: Record<string, string> = {
+  "Afghanistan": "AF", "Albania": "AL", "Algeria": "DZ", "Angola": "AO", "Argentina": "AR",
+  "Armenia": "AM", "Australia": "AU", "Austria": "AT", "Azerbaijan": "AZ", "Bangladesh": "BD",
+  "Belarus": "BY", "Belgium": "BE", "Benin": "BJ", "Bhutan": "BT", "Bolivia": "BO",
+  "Bosnia and Herz.": "BA", "Botswana": "BW", "Brazil": "BR", "Brunei": "BN", "Bulgaria": "BG",
+  "Burkina Faso": "BF", "Burundi": "BI", "Cambodia": "KH", "Cameroon": "CM", "Canada": "CA",
+  "Central African Rep.": "CF", "Chad": "TD", "Chile": "CL", "China": "CN", "Colombia": "CO",
+  "Congo": "CG", "Dem. Rep. Congo": "CD", "Costa Rica": "CR", "Côte d'Ivoire": "CI",
+  "Croatia": "HR", "Cuba": "CU", "Cyprus": "CY", "Czechia": "CZ", "Denmark": "DK",
+  "Djibouti": "DJ", "Dominican Rep.": "DO", "Ecuador": "EC", "Egypt": "EG", "El Salvador": "SV",
+  "Eq. Guinea": "GQ", "Eritrea": "ER", "Estonia": "EE", "eSwatini": "SZ", "Ethiopia": "ET",
+  "Fiji": "FJ", "Finland": "FI", "France": "FR", "Gabon": "GA", "Gambia": "GM", "Georgia": "GE",
+  "Germany": "DE", "Ghana": "GH", "Greece": "GR", "Greenland": "GL", "Guatemala": "GT",
+  "Guinea": "GN", "Guinea-Bissau": "GW", "Guyana": "GY", "Haiti": "HT", "Honduras": "HN",
+  "Hungary": "HU", "Iceland": "IS", "India": "IN", "Indonesia": "ID", "Iran": "IR", "Iraq": "IQ",
+  "Ireland": "IE", "Israel": "IL", "Italy": "IT", "Jamaica": "JM", "Japan": "JP", "Jordan": "JO",
+  "Kazakhstan": "KZ", "Kenya": "KE", "North Korea": "KP", "South Korea": "KR", "Kuwait": "KW",
+  "Kyrgyzstan": "KG", "Laos": "LA", "Latvia": "LV", "Lebanon": "LB", "Lesotho": "LS",
+  "Liberia": "LR", "Libya": "LY", "Lithuania": "LT", "Luxembourg": "LU", "Madagascar": "MG",
+  "Malawi": "MW", "Malaysia": "MY", "Mali": "ML", "Mauritania": "MR", "Mexico": "MX",
+  "Moldova": "MD", "Mongolia": "MN", "Montenegro": "ME", "Morocco": "MA", "Mozambique": "MZ",
+  "Myanmar": "MM", "Namibia": "NA", "Nepal": "NP", "Netherlands": "NL", "New Zealand": "NZ",
+  "Nicaragua": "NI", "Niger": "NE", "Nigeria": "NG", "Norway": "NO", "Oman": "OM",
+  "Pakistan": "PK", "Panama": "PA", "Papua New Guinea": "PG", "Paraguay": "PY", "Peru": "PE",
+  "Philippines": "PH", "Poland": "PL", "Portugal": "PT", "Puerto Rico": "PR", "Qatar": "QA",
+  "Romania": "RO", "Russia": "RU", "Rwanda": "RW", "Saudi Arabia": "SA", "Senegal": "SN",
+  "Serbia": "RS", "Sierra Leone": "SL", "Singapore": "SG", "Slovakia": "SK", "Slovenia": "SI",
+  "Solomon Is.": "SB", "Somalia": "SO", "South Africa": "ZA", "S. Sudan": "SS", "Spain": "ES",
+  "Sri Lanka": "LK", "Sudan": "SD", "Suriname": "SR", "Sweden": "SE", "Switzerland": "CH",
+  "Syria": "SY", "Taiwan": "TW", "Tajikistan": "TJ", "Tanzania": "TZ", "Thailand": "TH",
+  "Timor-Leste": "TL", "Togo": "TG", "Trinidad and Tobago": "TT", "Tunisia": "TN",
+  "Turkey": "TR", "Turkmenistan": "TM", "Uganda": "UG", "Ukraine": "UA",
+  "United Arab Emirates": "AE", "United Kingdom": "GB", "United States of America": "US",
+  "Uruguay": "UY", "Uzbekistan": "UZ", "Vanuatu": "VU", "Venezuela": "VE", "Vietnam": "VN",
+  "Yemen": "YE", "Zambia": "ZM", "Zimbabwe": "ZW", "Palestine": "PS", "Kosovo": "XK",
+  "North Macedonia": "MK", "New Caledonia": "NC", "W. Sahara": "EH", "Fr. S. Antarctic Lands": "TF",
+  "Falkland Is.": "FK",
+  // Small/micro nations not in 110m TopoJSON but useful for search
+  "Andorra": "AD", "Antigua and Barbuda": "AG", "Bahamas": "BS", "Bahrain": "BH", "Barbados": "BB",
+  "Belize": "BZ", "Cape Verde": "CV", "Comoros": "KM", "Dominica": "DM", "Grenada": "GD",
+  "Kiribati": "KI", "Liechtenstein": "LI", "Maldives": "MV", "Malta": "MT", "Marshall Islands": "MH",
+  "Mauritius": "MU", "Micronesia": "FM", "Monaco": "MC", "Nauru": "NR", "Palau": "PW",
+  "Samoa": "WS", "San Marino": "SM", "São Tomé and Príncipe": "ST", "Seychelles": "SC",
+  "Saint Kitts and Nevis": "KN", "Saint Lucia": "LC", "Saint Vincent and the Grenadines": "VC",
+  "Tonga": "TO", "Tuvalu": "TV", "Vatican City": "VA",
+};
+
+// Complete ISO 3166-1 alpha-2 to country name mapping (for display)
+// Includes all countries, territories, and small island nations
+export const ALPHA2_TO_NAME: Record<string, string> = {
+  // From TopoJSON (use these names for map consistency)
+  ...Object.fromEntries(Object.entries(NAME_TO_ALPHA2).map(([name, code]) => [code, name])),
+  // Additional countries and territories not in TopoJSON
+  "AD": "Andorra", "AG": "Antigua and Barbuda", "AI": "Anguilla", "AQ": "Antarctica",
+  "AS": "American Samoa", "AW": "Aruba", "AX": "Åland Islands", "BB": "Barbados",
+  "BH": "Bahrain", "BL": "Saint Barthélemy", "BM": "Bermuda", "BQ": "Bonaire",
+  "BS": "Bahamas", "BV": "Bouvet Island", "BZ": "Belize", "CC": "Cocos Islands",
+  "CK": "Cook Islands", "CV": "Cape Verde", "CW": "Curaçao", "CX": "Christmas Island",
+  "DM": "Dominica", "FK": "Falkland Islands", "FM": "Micronesia", "FO": "Faroe Islands",
+  "GD": "Grenada", "GF": "French Guiana", "GG": "Guernsey", "GI": "Gibraltar",
+  "GP": "Guadeloupe", "GS": "South Georgia", "GU": "Guam", "HK": "Hong Kong",
+  "HM": "Heard Island", "IM": "Isle of Man", "IO": "British Indian Ocean Territory",
+  "JE": "Jersey", "KI": "Kiribati", "KM": "Comoros", "KN": "Saint Kitts and Nevis",
+  "KY": "Cayman Islands", "LC": "Saint Lucia", "LI": "Liechtenstein", "MC": "Monaco",
+  "MF": "Saint Martin", "MH": "Marshall Islands", "MO": "Macao", "MP": "Northern Mariana Islands",
+  "MQ": "Martinique", "MS": "Montserrat", "MT": "Malta", "MU": "Mauritius", "MV": "Maldives",
+  "NF": "Norfolk Island", "NR": "Nauru", "NU": "Niue", "PF": "French Polynesia",
+  "PM": "Saint Pierre and Miquelon", "PN": "Pitcairn", "PW": "Palau", "RE": "Réunion",
+  "SC": "Seychelles", "SH": "Saint Helena", "SJ": "Svalbard", "SM": "San Marino",
+  "ST": "São Tomé and Príncipe", "SV": "El Salvador", "SX": "Sint Maarten",
+  "TC": "Turks and Caicos", "TK": "Tokelau", "TO": "Tonga", "TV": "Tuvalu",
+  "UM": "U.S. Minor Outlying Islands", "VA": "Vatican City", "VC": "Saint Vincent and the Grenadines",
+  "VG": "British Virgin Islands", "VI": "U.S. Virgin Islands", "WF": "Wallis and Futuna",
+  "WS": "Samoa", "YT": "Mayotte",
+};
+
+// --- Resolution helpers -------------------------------------------------
+
+// Informal / common aliases not present as canonical names above.
+const ALIAS_TO_ALPHA2: Record<string, string> = {
+  "usa": "US", "u.s.a.": "US", "us": "US", "united states": "US", "america": "US",
+  "uk": "GB", "u.k.": "GB", "britain": "GB", "great britain": "GB", "england": "GB",
+  "drc": "CD", "dr congo": "CD", "democratic republic of the congo": "CD",
+  "czech republic": "CZ", "swaziland": "SZ", "ivory coast": "CI",
+};
+
+const NAME_LOOKUP: Record<string, string> = (() => {
+  const m: Record<string, string> = {};
+  for (const [name, code] of Object.entries(NAME_TO_ALPHA2)) m[name.toLowerCase()] = code;
+  for (const [code, name] of Object.entries(ALPHA2_TO_NAME)) m[name.toLowerCase()] = code;
+  for (const [k, v] of Object.entries(ALIAS_TO_ALPHA2)) m[k] = v;
+  return m;
+})();
+
+/** Resolve a country code or human-readable name to an ISO alpha-2 code, or null. */
+export function resolveCountryToAlpha2(value: string): string | null {
+  const v = value.trim();
+  if (!v) return null;
+  const upper = v.toUpperCase();
+  if (/^[A-Z]{2}$/.test(upper) && ALPHA2_TO_NAME[upper]) return upper;
+  return NAME_LOOKUP[v.toLowerCase()] ?? null;
+}

--- a/app/src/lib/filter-vocab.ts
+++ b/app/src/lib/filter-vocab.ts
@@ -1,0 +1,245 @@
+/**
+ * Filter vocabulary + human-friendly value resolution.
+ *
+ * Single source of truth for the /browse endpoint and llms.txt. Lets an LLM
+ * (or human) use plain-English values — "climate-change", "endangered",
+ * "birds", "Brazil" — instead of internal codes, and lets us render codes
+ * back as labels in output so the codebook is never required either way.
+ */
+
+import { CATEGORY_NAMES } from "@/config/taxa";
+import { findNode } from "@/lib/taxonomy-utils";
+import { resolveCountryToAlpha2, ALPHA2_TO_NAME } from "@/lib/countries";
+
+// ─── Threats (IUCN threat classification) ────────────────────────────────
+
+/** IUCN threat classification hierarchy (moved from RedListView). */
+export const THREAT_CATEGORIES: { code: string; label: string; children: { code: string; label: string }[] }[] = [
+  { code: "1", label: "Development", children: [
+    { code: "1.1", label: "Housing & urban areas" }, { code: "1.2", label: "Commercial & industrial areas" }, { code: "1.3", label: "Tourism & recreation areas" },
+  ]},
+  { code: "2", label: "Agriculture", children: [
+    { code: "2.1", label: "Crops" }, { code: "2.2", label: "Wood & pulp plantations" }, { code: "2.3", label: "Livestock farming & ranching" }, { code: "2.4", label: "Aquaculture" },
+  ]},
+  { code: "3", label: "Energy & Mining", children: [
+    { code: "3.1", label: "Oil & gas drilling" }, { code: "3.2", label: "Mining & quarrying" }, { code: "3.3", label: "Renewable energy" },
+  ]},
+  { code: "4", label: "Transport", children: [
+    { code: "4.1", label: "Roads & railroads" }, { code: "4.2", label: "Utility & service lines" }, { code: "4.3", label: "Shipping lanes" }, { code: "4.4", label: "Flight paths" },
+  ]},
+  { code: "5", label: "Harvesting", children: [
+    { code: "5.1", label: "Hunting & trapping" }, { code: "5.2", label: "Gathering plants" }, { code: "5.3", label: "Logging & wood harvesting" }, { code: "5.4", label: "Fishing & harvesting" },
+  ]},
+  { code: "6", label: "Disturbance", children: [
+    { code: "6.1", label: "Recreational activities" }, { code: "6.2", label: "War & military" }, { code: "6.3", label: "Work & other activities" },
+  ]},
+  { code: "7", label: "System modifications", children: [
+    { code: "7.1", label: "Fire & fire suppression" }, { code: "7.2", label: "Dams & water management" }, { code: "7.3", label: "Other modifications" },
+  ]},
+  { code: "8", label: "Invasive species", children: [
+    { code: "8.1", label: "Invasive non-native species" }, { code: "8.2", label: "Problematic native species" }, { code: "8.3", label: "Introduced genetic material" }, { code: "8.4", label: "Unknown origin species" }, { code: "8.5", label: "Viral/prion diseases" }, { code: "8.6", label: "Diseases of unknown cause" },
+  ]},
+  { code: "9", label: "Pollution", children: [
+    { code: "9.1", label: "Domestic & urban waste water" }, { code: "9.2", label: "Industrial & military effluents" }, { code: "9.3", label: "Agricultural & forestry effluents" },
+    { code: "9.4", label: "Garbage & solid waste" }, { code: "9.5", label: "Air-borne pollutants" }, { code: "9.6", label: "Excess energy (light, thermal, noise)" },
+  ]},
+  { code: "10", label: "Geological events", children: [
+    { code: "10.1", label: "Volcanoes" }, { code: "10.2", label: "Earthquakes/tsunamis" }, { code: "10.3", label: "Avalanches/landslides" },
+  ]},
+  { code: "11", label: "Climate change", children: [
+    { code: "11.1", label: "Habitat shifting & alteration" }, { code: "11.2", label: "Droughts" }, { code: "11.3", label: "Temperature extremes" }, { code: "11.4", label: "Storms & flooding" }, { code: "11.5", label: "Other impacts" },
+  ]},
+  { code: "12", label: "Other", children: [
+    { code: "12.1", label: "Other threat" },
+  ]},
+];
+
+/** code → label, including sub-codes. */
+export const THREAT_LABEL: Record<string, string> = (() => {
+  const m: Record<string, string> = {};
+  for (const c of THREAT_CATEGORIES) {
+    m[c.code] = c.label;
+    for (const sub of c.children) m[sub.code] = sub.label;
+  }
+  return m;
+})();
+
+/** Human label for a threat code, walking up to the nearest known parent for
+ *  deep sub-codes (e.g. "5.4.1" → "Fishing & harvesting"). Never returns a bare
+ *  number when a labelled ancestor exists. */
+export function threatDisplay(code: string): string {
+  if (THREAT_LABEL[code]) return THREAT_LABEL[code];
+  const parts = code.split(".");
+  while (parts.length > 1) {
+    parts.pop();
+    const parent = parts.join(".");
+    if (THREAT_LABEL[parent]) return THREAT_LABEL[parent];
+  }
+  return code;
+}
+
+const slugify = (v: string) => v.trim().toLowerCase().replace(/[\s_]+/g, "-");
+
+// Informal names → top-level threat code.
+const THREAT_ALIASES: Record<string, string> = {
+  "climate-change": "11", "climate": "11", "global-warming": "11", "warming": "11",
+  "pollution": "9",
+  "invasive-species": "8", "invasives": "8", "invasive": "8", "disease": "8", "diseases": "8", "pathogens": "8",
+  "harvesting": "5", "overharvesting": "5",
+  "overfishing": "5.4", "fishing": "5.4",
+  "hunting": "5.1", "poaching": "5.1", "trapping": "5.1",
+  "logging": "5.3", "deforestation": "5.3",
+  "agriculture": "2", "farming": "2", "crops": "2.1",
+  "development": "1", "urbanisation": "1", "urbanization": "1", "housing": "1.1",
+  "mining": "3.2", "energy": "3", "oil-and-gas": "3.1",
+  "transport": "4", "roads": "4.1", "shipping": "4.3",
+  "dams": "7.2", "fire": "7.1",
+  "geological-events": "10", "volcanoes": "10.1", "earthquakes": "10.2",
+  "droughts": "11.2", "storms": "11.4", "flooding": "11.4", "temperature-extremes": "11.3",
+};
+
+// label (lowercased) → code, for matching full labels.
+const THREAT_LABEL_TO_CODE: Record<string, string> = (() => {
+  const m: Record<string, string> = {};
+  for (const [code, label] of Object.entries(THREAT_LABEL)) m[label.toLowerCase()] = code;
+  return m;
+})();
+
+export function resolveThreats(values: string[]): { codes: string[]; unresolved: string[] } {
+  const codes = new Set<string>();
+  const unresolved: string[] = [];
+  for (const raw of values) {
+    const v = raw.trim();
+    if (!v) continue;
+    if (/^\d+(\.\d+)*$/.test(v) && THREAT_LABEL[v]) { codes.add(v); continue; }
+    const slug = slugify(v);
+    if (THREAT_ALIASES[slug]) { codes.add(THREAT_ALIASES[slug]); continue; }
+    if (THREAT_LABEL_TO_CODE[v.toLowerCase()]) { codes.add(THREAT_LABEL_TO_CODE[v.toLowerCase()]); continue; }
+    unresolved.push(raw);
+  }
+  return { codes: [...codes], unresolved };
+}
+
+// ─── IUCN categories ─────────────────────────────────────────────────────
+
+const CATEGORY_ALIASES: Record<string, string[]> = {
+  "extinct": ["EX", "EW"], "extinct-in-the-wild": ["EW"],
+  "critically-endangered": ["CR"], "critical": ["CR"],
+  "endangered": ["EN"],
+  "vulnerable": ["VU"],
+  "threatened": ["CR", "EN", "VU"],
+  "near-threatened": ["NT"],
+  "least-concern": ["LC"],
+  "data-deficient": ["DD"],
+  "not-evaluated": ["NE"],
+};
+
+const CATEGORY_NAME_TO_CODE: Record<string, string> = (() => {
+  const m: Record<string, string> = {};
+  for (const [code, name] of Object.entries(CATEGORY_NAMES)) m[name.toLowerCase()] = code;
+  return m;
+})();
+
+export function resolveCategories(values: string[]): { codes: string[]; unresolved: string[] } {
+  const codes = new Set<string>();
+  const unresolved: string[] = [];
+  for (const raw of values) {
+    const v = raw.trim();
+    if (!v) continue;
+    const upper = v.toUpperCase();
+    if (CATEGORY_NAMES[upper]) { codes.add(upper); continue; }
+    const slug = slugify(v);
+    if (CATEGORY_ALIASES[slug]) { CATEGORY_ALIASES[slug].forEach((c) => codes.add(c)); continue; }
+    if (CATEGORY_NAME_TO_CODE[v.toLowerCase()]) { codes.add(CATEGORY_NAME_TO_CODE[v.toLowerCase()]); continue; }
+    unresolved.push(raw);
+  }
+  return { codes: [...codes], unresolved };
+}
+
+export function categoryLabel(code: string): string {
+  return CATEGORY_NAMES[code] ? `${CATEGORY_NAMES[code]} (${code})` : code;
+}
+
+// ─── Taxa ────────────────────────────────────────────────────────────────
+
+/** Featured top-level groups, shown in the index/llms.txt. Each id is a real
+ *  taxonomy-tree node; display names come from the tree at runtime. */
+export const FEATURED_TAXA: string[] = [
+  "mammalia", "aves", "reptilia", "amphibia", "fishes",
+  "insecta", "arachnida", "mollusca", "crustacea", "corals",
+  "other_invertebrates", "velvet_worms", "horseshoe_crabs",
+  "flowering_plants", "gymnosperms", "ferns_and_allies", "mosses",
+  "green_algae", "red_algae", "brown_algae", "mushrooms",
+];
+
+// Common English names → taxonomy node id.
+const TAXA_ALIASES: Record<string, string> = {
+  "mammals": "mammalia", "mammal": "mammalia",
+  "birds": "aves", "bird": "aves",
+  "reptiles": "reptilia", "reptile": "reptilia",
+  "amphibians": "amphibia", "amphibian": "amphibia", "frogs": "amphibia", "frog": "amphibia", "toads": "amphibia",
+  "fish": "fishes",
+  "sharks": "sharks-rays", "rays": "sharks-rays", "sharks-and-rays": "sharks-rays",
+  "insects": "insecta", "insect": "insecta",
+  "beetles": "beetles", "butterflies": "butterflies-moths", "moths": "butterflies-moths", "bees": "bees-wasps-ants", "wasps": "bees-wasps-ants", "ants": "bees-wasps-ants",
+  "spiders": "arachnida", "arachnids": "arachnida",
+  "molluscs": "mollusca", "mollusks": "mollusca", "snails": "mollusca", "slugs": "mollusca",
+  "crustaceans": "crustacea", "crabs": "crustacea", "crayfish": "crustacea",
+  "coral": "corals",
+  "plants": "flowering_plants", "plant": "flowering_plants", "flowers": "flowering_plants", "trees": "flowering_plants",
+  "conifers": "gymnosperms",
+  "ferns": "ferns_and_allies", "fern": "ferns_and_allies",
+  "moss": "mosses",
+  "fungi": "mushrooms", "mushroom": "mushrooms",
+  "velvet-worms": "velvet_worms",
+  "horseshoe-crabs": "horseshoe_crabs",
+};
+
+export function resolveTaxa(values: string[]): { ids: string[]; unresolved: string[] } {
+  const ids = new Set<string>();
+  const unresolved: string[] = [];
+  for (const raw of values) {
+    const v = raw.trim();
+    if (!v || v.toLowerCase() === "all") { if (v) unresolved.push(raw); continue; }
+    // direct node id (tolerate hyphen/underscore swaps)
+    if (findNode(v)) { ids.add(v); continue; }
+    const underscored = v.toLowerCase().replace(/-/g, "_");
+    if (findNode(underscored)) { ids.add(underscored); continue; }
+    const hyphenated = v.toLowerCase().replace(/_/g, "-");
+    if (findNode(hyphenated)) { ids.add(hyphenated); continue; }
+    const slug = slugify(v);
+    if (TAXA_ALIASES[slug]) { ids.add(TAXA_ALIASES[slug]); continue; }
+    if (TAXA_ALIASES[underscored]) { ids.add(TAXA_ALIASES[underscored]); continue; }
+    unresolved.push(raw);
+  }
+  return { ids: [...ids], unresolved };
+}
+
+export function taxonLabel(id: string): string {
+  return findNode(id)?.name ?? id;
+}
+
+// ─── Countries ───────────────────────────────────────────────────────────
+
+export function resolveCountries(values: string[]): { codes: string[]; unresolved: string[] } {
+  const codes = new Set<string>();
+  const unresolved: string[] = [];
+  for (const raw of values) {
+    const v = raw.trim();
+    if (!v) continue;
+    const code = resolveCountryToAlpha2(v);
+    if (code) codes.add(code);
+    else unresolved.push(raw);
+  }
+  return { codes: [...codes], unresolved };
+}
+
+export function countryLabel(code: string): string {
+  return ALPHA2_TO_NAME[code] ? `${ALPHA2_TO_NAME[code]} (${code})` : code;
+}
+
+// ─── Misc base-filter vocab (free-text, passed through as-is) ──────────────
+
+export const SYSTEMS = ["Terrestrial", "Freshwater", "Marine"];
+export const POPULATION_TRENDS = ["Increasing", "Stable", "Decreasing", "Unknown"];
+export const ALL_CATEGORIES = Object.keys(CATEGORY_NAMES);

--- a/app/src/lib/species-filter.ts
+++ b/app/src/lib/species-filter.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared species filter predicate.
+ *
+ * Extracted from RedListView.tsx so the same base-filter logic runs both
+ * client-side (the dashboard) and server-side (the /browse LLM endpoint).
+ *
+ * Semantics (must match the dashboard exactly):
+ *  - Within one filter, multiple selected values are OR (species matches ANY).
+ *  - Across different filters it is AND (species must satisfy EVERY active filter).
+ *  - Threats match by prefix: "11" matches "11", "11.1", "11.4", ...
+ *  - Categories match exactly.
+ *
+ * Note: time-relative filters (years/obs/assessment-year), assessor/reviewer,
+ * and the "starred" filter are intentionally NOT included here — they depend on
+ * the current date, GBIF counts, or local UI state and stay inline in RedListView.
+ */
+
+/** Minimal structural shape this predicate needs. Both `SpeciesRow`
+ *  (server data store) and `RedListSpecies` (client hook) satisfy it. */
+export interface FilterableSpecies {
+  category: string;
+  countries: string[];
+  systems?: string[] | null;
+  population_trend: string | null;
+  movement_pattern: string | null;
+  threat_codes?: string[] | null;
+  has_map: boolean;
+  growth_forms?: string[] | null;
+  scientific_name: string;
+  common_name: string | null;
+}
+
+export interface SpeciesFilterCriteria {
+  categories?: Set<string>;
+  threats?: Set<string>;
+  countries?: Set<string>;
+  systems?: Set<string>;
+  populationTrends?: Set<string>;
+  movementPatterns?: Set<string>;
+  growthForms?: Set<string>;
+  hasMap?: "yes" | "no" | null;
+  /** Already lowercased by the caller. */
+  search?: string;
+}
+
+const empty = (s?: Set<string>) => !s || s.size === 0;
+
+export function matchesSpeciesFilter(s: FilterableSpecies, f: SpeciesFilterCriteria): boolean {
+  const matchesCategory = empty(f.categories) || f.categories!.has(s.category);
+
+  const matchesCountry = empty(f.countries) || s.countries.some((c) => f.countries!.has(c));
+
+  const matchesSystem = empty(f.systems) || (s.systems?.some((sys) => f.systems!.has(sys)) ?? false);
+
+  const matchesTrend =
+    empty(f.populationTrends) ||
+    (s.population_trend != null && f.populationTrends!.has(s.population_trend));
+
+  const matchesMovement =
+    empty(f.movementPatterns) ||
+    (s.movement_pattern != null && f.movementPatterns!.has(s.movement_pattern));
+
+  const matchesThreat =
+    empty(f.threats) ||
+    (s.threat_codes?.some((tc) =>
+      Array.from(f.threats!).some((sel) => tc === sel || tc.startsWith(sel + "."))
+    ) ?? false);
+
+  const matchesMap = !f.hasMap || (f.hasMap === "yes" ? s.has_map : !s.has_map);
+
+  const matchesGrowth =
+    empty(f.growthForms) || (s.growth_forms?.some((gf) => f.growthForms!.has(gf)) ?? false);
+
+  const q = f.search;
+  const matchesSearch =
+    !q ||
+    s.scientific_name.toLowerCase().includes(q) ||
+    (s.common_name?.toLowerCase().includes(q) ?? false);
+
+  return (
+    matchesCategory &&
+    matchesCountry &&
+    matchesSystem &&
+    matchesTrend &&
+    matchesMovement &&
+    matchesThreat &&
+    matchesMap &&
+    matchesGrowth &&
+    matchesSearch
+  );
+}

--- a/app/src/lib/species-filter.ts
+++ b/app/src/lib/species-filter.ts
@@ -28,6 +28,8 @@ export interface FilterableSpecies {
   growth_forms?: string[] | null;
   scientific_name: string;
   common_name: string | null;
+  gbif_occurrence_count?: number | null;
+  assessment_date?: string | null;
 }
 
 export interface SpeciesFilterCriteria {
@@ -41,6 +43,12 @@ export interface SpeciesFilterCriteria {
   hasMap?: "yes" | "no" | null;
   /** Already lowercased by the caller. */
   search?: string;
+  /** GBIF occurrence count bounds (null obs counts as 0). */
+  minObs?: number;
+  maxObs?: number;
+  /** Assessment year bounds (inclusive). */
+  minAssessmentYear?: number;
+  maxAssessmentYear?: number;
 }
 
 const empty = (s?: Set<string>) => !s || s.size === 0;
@@ -77,6 +85,20 @@ export function matchesSpeciesFilter(s: FilterableSpecies, f: SpeciesFilterCrite
     s.scientific_name.toLowerCase().includes(q) ||
     (s.common_name?.toLowerCase().includes(q) ?? false);
 
+  const obs = s.gbif_occurrence_count ?? 0;
+  const matchesMinObs = f.minObs == null || obs >= f.minObs;
+  const matchesMaxObs = f.maxObs == null || obs <= f.maxObs;
+
+  let matchesYear = true;
+  if (f.minAssessmentYear != null || f.maxAssessmentYear != null) {
+    const year = s.assessment_date ? parseInt(s.assessment_date.slice(0, 4), 10) : NaN;
+    if (Number.isNaN(year)) matchesYear = false;
+    else {
+      if (f.minAssessmentYear != null && year < f.minAssessmentYear) matchesYear = false;
+      if (f.maxAssessmentYear != null && year > f.maxAssessmentYear) matchesYear = false;
+    }
+  }
+
   return (
     matchesCategory &&
     matchesCountry &&
@@ -86,6 +108,9 @@ export function matchesSpeciesFilter(s: FilterableSpecies, f: SpeciesFilterCrite
     matchesThreat &&
     matchesMap &&
     matchesGrowth &&
-    matchesSearch
+    matchesSearch &&
+    matchesMinObs &&
+    matchesMaxObs &&
+    matchesYear
   );
 }


### PR DESCRIPTION
## Why

The dashboard is a client-rendered SPA, so pointing an LLM (Claude/ChatGPT web UI) at the live URL returns an **empty HTML shell** — no data. And threat filtering (e.g. climate change = code `11`) only runs client-side, so there's no single URL today that answers *"which coral species are threatened by climate change?"*

This adds a small **server-rendered web layer** so an LLM can answer base-filter questions from a fetched URL, navigating the data like a human would — without needing to know internal codes on the way in *or* out.

## What

- **`/browse`** — mirrors the dashboard's own filter-param vocabulary; returns readable **HTML** (or **JSON** via `?format=json`).
  - Accepts plain-English values: `threats=climate-change`, `categories=endangered`/`threatened`, `taxa=birds`, `countries=Brazil` (codes still work too).
  - Renders codes back as **labels** (threats + IUCN categories).
  - Leads with a **total + by-category breakdown**; **capped at 200 rows** (browsable, not a bulk dump).
  - Self-describing **vocabulary page** when called bare; **search-only** fast path via the search index.
- **`/llms.txt`** — concise, generated guide to the vocabulary + example URLs (the thing you paste into a chat).
- **Shared `species-filter` predicate** extracted from `RedListView` so the SPA and `/browse` stay in sync (OR-within / AND-across / prefix threats — behaviour unchanged).
- **`filter-vocab`** — human-friendly resolvers + `threatDisplay` (deep sub-codes like `5.4.1` walk up to the nearest known label).
- **`countries`** — ISO name↔code maps relocated out of the client `WorldMap` so server code can import them; `WorldMap` re-exports `ALPHA2_TO_NAME` so existing importers are untouched.
- **`layout`** — small server-rendered footer linking `/browse` + `/llms.txt` (the only crawler-visible spot, since the app is client-rendered).

Discoverability preserved (no `noindex`); no bulk-downloadable data file.

## Example

`GET /browse?taxa=corals&threats=climate-change` → **878** corals, breakdown `CR:31 EN:244 VU:56 NT:18 LC:417 DD:112`, top hit *Acropora cervicornis (Critically Endangered)* with labelled threats.

## Verification

- Live-tested against real R2 data: canonical corals+climate query, `Brazil`→`BR` resolution, cross-taxa `search=tiger`, empty/unknown/over-cap/dedup cases.
- **27 new tests**; full suite **438/438** passes; typecheck + lint clean.

## Notes / deliberate limits

- **Cross-taxa listings** (all groups at once) intentionally aren't a 280k scan — the index/`llms.txt` steer per-taxon. Could be added via the precomputed summaries if wanted.
- **Synonym search** was dropped: `SpeciesRow` has no `synonyms` field, so search matches scientific + common name (same as the dashboard). Adding it needs a data-model change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)