### PR TITLE
Speed up search; stop syncing the unused JSON search index

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -50,6 +50,11 @@ const nextConfig: NextConfig = {
   // over Vercel's 250MB uncompressed limit. Prune per route to what each
   // actually reads at runtime. Globs use **/ so they match whether the tracing
   // root is app/ (local) or the repo root (Vercel, where paths are app/data/…).
+  // NOTE: search-index.json is now legacy (no code reads it; live search queries
+  // Parquet over R2) and is excluded from new syncs (upload-data-to-r2.ts). The
+  // search-index.json entries below are retained only because the active sync still
+  // ships the file into data/ at build time; drop them once a sync without it reaches
+  // production.
   outputFileTracingExcludes: {
     // Search now queries the parquets in R2 (httpfs) — no local data bundled.
     "/api/search": ["**/data/**"],

--- a/app/scripts/upload-data-to-r2.ts
+++ b/app/scripts/upload-data-to-r2.ts
@@ -13,7 +13,7 @@
  *       2026-05-20T10-30-00Z/
  *         gbif/amphibia.csv
  *         redlist/...
- *         search-index.json
+ *         backbone.parquet
  *         ...
  *
  * Active sync pointer lives in app/latest-sync.txt (version-controlled).
@@ -34,6 +34,12 @@ import { loadEnvFiles, SyncLogger, DATA_DIR, mapConcurrent } from "./utils";
 
 const UPLOAD_CONCURRENCY = 16;
 const LATEST_SYNC_FILE = path.join(__dirname, "..", "latest-sync.txt");
+
+// Legacy artifacts to leave out of new syncs. search-index.json (~95MB) backed the old
+// in-memory search; live search now queries Parquet over R2 (searchSpecies in
+// species-duckdb.ts) and nothing reads the JSON. Excluding it here stops it propagating
+// (fetch → data/ → re-upload) into future syncs. Relative-to-DATA_DIR, forward-slashed.
+const EXCLUDE_FROM_SYNC = new Set(["search-index.json"]);
 
 function getR2Client(): S3Client {
   const accountId = process.env.R2_ACCOUNT_ID;
@@ -96,7 +102,9 @@ async function main(): Promise<void> {
   const timestamp = makeTimestamp();
   const syncPrefix = `syncs/${timestamp}/`;
 
-  const localPaths = walkFiles(DATA_DIR);
+  const localPaths = walkFiles(DATA_DIR).filter(
+    (p) => !EXCLUDE_FROM_SYNC.has(path.relative(DATA_DIR, p).split(path.sep).join("/"))
+  );
   if (localPaths.length === 0) {
     throw new Error(`No files found under ${DATA_DIR}`);
   }

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -398,14 +398,20 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
       countries: splitList(r.countries),
     };
   });
-  if (fast.length >= lim) return fast;
+  // Return as soon as the direct search (assessed ∪ unassessed, ~16MB) finds anything.
+  // The CoL-only and synonym tiers below each full-scan a large parquet over R2 (species/
+  // ~36MB, synonym-index ~77MB) with no pruning — ~10s on a cold function. They exist to
+  // *answer* queries the direct search can't (an old/synonym name, or a CoL-only species),
+  // not to pad results, so only run them when the direct search came up empty. A precise
+  // hit like "Panthera leo" returns here after one cheap scan instead of falling through
+  // both heavy tiers.
+  if (fast.length > 0) return fast;
 
   // CoL-only fallback: universe species (species/) that are neither IUCN-assessed nor
-  // GBIF-observed, to fill the remaining slots. species/ has no common name and can't
-  // partition-prune on name, so this full-scans the name column — only run it when the
-  // fast path returned fewer than `limit` hits (it then holds ALL assessed+GBIF matches,
-  // so any species/ match not already listed is genuinely CoL-only — name-dedup suffices,
-  // no species_link anti-join needed). These render as NE and navigate to their leaf taxon.
+  // GBIF-observed. species/ has no common name and can't partition-prune on name, so this
+  // full-scans the name column — gated above on the direct search returning nothing, so it
+  // holds ALL assessed+GBIF matches (none), and any species/ match is genuinely CoL-only
+  // (name-dedup suffices, no species_link anti-join needed). Render as NE → leaf taxon.
   const seen = new Set(fast.map((r) => r.scientific_name.toLowerCase()));
   const colSql = `
     SELECT col_id, scientific_name, taxon_group
@@ -437,10 +443,10 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
   if (fast.length >= lim) return fast;
 
   // Synonym tier: resolve an old/synonym name to its accepted species via synonym-index.parquet
-  // (name-sorted → prefix-range prunes to ~1 row group; substring backstop when sparse). Runs
-  // only when the accepted-name search above is still short. The accepted species routes like a
-  // direct hit — assessed → reassessments (sis id), NE → new-assessments/leaf node — and carries
-  // the matched synonym for the UI. Graceful no-op if the index isn't in this sync prefix.
+  // (name-sorted → prefix-range prunes to ~1 row group). Reached only when the direct search
+  // found nothing (gated above). The accepted species routes like a direct hit — assessed →
+  // reassessments (sis id), NE → new-assessments/leaf node — and carries the matched synonym
+  // for the UI. Graceful no-op if the index isn't in this sync prefix.
   const synUri = parquetUri("synonym-index.parquet");
   const synLo = `'${query.toLowerCase().replace(/'/g, "''")}'`;
   const need = lim - fast.length;
@@ -450,11 +456,14 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
       `SELECT ${synCols} FROM read_parquet('${synUri}')
        WHERE synonym_name_lower >= ${synLo} AND synonym_name_lower < ${synLo} || chr(1114111)
        ORDER BY synonym_name_lower LIMIT ${need * 3 + 5}`, {})).getRowObjects();
-    if (synRows.length < need) {
-      synRows = synRows.concat((await conn.runAndReadAll(
+    // Substring backstop (the query appears mid-name, not as a prefix) full-scans the whole
+    // 77MB index over R2 with no pruning, so only fall back to it when the prefix-range found
+    // nothing at all — not merely when it returned fewer than `need`.
+    if (synRows.length === 0) {
+      synRows = (await conn.runAndReadAll(
         `SELECT ${synCols} FROM read_parquet('${synUri}')
          WHERE synonym_name_lower LIKE '%' || ${synLo} || '%' AND synonym_name_lower NOT LIKE ${synLo} || '%'
-         ORDER BY synonym_name_lower LIMIT ${need * 3 + 5}`, {})).getRowObjects());
+         ORDER BY synonym_name_lower LIMIT ${need * 3 + 5}`, {})).getRowObjects();
     }
     for (const r of synRows) {
       const accName = String(r.accepted_name ?? "");


### PR DESCRIPTION
## Problem

Search cold-start was **10–15s even for assessed species** (e.g. `panthera leo`).

The early-return after the direct search (`assessed ∪ unassessed`, ~16MB) was gated on `fast.length >= limit`. A precise query returns far fewer than `limit` hits, so it never returned there and fell through **both** heavy fallback tiers:
- a full-scan of the `species/` universe (~36MB, `ILIKE '%…%'`, no pruning), and
- the synonym-index contains-backstop (~77MB full-scan).

So a single-hit query did ~110MB of un-prunable cold R2 reads on top of function/DuckDB spin-up.

## Changes

1. **Return as soon as the direct search finds anything.** The CoL-only and synonym tiers now run only when the direct search comes up *empty* — exactly when they're needed (an old/synonym name, or a CoL-only species), not to pad results.
2. **Tighten the synonym contains-backstop** so the 77MB full-scan fires only when the name-sorted prefix-range query returns nothing, not merely when it's short.
3. **Drop the legacy `search-index.json` (~95MB) from new syncs.** Nothing reads it (live search queries Parquet over R2), but it self-perpetuated via fetch → `data/` → re-upload. `upload-data-to-r2.ts` now excludes it. The `next.config` `search-index.json` trace-excludes are retained until a sync without it reaches production (the active sync still ships it into `data/` at build).

## Validation (preview deploy)

- `panthera leo`: **4.4s cold → 0.27s warm** (was 10–15s); returns `Panthera leo` (VU).
- `Felis leo` (old synonym, zero direct hits) still resolves → `Panthera leo`, `matched_synonym: Felis leo` — the deep tiers run when there's no direct hit.
- `tsc`, `eslint`, `npm test` (400 tests) green.

## Trade-off

Broad partial queries that already have a few direct hits are no longer padded with CoL-only species or synonym matches up to the limit. For a typeahead box this is generally an improvement (less clutter); it is a behavior change.

## Follow-up

Once a data sync without `search-index.json` reaches production, the `search-index.json` entries in `next.config` `outputFileTracingExcludes` can be removed (they're no-ops at that point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)