### PR TITLE
Search the full CoL universe (CoL-only species)

### DIFF
--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -1496,7 +1496,13 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   // Include single-species preview at the top of the page when bulk data hasn't loaded yet
   const paginatedSpecies = useMemo(() => {
     if (!singleSpeciesPreview) return paginatedSpeciesBase;
-    if (paginatedSpeciesBase.some(s => s.id === singleSpeciesPreview.id)) return paginatedSpeciesBase;
+    // De-dupe by id, and (for NE search results, whose cached-preview id differs from the
+    // loaded NE row's synthetic id) also by scientific name — so a searched CoL species
+    // shows the loaded row once the list arrives, not a duplicate alongside the preview.
+    if (paginatedSpeciesBase.some(s =>
+      s.id === singleSpeciesPreview.id ||
+      (singleSpeciesPreview.category === "NE" && s.scientific_name === singleSpeciesPreview.scientific_name)
+    )) return paginatedSpeciesBase;
     return [singleSpeciesPreview, ...paginatedSpeciesBase];
   }, [paginatedSpeciesBase, singleSpeciesPreview]);
 

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -318,10 +318,21 @@ export interface SearchResult {
   countries: string[];
 }
 
+// Stable negative int id for a CoL-only species (no IUCN sis id / GBIF key). Used as the
+// search result's id — the URL `species=` param + the cached-preview key — and never
+// collides with real positive sis/gbif ids. (The NE list itself assigns its own per-query
+// synthetic ids; the cached preview, built from this result, is what renders on click.)
+function colIdToSearchId(colId: string): number {
+  let h = 0;
+  for (let i = 0; i < colId.length; i++) h = (Math.imul(h, 31) + colId.charCodeAt(i)) | 0;
+  return -(Math.abs(h) || 1);
+}
+
 // Substring search over both parquets (replaces the in-memory search-index.json).
 // ILIKE can't use row-group pruning, but with column projection it scans only the
 // name columns from R2 — ~200ms warm over both files. Ranking mirrors the old
 // JSON path: exact common-name > common-name prefix > scientific prefix > alpha.
+// Falls back to the CoL universe (species/) only when the fast path is sparse — see below.
 export async function searchSpecies(query: string, limit = 10): Promise<SearchResult[]> {
   if (query.length < 2) return [];
   const conn = await getConn();
@@ -342,7 +353,7 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
              lower(scientific_name)
     LIMIT ${lim}`;
   const rows = (await conn.runAndReadAll(sql, { q: query.toLowerCase() })).getRowObjects();
-  return rows.map((r) => ({
+  const fast: SearchResult[] = rows.map((r) => ({
     id: Number(r.id),
     scientific_name: String(r.scientific_name ?? ""),
     common_name: (r.common_name as string) ?? null,
@@ -354,6 +365,43 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
     assessment_date: (r.assessment_date as string) ?? null,
     countries: splitList(r.countries),
   }));
+  if (fast.length >= lim) return fast;
+
+  // CoL-only fallback: universe species (species/) that are neither IUCN-assessed nor
+  // GBIF-observed, to fill the remaining slots. species/ has no common name and can't
+  // partition-prune on name, so this full-scans the name column — only run it when the
+  // fast path returned fewer than `limit` hits (it then holds ALL assessed+GBIF matches,
+  // so any species/ match not already listed is genuinely CoL-only — name-dedup suffices,
+  // no species_link anti-join needed). These render as NE and navigate to their leaf taxon.
+  const seen = new Set(fast.map((r) => r.scientific_name.toLowerCase()));
+  const colSql = `
+    SELECT col_id, scientific_name, taxon_group
+    FROM read_parquet('${parquetUri("species/**/*.parquet")}', hive_partitioning=true)
+    WHERE scientific_name ILIKE '%' || $q || '%' AND in_base AND extinct IS NOT TRUE
+      AND col_id NOT IN ${EXCLUDED_COL_IDS_SQL}
+    ORDER BY (lower(scientific_name) LIKE $q || '%') DESC, lower(scientific_name)
+    LIMIT ${(lim - fast.length) * 3 + 5}`;
+  const colRows = (await conn.runAndReadAll(colSql, { q: query.toLowerCase() })).getRowObjects();
+  for (const r of colRows) {
+    const name = String(r.scientific_name ?? "");
+    if (seen.has(name.toLowerCase())) continue;
+    seen.add(name.toLowerCase());
+    const tg = String(r.taxon_group);
+    fast.push({
+      id: colIdToSearchId(String(r.col_id)),
+      scientific_name: name,
+      common_name: null,
+      taxon_id: mapTaxonId(tg),
+      taxon_group: tg,
+      category: "NE",
+      gbif_species_key: null,
+      assessment_id: null,
+      assessment_date: null,
+      countries: [],
+    });
+    if (fast.length >= lim) break;
+  }
+  return fast;
 }
 
 // Prime the cached connection (httpfs load + S3 config) so the first search

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -318,6 +318,22 @@ export interface SearchResult {
   countries: string[];
 }
 
+// taxon_group → its representative *leaf* display node (csvGroups===[group], no class/order
+// sub-filter). mapTaxonId maps to the top-level taxon (e.g. invertebrates), which is too
+// large to load in new-assessments; a CoL-only search result must navigate to the leaf node
+// (e.g. dragonflies-damselflies) so its NE list actually loads.
+const GROUP_TO_LEAF_NODE: Map<string, string> = (() => {
+  const m = new Map<string, string>();
+  for (const [id, node] of NODE_INDEX) {
+    const f = node.filter;
+    if (f.csvGroups?.length === 1 && !f.classNames && !f.orderNames && !f.excludeClasses &&
+        !f.excludeOrders && !f.families && !f.excludeFamilies && !m.has(f.csvGroups[0])) {
+      m.set(f.csvGroups[0], id);
+    }
+  }
+  return m;
+})();
+
 // Stable negative int id for a CoL-only species (no IUCN sis id / GBIF key). Used as the
 // search result's id — the URL `species=` param + the cached-preview key — and never
 // collides with real positive sis/gbif ids. (The NE list itself assigns its own per-query
@@ -353,18 +369,25 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
              lower(scientific_name)
     LIMIT ${lim}`;
   const rows = (await conn.runAndReadAll(sql, { q: query.toLowerCase() })).getRowObjects();
-  const fast: SearchResult[] = rows.map((r) => ({
-    id: Number(r.id),
-    scientific_name: String(r.scientific_name ?? ""),
-    common_name: (r.common_name as string) ?? null,
-    taxon_id: mapTaxonId(String(r.taxon_group)),
-    taxon_group: String(r.taxon_group),
-    category: String(r.category ?? ""),
-    gbif_species_key: num(r.gbif_species_key),
-    assessment_id: num(r.assessment_id),
-    assessment_date: (r.assessment_date as string) ?? null,
-    countries: splitList(r.countries),
-  }));
+  const fast: SearchResult[] = rows.map((r) => {
+    const tg = String(r.taxon_group);
+    const cat = String(r.category ?? "");
+    // NE results navigate to the new-assessments view, which can't load a giant aggregate
+    // (mapTaxonId's top-level taxon) — send them to the leaf node so the list loads. Assessed
+    // results go to reassessments (assessed-only, always loadable) via the top-level taxon.
+    return {
+      id: Number(r.id),
+      scientific_name: String(r.scientific_name ?? ""),
+      common_name: (r.common_name as string) ?? null,
+      taxon_id: cat === "NE" ? (GROUP_TO_LEAF_NODE.get(tg) ?? mapTaxonId(tg)) : mapTaxonId(tg),
+      taxon_group: tg,
+      category: cat,
+      gbif_species_key: num(r.gbif_species_key),
+      assessment_id: num(r.assessment_id),
+      assessment_date: (r.assessment_date as string) ?? null,
+      countries: splitList(r.countries),
+    };
+  });
   if (fast.length >= lim) return fast;
 
   // CoL-only fallback: universe species (species/) that are neither IUCN-assessed nor
@@ -391,7 +414,7 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
       id: colIdToSearchId(String(r.col_id)),
       scientific_name: name,
       common_name: null,
-      taxon_id: mapTaxonId(tg),
+      taxon_id: GROUP_TO_LEAF_NODE.get(tg) ?? mapTaxonId(tg),
       taxon_group: tg,
       category: "NE",
       gbif_species_key: null,


### PR DESCRIPTION
Closes the search gap noted in #272: free-text search covered only assessed (IUCN) + GBIF-observed species, so CoL-only universe species (neither assessed nor GBIF-observed) returned nothing — even though they're browsable via taxonomic drill-down.

## Approach — fallback scan
`searchSpecies` keeps the fast `assessed.parquet UNION unassessed.parquet` path, then **falls back to `species/` only when the fast path returns fewer than `limit` hits**. At that point the fast path holds *all* assessed+GBIF matches, so any `species/` match not already listed is genuinely CoL-only — a name-dedup suffices (no `species_link` anti-join).

- The fallback `ILIKE`-scans the name column (no partition pruning on name), so it's gated on sparse queries — common species never trigger it.
- **All NE results** (CoL-only *and* GBIF-observed) navigate to their **leaf node** (`GROUP_TO_LEAF_NODE`), not the top-level taxon — `mapTaxonId` sends them to e.g. `invertebrates`, which is `tooLarge` in new-assessments, so the list wouldn't load. This also fixes pre-existing breakage for searching GBIF-observed NE species. CoL-only hits carry a stable `col_id`-derived id; the cached preview renders instantly.
- Excludes the `EXCLUDED_COL_IDS` denylist (Homo sapiens), consistent with the universe.

## Client
One tweak: de-dupe the cached single-species preview by scientific name for NE results (its `col_id`-derived id differs from the loaded NE row's synthetic id), so a searched CoL species shows once, not duplicated.

## Validated
- `Aeschnosoma yelenae` (CoL-only) → now returns a result (was 0); `Panthera leo` still hits the fast path; genus queries mix assessed + CoL-only.
- typecheck/lint clean, 361 tests.

## Note
The CoL fallback full-scans the `species/` name column from R2 (15 partition files), only on sparse queries (never the common-species path). Measured: **~1.4s warm**, **~12s on a cold container** (first search after the container spins up). Warm is fine; the cold hit is the species/ scan. A dedicated single-file **universe-names index** (col_id, name, taxon_group — built at sync) would cut cold materially and is the clean follow-up if cold matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
