### PR TITLE
Default GPS uncertainty filter to Any

### DIFF
--- a/app/src/components/OccurrenceMapRow.tsx
+++ b/app/src/components/OccurrenceMapRow.tsx
@@ -552,7 +552,7 @@ export default function OccurrenceMapRow({
   });
 
   // Advanced filter state
-  const [maxUncertainty, setMaxUncertainty] = useState<number | null>(50000);
+  const [maxUncertainty, setMaxUncertainty] = useState<number | null>(null);
   const [colorByDate, setColorByDate] = useState(false);
   const [basemap, setBasemap] = useState<BasemapKey>("streets");
   const [showProtectedAreas, setShowProtectedAreas] = useState(false);


### PR DESCRIPTION
## Summary
Changes the default value of the GPS uncertainty filter on the occurrence map from ≤ 50km to **Any**, so no uncertainty filtering is applied on initial load.

## Changes
- `OccurrenceMapRow.tsx`: initialize `maxUncertainty` state to `null` (Any) instead of `50000` (≤ 50km). The "Any" option already existed in the dropdown.

https://claude.ai/code/session_01DpsZXkNbw3pBToLAragC55

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpsZXkNbw3pBToLAragC55)_