### PR TITLE
Add Protected Areas (WDPA) overlay toggle to the GBIF occurrence map

### DIFF
--- a/app/src/components/OccurrenceMapRow.tsx
+++ b/app/src/components/OccurrenceMapRow.tsx
@@ -128,6 +128,18 @@ const BASEMAP_STYLES: Record<string, { label: string; style: MaplibreStyle }> = 
 };
 type BasemapKey = keyof typeof BASEMAP_STYLES;
 
+// Protected areas overlay — the World Database on Protected Areas (WDPA),
+// UNEP-WCMC & IUCN (the dataset behind protectedplanet.net, refreshed monthly).
+// Served straight from UNEP-WCMC's ArcGIS MapServer `export` endpoint as a
+// transparent PNG, which MapLibre fetches per-tile via the {bbox-epsg-3857}
+// token. Drawn semi-transparently beneath the occurrence points so you can see
+// at a glance which occurrences fall inside a protected area. No API key needed.
+const PROTECTED_AREAS_TILE_URL =
+  "https://data-gis.unep-wcmc.org/server/rest/services/ProtectedSites/The_World_Database_of_Protected_Areas/MapServer/export" +
+  "?bbox={bbox-epsg-3857}&bboxSR=3857&imageSR=3857&size=256,256&dpi=96&format=png32&transparent=true&f=image";
+const PROTECTED_AREAS_ATTRIBUTION =
+  '<a href="https://www.protectedplanet.net" target="_blank" rel="noopener noreferrer">WDPA</a> &copy; UNEP-WCMC &amp; IUCN';
+
 /**
  * Determine whether an occurrence record is "new" (recorded after the assessment date).
  * Uses full date comparison when eventDate is available, falls back to year comparison.
@@ -784,6 +796,7 @@ export default function OccurrenceMapRow({
   const [maxUncertainty, setMaxUncertainty] = useState<number | null>(50000);
   const [colorByDate, setColorByDate] = useState(false);
   const [basemap, setBasemap] = useState<BasemapKey>("streets");
+  const [showProtectedAreas, setShowProtectedAreas] = useState(false);
   const [splitView, setSplitView] = useState(false);
   const [splitDate, setSplitDate] = useState<string>(assessmentDate?.split("T")[0] || "");
   const [sharedViewState, setSharedViewState] = useState({ longitude: 0, latitude: 20, zoom: 1.5 });
@@ -1355,6 +1368,19 @@ export default function OccurrenceMapRow({
               cursor={hoveredFeature && hoveredPanel === panelId ? "pointer" : "grab"}
             >
               <ScaleControl position="bottom-right" />
+              {/* Protected areas overlay (WDPA) — rendered before the occurrence
+                  circles so the points draw on top of the shaded PA polygons */}
+              {showProtectedAreas && (
+                <Source
+                  id={`wdpa-${panelId}`}
+                  type="raster"
+                  tiles={[PROTECTED_AREAS_TILE_URL]}
+                  tileSize={256}
+                  attribution={PROTECTED_AREAS_ATTRIBUTION}
+                >
+                  <Layer id={`wdpa-layer-${panelId}`} type="raster" paint={{ "raster-opacity": 0.5 }} />
+                </Source>
+              )}
               {/* Occurrence circles (GeoJSON source + circle layer) */}
               <Source id={`occurrences-${panelId}`} type="geojson" data={styledGeoJson}>
                 <Layer {...circleLayerStyle} />
@@ -1483,6 +1509,29 @@ export default function OccurrenceMapRow({
           {label && (
             <div className="absolute top-2 left-2 z-[1000] bg-zinc-900/80 text-white text-[11px] font-medium px-2.5 py-1 rounded-full shadow-md">
               {label}
+            </div>
+          )}
+          {/* Protected areas (WDPA) overlay toggle */}
+          {!loadingOccurrences && mounted && (
+            <div className="absolute top-2 right-2 z-[1000]">
+              <button
+                onClick={() => setShowProtectedAreas((v) => !v)}
+                className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-lg shadow-md border text-[11px] font-medium transition-colors ${
+                  showProtectedAreas
+                    ? "bg-emerald-600 border-emerald-600 text-white"
+                    : "bg-white dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700"
+                }`}
+                title="Overlay World Database on Protected Areas (WDPA) — UNEP-WCMC & IUCN"
+              >
+                <span
+                  className={`w-3 h-3 rounded-sm border ${
+                    showProtectedAreas
+                      ? "bg-white/30 border-white/70"
+                      : "bg-emerald-500/40 border-emerald-600"
+                  }`}
+                />
+                Protected areas
+              </button>
             </div>
           )}
           {/* Basemap toggle */}


### PR DESCRIPTION
## What & why

Adds a **"Protected areas" toggle** to the species-detail GBIF observations map view. When on, it overlays the **World Database on Protected Areas (WDPA)** — UNEP-WCMC & IUCN, the dataset behind [protectedplanet.net](https://www.protectedplanet.net) — semi-transparently *beneath* the occurrence points, so you can see at a glance which occurrences fall inside a protected area.

This came out of an "explore feasibility & prototype" task. The map view (`OccurrenceMapRow.tsx`) is already a MapLibre GL map with toggleable raster basemaps and GeoJSON occurrence layers, so a protected-areas overlay slots in cleanly as another `Source`/`Layer` — **no server, API-route, or data-pipeline changes**.

## How it works

- Overlay is a **semi-transparent raster layer** (`raster-opacity: 0.5`) fetched per-tile from UNEP-WCMC's authoritative ArcGIS `MapServer/export` endpoint via MapLibre's `{bbox-epsg-3857}` token — **no API key required**, and the data is refreshed monthly at source.
- Drawn **before** the occurrence circles so the points stay on top of the shaded PA polygons.
- Works in **both single and split-view** maps (it lives in the shared `renderMapPanel`).
- Endpoint + attribution are single constants (`PROTECTED_AREAS_TILE_URL`, `PROTECTED_AREAS_ATTRIBUTION`) at the top of the file, so the source is trivial to swap (e.g. for a WMS or vector-tile service).

## Scope

This is a **visual** overlay — it answers "can I *see* whether occurrences are in a PA," not "flag each occurrence in/out." A per-occurrence in/out classification (e.g. "X% of new observations fall in protected areas") is a possible follow-up using the WDPA FeatureServer for point-in-polygon, and is intentionally out of scope here.

## Testing

- `tsc --noEmit` — clean
- `eslint` on the changed file — clean
- existing component tests pass

⚠️ **Needs a visual check on a real deploy/local run.** This couldn't be verified in the dev sandbox because outbound network is egress-restricted (even GBIF is blocked there), so the WDPA tile host is unreachable for automated testing. The overlay tiles load in the **end-user's browser** — exactly like the existing OSM/Esri basemaps — so this is a sandbox limitation, not a code one. Two things worth confirming live:
1. The UNEP-WCMC server returns permissive **CORS** headers (very likely — it's a public web-map service).
2. Polygons appear at the zoom levels where occurrences cluster (WDPA layers sometimes have scale thresholds; the map auto-fits to the occurrence bbox, so this is usually fine).

## Screenshots

_Not included — see the sandbox note above. The toggle appears top-right of the map, styled like the existing basemap control._

https://claude.ai/code/session_01TUDL5vNR1tPoW9NkDhGJ85

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUDL5vNR1tPoW9NkDhGJ85)_