### PR TITLE
Show a spinner instead of "0 species" while the list loads

### DIFF
--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2871,7 +2871,11 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
               </button>
             )}
             <span className="ml-auto text-sm md:text-base font-semibold text-zinc-700 dark:text-zinc-300 tabular-nums flex items-center gap-2">
-              {totalFiltered.toLocaleString()} species
+              {speciesLoading && totalFiltered === 0 && !singleSpeciesPreview ? (
+                <Spinner className="h-4 w-4" />
+              ) : (
+                <>{totalFiltered.toLocaleString()} species</>
+              )}
             </span>
             {!isNewAssessments && neCount > 0 && (
               <button


### PR DESCRIPTION
The species-count label in the list header renders `totalFiltered`, which is `0` during an active fetch — so the header flashed **"0 species"** before rows arrived.

Now it shows an inline spinner while loading with no results yet, and the count once rows are present. Matches the table body's existing loading gate (`!singleSpeciesPreview`), and a re-fetch over already-loaded rows keeps the count (the table's overlay spinner covers that).

One-line render change in `RedListView.tsx`; tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)