### PR TITLE
Disable @next/next/no-img-element (deliberate plain <img> for remote images)

### DIFF
--- a/app/eslint.config.mjs
+++ b/app/eslint.config.mjs
@@ -19,6 +19,12 @@ const eslintConfig = defineConfig([
       "unused-imports": unusedImports,
     },
     rules: {
+      // All <img> usages are arbitrary remote third-party images (GBIF occurrence
+      // photos, iNaturalist species photos). next/image is a poor fit here: the
+      // source hosts are unpredictable (can't allowlist in images.remotePatterns),
+      // dimensions are unknown, and per-image Vercel optimization would add real
+      // cost across many occurrence thumbnails. Plain <img> is the deliberate choice.
+      "@next/next/no-img-element": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "unused-imports/no-unused-imports": "error",
       "unused-imports/no-unused-vars": [


### PR DESCRIPTION
Silences the recurring `no-img-element` warning, which flags a deliberate choice rather than a problem.

All six `<img>` usages render **arbitrary remote third-party images** — GBIF occurrence photos (`MapImageTooltip`, `MapOccurrenceTooltip`, `OccurrenceMapRow`) and iNaturalist species photos (`RedListView`). `next/image` is the wrong tool here:
- **Unpredictable source hosts** — can't reliably allowlist in `images.remotePatterns`; new hosts would break at runtime.
- **Cost** — Vercel bills per optimized image; occurrence maps render many thumbnails.
- **Unknown dimensions** — these images have no known width/height.

So the fix is to stop the linter nagging about an intentional decision (rule off + explanatory comment), not to migrate. `eslint src` is now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)