### PR TITLE
Phase 2: cut v2 cold-start + history-join latency

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -45,6 +45,10 @@ yarn-error.log*
 !/data/taxa-summary.json
 !/data/node-children-summaries.json
 
+# DuckDB httpfs extension — vendored at build time by scripts/fetch-duckdb-ext.ts
+# (downloaded, not committed; traced into the v2 function via next.config).
+/duckdb-ext/
+
 # vercel
 .vercel
 

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -8,8 +8,13 @@ const nextConfig: NextConfig = {
   // .so isn't bundled into every function. Vercel runs linux-x64.
   serverExternalPackages: ["@duckdb/node-api"],
   outputFileTracingIncludes: {
-    // libduckdb.so (dlopen'd) + the version pointer used to build the R2 path.
-    "/api/v2/**": ["./node_modules/@duckdb/node-bindings-linux-x64/**", "./latest-sync.txt"],
+    // libduckdb.so (dlopen'd) + the version pointer used to build the R2 path +
+    // the vendored httpfs extension (LOAD'd by path, avoiding a cold-start INSTALL).
+    "/api/v2/**": [
+      "./node_modules/@duckdb/node-bindings-linux-x64/**",
+      "./latest-sync.txt",
+      "./duckdb-ext/**",
+    ],
   },
 
   // The API routes import a shared species-store module that references every

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "prebuild": "npm run fetch-data-from-r2",
+    "prebuild": "npm run fetch-data-from-r2 && npm run fetch-duckdb-ext",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
@@ -12,7 +12,8 @@
     "test:watch": "vitest",
     "upload-data-to-r2": "npx tsx scripts/upload-data-to-r2.ts",
     "fetch-data-from-r2": "npx tsx scripts/fetch-data-from-r2.ts",
-    "diff-data-vs-r2": "npx tsx scripts/diff-data-vs-r2.ts"
+    "diff-data-vs-r2": "npx tsx scripts/diff-data-vs-r2.ts",
+    "fetch-duckdb-ext": "npx tsx scripts/fetch-duckdb-ext.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1020.0",

--- a/app/scripts/fetch-duckdb-ext.ts
+++ b/app/scripts/fetch-duckdb-ext.ts
@@ -1,0 +1,66 @@
+/**
+ * fetch-duckdb-ext (#260 Phase 2): vendor the DuckDB `httpfs` extension for the
+ * deployment target into app/duckdb-ext/ at build time.
+ *
+ * Why: the v2 read layer queries Parquet in R2 over httpfs. Doing
+ * `INSTALL httpfs` at runtime hits extensions.duckdb.org on every cold start
+ * (a network round-trip on the request path). Instead we download the matching
+ * extension once at build time and `LOAD` it by path — no runtime network, no
+ * cold-start INSTALL. next.config traces this dir into the v2 function.
+ *
+ * Target is always linux_amd64 (Vercel's runtime). Locally the file is unused
+ * (dev reads local parquets, USE_R2=false) but harmless to have. The engine
+ * version is read from DuckDB itself so this survives a @duckdb/node-api bump.
+ *
+ * Runs as part of `prebuild`. Idempotent: skips the download when the vendored
+ * file already matches the current engine version (via a .version sidecar).
+ *
+ * Usage:
+ *   npx tsx scripts/fetch-duckdb-ext.ts
+ */
+import * as fs from "fs";
+import * as path from "path";
+import * as zlib from "zlib";
+import { DuckDBInstance } from "@duckdb/node-api";
+
+export const EXT_DIR = path.join(__dirname, "..", "duckdb-ext");
+const EXT_NAME = "httpfs";
+const PLATFORM = "linux_amd64"; // Vercel runtime; the only place USE_R2 is true.
+
+async function engineVersion(): Promise<string> {
+  const inst = await DuckDBInstance.create(":memory:");
+  const conn = await inst.connect();
+  const rows = (await (await conn.run("SELECT version() AS v")).getRowObjects()) as { v: string }[];
+  return rows[0].v; // e.g. "v1.5.3"
+}
+
+export async function run(): Promise<void> {
+  const version = await engineVersion();
+  const extPath = path.join(EXT_DIR, `${EXT_NAME}.duckdb_extension`);
+  const versionPath = path.join(EXT_DIR, `${EXT_NAME}.version`);
+
+  const have = fs.existsSync(extPath) && fs.existsSync(versionPath)
+    ? fs.readFileSync(versionPath, "utf-8").trim()
+    : null;
+  if (have === version) {
+    console.log(`duckdb-ext: ${EXT_NAME} ${version} already vendored — skipping.`);
+    return;
+  }
+
+  const url = `http://extensions.duckdb.org/${version}/${PLATFORM}/${EXT_NAME}.duckdb_extension.gz`;
+  console.log(`duckdb-ext: downloading ${url}`);
+  const resp = await fetch(url);
+  if (!resp.ok) throw new Error(`Failed to fetch ${url}: ${resp.status} ${resp.statusText}`);
+  const gz = Buffer.from(await resp.arrayBuffer());
+  const bin = zlib.gunzipSync(gz);
+
+  fs.mkdirSync(EXT_DIR, { recursive: true });
+  fs.writeFileSync(extPath, bin);
+  fs.writeFileSync(versionPath, version + "\n");
+  console.log(`duckdb-ext: wrote ${extPath} (${(bin.length / 1e6).toFixed(1)} MB) for engine ${version}`);
+}
+
+const isDirectRun = process.argv[1]?.endsWith("fetch-duckdb-ext.ts") || process.argv[1]?.endsWith("fetch-duckdb-ext.js");
+if (isDirectRun) {
+  run().catch((err) => { console.error("Fatal error:", err); process.exit(1); });
+}

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -16,6 +16,9 @@ import { canonicalizeTaxonId, mapTaxonId } from "@/lib/data/taxonomy-constants";
 const DATA_DIR = path.join(process.cwd(), "data");
 // Dev has the parquets on disk; on Vercel they aren't bundled → read from R2.
 const USE_R2 = !fs.existsSync(path.join(DATA_DIR, "assessed.parquet"));
+// httpfs vendored at build time (scripts/fetch-duckdb-ext.ts) + traced into the
+// v2 function (next.config). LOAD by path avoids the cold-start network INSTALL.
+const HTTPFS_EXT = path.join(process.cwd(), "duckdb-ext", "httpfs.duckdb_extension");
 
 function parquetUri(name: string): string {
   if (!USE_R2) return path.join(DATA_DIR, name);
@@ -27,13 +30,10 @@ let connPromise: Promise<DuckDBConnection> | null = null;
 async function getConn(): Promise<DuckDBConnection> {
   if (!connPromise) {
     connPromise = (async () => {
-      const inst = await DuckDBInstance.create(
-        ":memory:",
-        USE_R2 ? { extension_directory: "/tmp/duckdb_ext", home_directory: "/tmp" } : {},
-      );
+      const inst = await DuckDBInstance.create(":memory:");
       const conn = await inst.connect();
       if (USE_R2) {
-        await conn.run("INSTALL httpfs; LOAD httpfs;");
+        await conn.run(`LOAD '${HTTPFS_EXT}'`);
         await conn.run(`
           SET s3_region='auto';
           SET s3_endpoint='${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com';

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -146,21 +146,31 @@ export async function querySpecies(opts: {
   const conn = await getConn();
   const where = resolveWhere(opts.taxon);
   const whereSql = where.clauses.length ? `WHERE ${where.clauses.join(" AND ")}` : "";
+  const assessedUri = parquetUri("assessed.parquet");
 
   // Assessed: join the per-species history (rebuilt in original array order via
   // seq; index 0 = latest) into previous_assessments. Run NE as a second query
   // (avoids UNION-ing the nested struct list) and concat — order doesn't matter
   // (the client sorts).
+  //
+  // Correlate the history aggregation to just the filtered species (the IN
+  // subquery) so the GROUP BY scans only the result set's rows, not all of
+  // assessments.parquet — ~3× faster on a cold R2 read for a taxon filter, never
+  // slower. Skipped for the unfiltered "all" case (the subquery would be every id).
+  const histFilter = where.clauses.length
+    ? `WHERE sis_taxon_id IN (SELECT id FROM '${assessedUri}' ${whereSql})`
+    : "";
   const assessedSql = `
     WITH hist AS (
       SELECT sis_taxon_id,
              to_json(list({'id': id, 'year': "year", 'category': category, 'date': "date",
                    'assessors': assessors, 'reviewers': reviewers} ORDER BY seq)) AS previous_assessments
       FROM '${parquetUri("assessments.parquet")}'
+      ${histFilter}
       GROUP BY sis_taxon_id
     )
     SELECT ${ASSESSED_SELECT}, h.previous_assessments
-    FROM '${parquetUri("assessed.parquet")}' a
+    FROM '${assessedUri}' a
     LEFT JOIN hist h ON h.sis_taxon_id = a.id
     ${whereSql}`;
   let rows = (await conn.runAndReadAll(assessedSql, where.params)).getRowObjects();


### PR DESCRIPTION
Phase 2 latency work toward the CoL cutover (#260). Three changes to the v2 DuckDB read layer, all validated on preview.

## 1. Vendor `httpfs`, `LOAD` by path (kill the cold-start `INSTALL`)
The v2 layer did `INSTALL httpfs` at runtime, hitting `extensions.duckdb.org` on every cold start. Now `scripts/fetch-duckdb-ext.ts` downloads the engine-matched extension (linux_amd64, version read from DuckDB itself) into a gitignored `duckdb-ext/` at build time (wired into `prebuild`, idempotent via a `.version` sidecar); `next.config.ts` traces it into the v2 function; `species-duckdb.ts` does `LOAD '<path>'`.

## 2. Correlate the history aggregation to the filtered species
(Superseded by #3 for the list query, but the technique stands.) Restricting the history scan with `WHERE sis_taxon_id IN (filtered ids)` cut mammals 858ms → 275ms cold locally.

## 3. Lazy assessment history (drop ~40% of the species-list payload)
History was ~half the list bytes and the join was the dominant query cost.
- `build-parquet` denormalizes `latest_assessors`/`latest_reviewers` (history seq 0) into `assessed.parquet` → the list query reads ONE file, no history join. The list view's assessor/reviewer filter reads these scalars.
- New `/api/v2/species/history?id=` + `getAssessmentHistory` fetch the full ordered array lazily when a detail row opens (`assessments.parquet` is sis-sorted → single-row-group prune).
- `RedListView`: assessor/reviewer accessors read the inline scalars; the Red List Assessments tab pulls history from a per-species lazy cache.

Requires the republished sync (`2026-06-10T16-36-54Z`, latest-sync.txt bump in this PR) — the parquets now carry the two new columns. Rebuilt from existing CSVs, no upstream re-fetch; columns are additive (backward-compatible).

## Validation (preview, commit de9d6f9)
- [x] Extension loads in serverless; `?taxon=mammals` → 6036, `turdidae` → 181, `mammals&category=NE` → 314.
- [x] `latest_assessors`/`latest_reviewers` inline; `previous_assessments` empty in the list.
- [x] `/api/v2/species/history?id=` → HTTP 200, full ordered array, `[0]` matches the inline denorm.
- [x] mammals payload 7.65MB → 4.76MB (−38%). Warm latency 0.3–1.0s.

## Cold-start finding (why no keep-warm in this PR)
Measured cold-container overhead ≈ 1s, once per cold container, mostly hidden by `CACHE_5M` edge caching. Warm latency is R2 range-reads + payload, not container init. Keep-warm deferred — low value vs the payload/query wins here.

## Not in this PR (remaining Phase 2)
Search + summaries onto DuckDB; collapse `/api/v2` into `/api/redlist/species`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)