### PR TITLE
Add "% of observations in protected areas" stat to the GBIF map

### DIFF
--- a/app/src/app/api/protected-areas/route.ts
+++ b/app/src/app/api/protected-areas/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { CACHE_1H } from "@/lib/cache-headers";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Protected-area polygons for a bounding box, from the authoritative WDPA
+ * (World Database on Protected Areas, UNEP-WCMC & IUCN) ArcGIS FeatureServer.
+ *
+ * This is a thin same-origin proxy that:
+ *  - keeps the (potentially flaky / CORS-restricted) upstream off the browser,
+ *  - generalizes polygon geometry server-side to keep payloads small, and
+ *  - lets Vercel's edge cache absorb repeat lookups for the same area.
+ *
+ * The client runs point-in-polygon locally (see lib/geo/pointInPolygon) to flag
+ * which occurrences fall inside a protected area and compute the "% in PA" stat.
+ */
+const WDPA_QUERY_URL =
+  "https://data-gis.unep-wcmc.org/server/rest/services/ProtectedSites/The_World_Database_of_Protected_Areas/FeatureServer/0/query";
+
+export async function GET(request: NextRequest) {
+  const bboxParam = request.nextUrl.searchParams.get("bbox");
+  if (!bboxParam) {
+    return NextResponse.json({ error: "bbox parameter is required (minLon,minLat,maxLon,maxLat)" }, { status: 400 });
+  }
+
+  const parts = bboxParam.split(",").map(Number);
+  if (parts.length !== 4 || parts.some((n) => !Number.isFinite(n))) {
+    return NextResponse.json({ error: "bbox must be 'minLon,minLat,maxLon,maxLat'" }, { status: 400 });
+  }
+  const [minLon, minLat, maxLon, maxLat] = parts;
+
+  // Generalize geometry to ~the resolution we'd render at (degrees). Larger
+  // bboxes get coarser polygons — enough for a point-in-polygon stat, far
+  // smaller payloads than full-resolution WDPA boundaries.
+  const span = Math.max(maxLon - minLon, maxLat - minLat);
+  const maxAllowableOffset = Math.max(span / 1024, 0.0001);
+
+  const params = new URLSearchParams({
+    geometry: `${minLon},${minLat},${maxLon},${maxLat}`,
+    geometryType: "esriGeometryEnvelope",
+    inSR: "4326",
+    outSR: "4326",
+    spatialRel: "esriSpatialRelIntersects",
+    where: "1=1",
+    outFields: "WDPAID,NAME,DESIG_ENG",
+    returnGeometry: "true",
+    maxAllowableOffset: maxAllowableOffset.toString(),
+    geometryPrecision: "5",
+    f: "geojson",
+  });
+
+  try {
+    const upstream = await fetch(`${WDPA_QUERY_URL}?${params}`, { cache: "no-store" });
+    if (!upstream.ok) {
+      throw new Error(`WDPA FeatureServer error: ${upstream.status} ${upstream.statusText}`);
+    }
+    const data = await upstream.json();
+
+    // ArcGIS flags incomplete results (too many PAs in the bbox) so the client
+    // can caveat the stat as a lower bound.
+    const truncated = Boolean(data.exceededTransferLimit ?? data.properties?.exceededTransferLimit);
+
+    return NextResponse.json(
+      {
+        type: "FeatureCollection",
+        features: Array.isArray(data.features) ? data.features : [],
+        metadata: { truncated },
+      },
+      { headers: CACHE_1H },
+    );
+  } catch (error) {
+    console.error("Error fetching protected areas:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      { status: 502 },
+    );
+  }
+}

--- a/app/src/components/OccurrenceMapRow.tsx
+++ b/app/src/components/OccurrenceMapRow.tsx
@@ -6,6 +6,7 @@ import dynamic from "next/dynamic";
 import type { MapRef, ViewStateChangeEvent, MapLayerMouseEvent } from "react-map-gl/maplibre";
 import type maplibregl from "maplibre-gl";
 import { mapTaxonId } from "@/lib/data/taxonomy-constants";
+import { pointInAnyFeature } from "@/lib/geo/pointInPolygon";
 
 // Fixed page size for iNat photo grid (5 columns x 2 rows)
 const INAT_PAGE_SIZE = 10;
@@ -869,6 +870,14 @@ export default function OccurrenceMapRow({
   // Bounding box from API: [minLon, minLat, maxLon, maxLat]
   const [bbox, setBbox] = useState<[number, number, number, number] | null>(null);
 
+  // Protected-area (WDPA) polygons for the species' occurrence bbox, fetched
+  // lazily the first time the overlay is toggled on. Used both for the visual
+  // overlay and to compute the "% of observations in a protected area" stat.
+  const [paFeatures, setPaFeatures] = useState<GeoJSON.Feature[]>([]);
+  const [paLoading, setPaLoading] = useState(false);
+  const [paTruncated, setPaTruncated] = useState(false);
+  const [paError, setPaError] = useState(false);
+
   // Fetch occurrences (re-fetches when sample size changes)
   useEffect(() => {
     setLoadingOccurrences(true); // eslint-disable-line react-hooks/set-state-in-effect -- loading state for fetch
@@ -914,6 +923,33 @@ export default function OccurrenceMapRow({
       .catch(console.error)
       .finally(() => setLoadingBreakdown(false));
   }, [speciesKey, countryCode]);
+
+  // Fetch protected-area (WDPA) polygons for the current occurrence bbox, but
+  // only once the overlay/stat is switched on. Keyed on the bbox so it follows
+  // the loaded sample (and re-fetches on species change / "load more").
+  useEffect(() => {
+    if (!showProtectedAreas || !bbox) return;
+    const controller = new AbortController();
+    setPaLoading(true); // eslint-disable-line react-hooks/set-state-in-effect -- loading state for fetch
+    setPaError(false);
+    fetch(`/api/protected-areas?bbox=${bbox.join(",")}`, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`Protected areas request failed: ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        setPaFeatures(Array.isArray(data.features) ? data.features : []);
+        setPaTruncated(Boolean(data.metadata?.truncated));
+      })
+      .catch((err) => {
+        if (err?.name === "AbortError") return;
+        console.error("Error fetching protected areas:", err);
+        setPaError(true);
+        setPaFeatures([]);
+      })
+      .finally(() => setPaLoading(false));
+    return () => controller.abort();
+  }, [showProtectedAreas, bbox]);
 
   // Fetch iNat photos for a given page
   const fetchInatPhotos = useCallback((page: number, limit: number) => {
@@ -1054,6 +1090,38 @@ export default function OccurrenceMapRow({
     }
     return filteredBeforeAnimation;
   }, [filteredBeforeAnimation, animatingDate]);
+
+  // Which loaded occurrences fall inside a protected area. Computed once over
+  // the full loaded sample (point-in-polygon is the expensive part), so the
+  // derived stat below stays instant as the basis/year/uncertainty filters
+  // change. Returns a Set of gbifIDs, or null when the overlay is off / no data.
+  const protectedGbifIds = useMemo(() => {
+    if (!showProtectedAreas || paFeatures.length === 0) return null;
+    const ids = new Set<number>();
+    for (const o of occurrences) {
+      if (pointInAnyFeature(o.geometry.coordinates, paFeatures)) {
+        ids.add(o.properties.gbifID);
+      }
+    }
+    return ids;
+  }, [showProtectedAreas, paFeatures, occurrences]);
+
+  // "% of observations in a protected area" over the currently-shown sample,
+  // with a new-since-assessment breakdown (the dashboard's reassessment lens).
+  const protectedAreaStats = useMemo(() => {
+    if (!protectedGbifIds) return null;
+    let total = 0, inPA = 0, newTotal = 0, newInPA = 0;
+    for (const o of filteredBeforeAnimation) {
+      total++;
+      const isIn = protectedGbifIds.has(o.properties.gbifID);
+      if (isIn) inPA++;
+      if (isAfterAssessment(o.properties.eventDate, o.properties.year, assessmentDate, assessmentYear)) {
+        newTotal++;
+        if (isIn) newInPA++;
+      }
+    }
+    return { total, inPA, newTotal, newInPA };
+  }, [protectedGbifIds, filteredBeforeAnimation, assessmentDate, assessmentYear]);
 
   // Bounding box from filtered occurrences
   const filteredBbox = useMemo<[number, number, number, number] | null>(() => {
@@ -1532,6 +1600,41 @@ export default function OccurrenceMapRow({
                 />
                 Protected areas
               </button>
+            </div>
+          )}
+          {/* Protected areas stat — "% of shown obs in a protected area".
+              Single-view only (the stat is over the whole sample, not per panel). */}
+          {!loadingOccurrences && mounted && showProtectedAreas && !label && (
+            <div className="absolute top-2 left-2 z-[1000] bg-white/95 dark:bg-zinc-800/95 px-2.5 py-1.5 rounded-lg shadow-md border border-emerald-200 dark:border-emerald-800 text-[11px] text-zinc-700 dark:text-zinc-200 max-w-[220px]">
+              {paLoading ? (
+                <span className="flex items-center gap-1.5 text-zinc-500 dark:text-zinc-400">
+                  <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  </svg>
+                  Checking protected areas…
+                </span>
+              ) : paError ? (
+                <span className="text-amber-600 dark:text-amber-400">Protected-area data unavailable</span>
+              ) : protectedAreaStats && protectedAreaStats.total > 0 ? (
+                <>
+                  <div className="font-medium text-emerald-700 dark:text-emerald-300">
+                    {Math.round((protectedAreaStats.inPA / protectedAreaStats.total) * 100)}% in protected areas
+                  </div>
+                  <div className="text-zinc-500 dark:text-zinc-400 tabular-nums">
+                    {protectedAreaStats.inPA.toLocaleString()} / {protectedAreaStats.total.toLocaleString()} shown obs.
+                  </div>
+                  {assessmentYear != null && protectedAreaStats.newTotal > 0 && (
+                    <div className="text-zinc-500 dark:text-zinc-400 tabular-nums">
+                      new: {Math.round((protectedAreaStats.newInPA / protectedAreaStats.newTotal) * 100)}%
+                      {" "}({protectedAreaStats.newInPA.toLocaleString()} / {protectedAreaStats.newTotal.toLocaleString()})
+                    </div>
+                  )}
+                  <div className="text-[9px] text-zinc-400 dark:text-zinc-500 mt-0.5 leading-tight">
+                    approx · loaded sample{paTruncated ? " · PA data truncated" : ""}
+                  </div>
+                </>
+              ) : null}
             </div>
           )}
           {/* Basemap toggle */}

--- a/app/src/lib/geo/__tests__/pointInPolygon.test.ts
+++ b/app/src/lib/geo/__tests__/pointInPolygon.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { pointInGeometry, pointInAnyFeature, type Position } from "../pointInPolygon";
+
+// A unit square from (0,0) to (10,10)
+const square = {
+  type: "Polygon" as const,
+  coordinates: [
+    [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]] as Position[],
+  ],
+};
+
+// Same square with a hole from (4,4) to (6,6)
+const squareWithHole = {
+  type: "Polygon" as const,
+  coordinates: [
+    [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]] as Position[],
+    [[4, 4], [6, 4], [6, 6], [4, 6], [4, 4]] as Position[],
+  ],
+};
+
+const multi = {
+  type: "MultiPolygon" as const,
+  coordinates: [
+    [[[0, 0], [2, 0], [2, 2], [0, 2], [0, 0]] as Position[]],
+    [[[20, 20], [22, 20], [22, 22], [20, 22], [20, 20]] as Position[]],
+  ],
+};
+
+describe("pointInGeometry", () => {
+  it("detects a point inside a simple polygon", () => {
+    expect(pointInGeometry([5, 5], square)).toBe(true);
+  });
+
+  it("detects a point outside a simple polygon", () => {
+    expect(pointInGeometry([15, 5], square)).toBe(false);
+    expect(pointInGeometry([-1, -1], square)).toBe(false);
+  });
+
+  it("treats points inside a hole as outside", () => {
+    expect(pointInGeometry([5, 5], squareWithHole)).toBe(false);
+    expect(pointInGeometry([1, 1], squareWithHole)).toBe(true); // in ring, not in hole
+  });
+
+  it("handles MultiPolygon — inside either part counts", () => {
+    expect(pointInGeometry([1, 1], multi)).toBe(true);
+    expect(pointInGeometry([21, 21], multi)).toBe(true);
+    expect(pointInGeometry([10, 10], multi)).toBe(false);
+  });
+});
+
+describe("pointInAnyFeature", () => {
+  it("returns true if the point is in any polygonal feature", () => {
+    const features = [{ geometry: square }, { geometry: multi }];
+    expect(pointInAnyFeature([21, 21], features)).toBe(true);
+    expect(pointInAnyFeature([100, 100], features)).toBe(false);
+  });
+
+  it("skips non-polygonal features without throwing", () => {
+    const features = [
+      { geometry: { type: "Point", coordinates: [5, 5] } },
+      { geometry: square },
+    ];
+    expect(pointInAnyFeature([5, 5], features)).toBe(true);
+    expect(pointInAnyFeature([50, 50], features)).toBe(false);
+  });
+});

--- a/app/src/lib/geo/pointInPolygon.ts
+++ b/app/src/lib/geo/pointInPolygon.ts
@@ -1,0 +1,79 @@
+/**
+ * Dependency-free point-in-polygon tests for GeoJSON geometries.
+ *
+ * Used to flag which GBIF occurrence points fall inside a protected-area
+ * polygon (WDPA). Kept self-contained (no turf dependency) since we only need
+ * a ray-casting test over Polygon / MultiPolygon geometries with holes.
+ *
+ * Coordinates are GeoJSON order: [longitude, latitude].
+ */
+
+export type Position = [number, number];
+type LinearRing = Position[];
+type PolygonCoords = LinearRing[]; // [outerRing, ...holes]
+type MultiPolygonCoords = PolygonCoords[];
+
+/**
+ * Standard ray-casting test for whether a point lies inside a single linear
+ * ring. Points exactly on an edge are treated inconsistently (as is typical for
+ * ray casting) — acceptable here, where occurrence coordinates landing exactly
+ * on a boundary are vanishingly rare and either answer is defensible.
+ */
+function pointInRing(point: Position, ring: LinearRing): boolean {
+  const [x, y] = point;
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [xi, yi] = ring[i];
+    const [xj, yj] = ring[j];
+    const intersects =
+      yi > y !== yj > y &&
+      x < ((xj - xi) * (y - yi)) / (yj - yi) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+/** Inside the outer ring and outside every hole. */
+function pointInPolygonCoords(point: Position, polygon: PolygonCoords): boolean {
+  if (polygon.length === 0 || !pointInRing(point, polygon[0])) return false;
+  for (let h = 1; h < polygon.length; h++) {
+    if (pointInRing(point, polygon[h])) return false; // inside a hole
+  }
+  return true;
+}
+
+/** Test a point against a GeoJSON Polygon or MultiPolygon geometry. */
+export function pointInGeometry(
+  point: Position,
+  geometry: { type: "Polygon"; coordinates: PolygonCoords } | { type: "MultiPolygon"; coordinates: MultiPolygonCoords },
+): boolean {
+  if (geometry.type === "Polygon") {
+    return pointInPolygonCoords(point, geometry.coordinates);
+  }
+  for (const polygon of geometry.coordinates) {
+    if (pointInPolygonCoords(point, polygon)) return true;
+  }
+  return false;
+}
+
+// Permissive geometry shape: accepts any GeoJSON geometry (incl. ones without
+// `coordinates`, like GeometryCollection), so callers can pass GeoJSON.Feature[]
+// straight through. Only Polygon / MultiPolygon are actually tested.
+type GeometryLike = { type: string; coordinates?: unknown } | null;
+
+/**
+ * Whether a point falls inside any polygonal feature of a collection.
+ * Non-polygonal features (e.g. PA point records with no boundary) are skipped.
+ */
+export function pointInAnyFeature(
+  point: Position,
+  features: ReadonlyArray<{ geometry: GeometryLike }>,
+): boolean {
+  for (const f of features) {
+    const g = f.geometry;
+    if (g && (g.type === "Polygon" || g.type === "MultiPolygon")) {
+      if (pointInGeometry(point, g as Parameters<typeof pointInGeometry>[1])) return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## What & why

Builds on the merged WDPA overlay (#283). When the **"Protected areas"** toggle is on, the GBIF map now also reports **what share of the shown occurrences fall inside a protected area**, with a **new-since-assessment breakdown** — directly relevant to the dashboard's reassessment-prioritization lens (are new observations accumulating inside vs. outside protected areas?).

GBIF doesn't tag occurrences with protected-area membership (no PA field or filter predicate exists — the UNEP-WCMC↔GBIF link is post-hoc spatial analysis), so we compute the intersection ourselves: occurrence points × WDPA polygons.

## How it works

- **New `/api/protected-areas` route** — a thin same-origin proxy over UNEP-WCMC's authoritative WDPA ArcGIS FeatureServer. It fetches PA polygons intersecting the occurrence bbox, **generalizes geometry server-side** (`maxAllowableOffset`/`geometryPrecision`) to keep payloads small, flags **truncated** results (`exceededTransferLimit`), and edge-caches (1h). Proxying also sidesteps any upstream CORS limits.
- **New point-in-polygon helper** (`lib/geo/pointInPolygon.ts`) — dependency-free ray casting over Polygon/MultiPolygon with holes, with unit tests. No new npm dependency added.
- **`OccurrenceMapRow`** fetches the polygons lazily (only once the toggle is on), computes membership **once over the loaded sample** (the expensive part), then derives the stat **instantly** as the basis/year/uncertainty filters change. Rendered as a small pill, with loading/error states.

## Scope & honest caveats

This is an **approximate, live indicator over the loaded sample** — not an exact figure over all records:

- **Sample, not census.** The map loads a sample (300–2000, GBIF's recent-first order), so the % is over what's loaded, biased toward recent records. The pill is explicitly labelled `approx · loaded sample`.
- **Truncation.** In PA-dense bboxes the FeatureServer caps returned polygons; the pill appends `PA data truncated` (so the % is a lower bound) when that happens.
- **Current boundaries.** Uses present-day WDPA, not boundaries as-of the assessment date.
- **No coordinate-uncertainty buffering** — a point is in/out by its coordinate alone.
- **Single-view only** — the stat is over the whole sample, so it's not duplicated per split-view panel.

The **exact** version ("X% of *all* this species' observations are in PAs") would be an offline spatial join (GBIF download × WDPA shapefiles) added to the sync pipeline — accurate but much heavier and as-of-sync-time. Deliberately out of scope here; easy to follow up if the approximate stat proves useful.

## Testing

- `tsc --noEmit` — clean
- `eslint` on all changed/new files — clean
- **367 tests pass**, including 6 new point-in-polygon tests

⚠️ **Needs a visual/functional check on a real deploy** — the dev sandbox is egress-restricted, so the live WDPA FeatureServer call (and the resulting stat) can't be exercised here. Worth confirming on a preview deploy: the FeatureServer returns GeoJSON for a sample bbox, and the % looks sane against the visual overlay. Same sandbox limitation noted in #283.

https://claude.ai/code/session_01TUDL5vNR1tPoW9NkDhGJ85

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUDL5vNR1tPoW9NkDhGJ85)_