### PR TITLE
/browse: fail loudly on query error + agent guidance (cold-start follow-up)

### DIFF
--- a/app/src/app/browse/__tests__/browse.test.ts
+++ b/app/src/app/browse/__tests__/browse.test.ts
@@ -78,6 +78,14 @@ describe("/browse", () => {
     expect(d.unresolved).toContain("threats=asteroids");
   });
 
+  it("returns 400 for an attempted-but-unresolved query (filters with no taxon), not a 200 index", async () => {
+    const r = await GET(req("?threats=climate-change&format=json"));
+    expect(r.status).toBe(400);
+    const d = await r.json();
+    expect(d.error).toBeTruthy();
+    expect(querySpecies).not.toHaveBeenCalled();
+  });
+
   it("fails loudly: a data-layer error returns 503 + error, never a misleading 200", async () => {
     querySpecies.mockRejectedValue(new Error("R2 read timeout"));
     const r = await GET(req("?taxa=corals&format=json"));

--- a/app/src/app/browse/__tests__/browse.test.ts
+++ b/app/src/app/browse/__tests__/browse.test.ts
@@ -78,6 +78,15 @@ describe("/browse", () => {
     expect(d.unresolved).toContain("threats=asteroids");
   });
 
+  it("fails loudly: a data-layer error returns 503 + error, never a misleading 200", async () => {
+    querySpecies.mockRejectedValue(new Error("R2 read timeout"));
+    const r = await GET(req("?taxa=corals&format=json"));
+    expect(r.status).toBe(503);
+    const d = await r.json();
+    expect(d.error).toBeTruthy();
+    expect(d.retryable).toBe(true);
+  });
+
   it("sets X-Robots-Tag noindex (unlisted to crawlers)", async () => {
     const r = await GET(req("?taxa=corals&format=json"));
     expect(r.headers.get("X-Robots-Tag")).toContain("noindex");

--- a/app/src/app/browse/route.ts
+++ b/app/src/app/browse/route.ts
@@ -194,6 +194,7 @@ export async function GET(req: NextRequest) {
   let matched: Row[] = [];
   let tooLarge = false;
 
+  try {
   if (taxa.ids.length) {
     // Browse mode: query each taxon, narrow curated sub-nodes client-side (the read
     // layer filters only by taxon_group), then apply the shared base predicate.
@@ -235,6 +236,15 @@ export async function GET(req: NextRequest) {
     // here (the lean hit shape lacks them); steer filtered queries to ?taxa=.
     const hits = await searchSpecies(search, RESULT_CAP);
     matched = hits.map(searchHitToRow);
+  }
+  } catch {
+    // Fail loudly: a query error/timeout (e.g. cold DuckDB container still warming)
+    // returns 503 with a clear message — never a 200 with unrelated data.
+    const msg = "The data service failed or timed out (it may be warming up on a cold start). Please retry shortly — this is a real failure, not a result.";
+    return format === "json"
+      ? NextResponse.json({ error: msg, retryable: true }, { status: 503, headers: { ...NOINDEX } })
+      : new NextResponse(`<!doctype html><meta charset="utf-8"><title>Temporarily unavailable</title><h1>Temporarily unavailable</h1><p>${msg}</p>`,
+          { status: 503, headers: { "Content-Type": "text/html; charset=utf-8", ...NOINDEX } });
   }
 
   matched.sort((a, b) => {

--- a/app/src/app/browse/route.ts
+++ b/app/src/app/browse/route.ts
@@ -167,8 +167,19 @@ export async function GET(req: NextRequest) {
     ...trends.unresolved.map((v) => `trends=${v}`),
   ];
 
-  // No actionable selector → self-describing index.
+  // No actionable selector. Distinguish a bare request (legit "what can I do here?"
+  // → 200 self-describing index) from an attempted-but-unresolved query (params were
+  // sent but nothing resolved → loud 400, so a client can't mistake the help page for
+  // a result or auto-follow one of its example links as the answer).
   if (taxa.ids.length === 0 && !search) {
+    const attempted = [...sp.keys()].some((k) => k !== "format");
+    if (attempted) {
+      const msg = "No taxon or search term resolved from this query. Provide ?taxa=<group, sub-group, or scientific name> or ?search=<species name>. See /llms.txt for the vocabulary.";
+      return format === "json"
+        ? NextResponse.json({ error: msg, unresolved, vocabulary: "/llms.txt" }, { status: 400, headers: { ...NOINDEX } })
+        : new NextResponse(`<!doctype html><meta charset="utf-8"><title>No valid query</title><h1>No valid query</h1><p>${msg}</p>`,
+            { status: 400, headers: { "Content-Type": "text/html; charset=utf-8", ...NOINDEX } });
+    }
     return format === "json"
       ? NextResponse.json(indexData(unresolved), { headers: { ...CACHE_1H, ...NOINDEX } })
       : html(indexHtml(unresolved));

--- a/app/src/app/llms.txt/route.ts
+++ b/app/src/app/llms.txt/route.ts
@@ -40,6 +40,12 @@ including synonyms / old names (they resolve to the accepted species).
 
 ## Rules
 - Browsing needs one \`taxa\` value; looking up a species needs \`search\`.
+- **Prefer \`&format=json\`** — it's the machine-readable response; the HTML view is
+  for humans. The JSON always includes the query you sent (\`query\`) and an
+  \`interpreted\` list, so you can confirm the result matches your request.
+- The first request after a quiet period may take a few seconds (cold start). If a
+  request times out, retry once. A genuine failure returns a **non-200 status with an
+  \`error\` field — never another species' data**, so trust the status code.
 - Within one filter, comma-separated values are OR; across filters they are AND.
 - Threats match by prefix: threats=11 covers 11.1, 11.4, ... ("Climate change").
 - Results cap at 200 rows; the total + a by-category breakdown are always shown.


### PR DESCRIPTION
Follow-up to #291 after an agent reported `/browse` returning the *Felis jubata* example page for unrelated queries.

## Root cause: confirmed not the origin
Reproduced against prod with `curl` — cache-busted (genuinely executed), warm, on the agent's exact fresh URL, across four User-Agents (default, `ChatGPT-User`, `Claude-Web`, `Googlebot`): **all 200, zero redirects, correct JSON**. No `middleware`, no `next.config` redirects/rewrites, no project-level redirects. The agent confirmed from its side that it can't capture origin headers and that every failure rendered the `llms.txt` cheetah **example** it had fetched in its first turn — i.e. a **retrieval/proxy layer in the browsing pipeline surfacing the cached example instead of fetching the intended URL**, before the request ever reaches the origin. (The agent also confirmed it treated those as failures and never reported the cheetah as real.)

## Cross-client guards (so no client can mistake a non-result for data)
1. **Fail loudly on query error** — `/browse` wraps the DuckDB data access in try/catch → **503 `{error, retryable:true}`** (or 503 HTML), never a 200 with unrelated data. (It previously had no handler.)
2. **400 on attempted-but-unresolved** — a request with params that resolve to no taxon/search (filters with no `taxa`, or multi-word garbage) returns **400 + error + the unresolved list**, instead of a 200 self-describing index whose example links could be mistaken for / auto-followed into a result. A bare `/browse` (no selector params) is still a 200 help page.
3. **Self-verifying responses** — every JSON response echoes the `query` sent + an `interpreted` filter list, so a consumer can detect "asked for X, got Felis jubata" and treat it as a failure. Documented in `llms.txt`, which also tells agents to prefer `&format=json`, retry once on a cold-start timeout, and trust the status code.

## Not addressed (your call)
The cold start on the first hit (the original timeout trigger) is unchanged; eliminating it needs keeping `/browse` warm (Vercel cron / min-instances), previously deprioritized. The guards above make a cold start surface as a clean retryable 503 rather than a hang.

## Validation
395 tests (incl. throw→503 and unresolved→400); tsc + lint clean. Curl-verified on prod across four UAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)