### PR TITLE
feat: CITES improvements — full history, dimmed trim handles, unit-aware commodities, re-export arcs

### DIFF
--- a/app/src/app/api/cites/trade/__tests__/route.test.ts
+++ b/app/src/app/api/cites/trade/__tests__/route.test.ts
@@ -186,19 +186,23 @@ describe("/api/cites/trade", () => {
     // topFlows
     expect(body.topFlows.length).toBeGreaterThan(0);
 
-    // shipments (compact records)
+    // shipments (compact records) — now include unit (u) and origin (o)
     expect(body.shipments).toHaveLength(3);
     expect(body.shipments[0]).toEqual(
-      expect.objectContaining({ y: 2022, s: "W", p: "S", t: "specimens" })
+      expect.objectContaining({ y: 2022, s: "W", p: "S", t: "specimens", u: "", o: "" })
     );
 
-    // allSources / allPurposes / allTerms present
+    // allSources / allPurposes / allTerms / allTermsByUnit present
     expect(body.allSources.length).toBeGreaterThan(0);
     expect(body.allPurposes.length).toBeGreaterThan(0);
     expect(body.allTerms.length).toBeGreaterThan(0);
+    expect(body.allTermsByUnit.length).toBeGreaterThan(0);
+    expect(body.allTermsByUnit[0]).toEqual(
+      expect.objectContaining({ term: expect.any(String), unit: expect.any(String) })
+    );
   });
 
-  it("uses max of importer/exporter reported quantity", async () => {
+  it("prefers exporter-reported quantity (per CITES guide)", async () => {
     const rows = [
       makeTradeRow({
         "Importer reported quantity": "20",
@@ -216,7 +220,50 @@ describe("/api/cites/trade", () => {
     const res = await GET(makeRequest({ taxon_id: "11136" }));
     const body = await res.json();
 
-    expect(body.byYear[0].quantity).toBe(20); // max(20, 15)
+    expect(body.byYear[0].quantity).toBe(15); // exporter preferred over importer
+  });
+
+  it("falls back to importer quantity when exporter is absent", async () => {
+    const rows = [
+      makeTradeRow({
+        "Importer reported quantity": "12",
+        "Exporter reported quantity": null,
+      }),
+    ];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({ shipment_comptab_export: { rows } })
+      )
+    );
+    const { GET } = await importRoute();
+    const res = await GET(makeRequest({ taxon_id: "11136" }));
+    const body = await res.json();
+
+    expect(body.byYear[0].quantity).toBe(12);
+  });
+
+  it("separates term quantities by unit", async () => {
+    const rows = [
+      makeTradeRow({ Term: "tusks", Unit: "kg", "Exporter reported quantity": "100" }),
+      makeTradeRow({ Term: "tusks", Unit: null, "Exporter reported quantity": "3" }),
+    ];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({ shipment_comptab_export: { rows } })
+      )
+    );
+    const { GET } = await importRoute();
+    const res = await GET(makeRequest({ taxon_id: "11136" }));
+    const body = await res.json();
+
+    const kg = body.allTermsByUnit.find((t: { term: string; unit: string }) => t.term === "tusks" && t.unit === "kg");
+    const items = body.allTermsByUnit.find((t: { term: string; unit: string }) => t.term === "tusks" && t.unit === "");
+    expect(kg.quantity).toBe(100);
+    expect(items.quantity).toBe(3);
   });
 
   it("handles null quantities gracefully", async () => {

--- a/app/src/app/api/cites/trade/route.ts
+++ b/app/src/app/api/cites/trade/route.ts
@@ -61,9 +61,11 @@ interface CompactRecord {
   s: string;   // source code
   p: string;   // purpose code
   t: string;   // term
-  q: number;   // quantity (max of importer/exporter reported)
+  u: string;   // unit ("" when reported as a count of items)
+  q: number;   // quantity (exporter-reported, falling back to importer)
   e: string;   // exporter country code
   i: string;   // importer country code
+  o: string;   // origin country code ("" when same as exporter / not a re-export)
 }
 
 interface TradeSummary {
@@ -91,12 +93,30 @@ interface TradeSummary {
   allPurposes: { code: string; label: string; records: number }[];
   /** All unique terms with record counts */
   allTerms: { term: string; records: number }[];
+  /**
+   * All unique term+unit combinations. Per the CITES Trade Database Guide,
+   * quantities of different units (kg, m, items, …) must never be aggregated,
+   * so each term+unit pair is reported as its own row.
+   */
+  allTermsByUnit: { term: string; unit: string; records: number; quantity: number }[];
 }
 
 function parseQty(val: string | null): number {
   if (!val) return 0;
   const n = parseFloat(val);
   return isNaN(n) ? 0 : n;
+}
+
+/**
+ * Quantity for a shipment. The CITES Trade Database Guide treats the
+ * exporter-reported quantity as the authoritative figure, so we prefer it and
+ * fall back to the importer-reported quantity only when the exporter did not
+ * report one.
+ */
+function pickQty(r: TradeRow): number {
+  const exp = parseQty(r["Exporter reported quantity"]);
+  if (exp > 0) return exp;
+  return parseQty(r["Importer reported quantity"]);
 }
 
 function summarize(rows: TradeRow[]): TradeSummary {
@@ -108,32 +128,42 @@ function summarize(rows: TradeRow[]): TradeSummary {
   for (const r of rows) {
     const entry = yearMap.get(r.Year) || { quantity: 0, records: 0 };
     entry.records++;
-    entry.quantity += Math.max(
-      parseQty(r["Importer reported quantity"]),
-      parseQty(r["Exporter reported quantity"])
-    );
+    entry.quantity += pickQty(r);
     yearMap.set(r.Year, entry);
   }
   const byYear = Array.from(yearMap.entries())
     .sort(([a], [b]) => a - b)
     .map(([year, v]) => ({ year, ...v }));
 
-  // By term
+  // By term (record counts only — quantities live in the term+unit breakdown
+  // below, since quantities of different units cannot be aggregated)
   const termMap = new Map<string, { quantity: number; records: number }>();
   for (const r of rows) {
     const term = r.Term || "unspecified";
     const entry = termMap.get(term) || { quantity: 0, records: 0 };
     entry.records++;
-    entry.quantity += Math.max(
-      parseQty(r["Importer reported quantity"]),
-      parseQty(r["Exporter reported quantity"])
-    );
+    entry.quantity += pickQty(r);
     termMap.set(term, entry);
   }
   const topTerms = Array.from(termMap.entries())
     .sort(([, a], [, b]) => b.records - a.records)
     .slice(0, 8)
     .map(([term, v]) => ({ term, ...v }));
+
+  // By term + unit — the CITES-compliant breakdown (never aggregate across units)
+  const termUnitMap = new Map<string, { term: string; unit: string; quantity: number; records: number }>();
+  for (const r of rows) {
+    const term = r.Term || "unspecified";
+    const unit = r.Unit || "";
+    const key = `${term}|${unit}`;
+    const entry = termUnitMap.get(key) || { term, unit, quantity: 0, records: 0 };
+    entry.records++;
+    entry.quantity += pickQty(r);
+    termUnitMap.set(key, entry);
+  }
+  const allTermsByUnit = Array.from(termUnitMap.values()).sort(
+    (a, b) => b.records - a.records
+  );
 
   // By purpose
   const purposeMap = new Map<string, number>();
@@ -169,10 +199,7 @@ function summarize(rows: TradeRow[]): TradeSummary {
     if (!r.Exporter) continue;
     const entry = exporterMap.get(r.Exporter) || { records: 0, quantity: 0 };
     entry.records++;
-    entry.quantity += Math.max(
-      parseQty(r["Importer reported quantity"]),
-      parseQty(r["Exporter reported quantity"])
-    );
+    entry.quantity += pickQty(r);
     exporterMap.set(r.Exporter, entry);
   }
   const topExporters = Array.from(exporterMap.entries())
@@ -186,10 +213,7 @@ function summarize(rows: TradeRow[]): TradeSummary {
     if (!r.Importer) continue;
     const entry = importerMap.get(r.Importer) || { records: 0, quantity: 0 };
     entry.records++;
-    entry.quantity += Math.max(
-      parseQty(r["Importer reported quantity"]),
-      parseQty(r["Exporter reported quantity"])
-    );
+    entry.quantity += pickQty(r);
     importerMap.set(r.Importer, entry);
   }
   const topImporters = Array.from(importerMap.entries())
@@ -204,10 +228,7 @@ function summarize(rows: TradeRow[]): TradeSummary {
     const key = `${r.Exporter}->${r.Importer}`;
     const entry = flowMap.get(key) || { records: 0, quantity: 0 };
     entry.records++;
-    entry.quantity += Math.max(
-      parseQty(r["Importer reported quantity"]),
-      parseQty(r["Exporter reported quantity"])
-    );
+    entry.quantity += pickQty(r);
     flowMap.set(key, entry);
   }
   const topFlows = Array.from(flowMap.entries())
@@ -224,12 +245,11 @@ function summarize(rows: TradeRow[]): TradeSummary {
     s: r.Source || "",
     p: r.Purpose || "",
     t: r.Term || "unspecified",
-    q: Math.max(
-      parseQty(r["Importer reported quantity"]),
-      parseQty(r["Exporter reported quantity"])
-    ),
+    u: r.Unit || "",
+    q: pickQty(r),
     e: r.Exporter || "",
     i: r.Importer || "",
+    o: r.Origin && r.Origin !== r.Exporter ? r.Origin : "",
   }));
 
   // All unique sources (not just top 6)
@@ -269,6 +289,7 @@ function summarize(rows: TradeRow[]): TradeSummary {
     allSources,
     allPurposes,
     allTerms,
+    allTermsByUnit,
   };
 }
 
@@ -295,9 +316,11 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    // Fetch last 10 years of comparative tabulation data
+    // Fetch the full history of comparative tabulation data. CITES entered into
+    // force in 1975, so there are no records before then; using a fixed start
+    // year avoids cutting off early records (e.g. Panthera leo back to 1977).
     const currentYear = new Date().getFullYear();
-    const startYear = currentYear - 10;
+    const startYear = 1975;
 
     const params = new URLSearchParams({
       "filters[taxon_concepts_ids][]": taxonId,

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import dynamic from "next/dynamic";
+import { useTheme } from "next-themes";
 import {
   LineChart,
   Line,
@@ -10,11 +11,17 @@ import {
   Tooltip,
   ResponsiveContainer,
   CartesianGrid,
+  ReferenceArea,
 } from "recharts";
 import { countryName, fmtQty } from "./cites-utils";
 import type { CountryAnnotation } from "./TradeFlowMap";
 
 const TradeFlowMap = dynamic(() => import("./TradeFlowMap"), { ssr: false });
+
+/** Stable key for a term+unit combination (units must never be aggregated) */
+function termKey(term: string, unit: string): string {
+  return `${term}|${unit}`;
+}
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -25,9 +32,11 @@ interface CompactRecord {
   s: string;
   p: string;
   t: string;
+  u: string;
   q: number;
   e: string;
   i: string;
+  o: string;
 }
 
 interface YearData {
@@ -51,6 +60,13 @@ interface CodedData {
 interface TermCount {
   term: string;
   records: number;
+}
+
+interface TermUnitData {
+  term: string;
+  unit: string;
+  records: number;
+  quantity: number;
 }
 
 interface CountryData {
@@ -82,6 +98,7 @@ interface TradeData {
   allSources?: CodedData[];
   allPurposes?: CodedData[];
   allTerms?: TermCount[];
+  allTermsByUnit?: TermUnitData[];
 }
 
 // Sources that indicate wild take — key concern for assessors
@@ -165,63 +182,240 @@ function FilterCheckbox({
 }
 
 /* ------------------------------------------------------------------ */
-/*  Trend line chart                                                   */
+/*  Filter section header with All / None bulk-select                  */
 /* ------------------------------------------------------------------ */
+
+function SectionHeader({
+  title,
+  onAll,
+  onNone,
+}: {
+  title: string;
+  onAll: () => void;
+  onNone: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between mb-1.5">
+      <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+        {title}
+      </h5>
+      <div className="flex items-center gap-1 text-[10px]">
+        <button
+          className="text-blue-600 dark:text-blue-400 hover:underline"
+          onClick={onAll}
+        >
+          All
+        </button>
+        <span className="text-zinc-300 dark:text-zinc-600">/</span>
+        <button
+          className="text-blue-600 dark:text-blue-400 hover:underline"
+          onClick={onNone}
+        >
+          None
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Trend line chart with draggable year-range trim handles            */
+/* ------------------------------------------------------------------ */
+
+const CHART_HEIGHT = 170;
+const PLOT_LEFT = 45; // YAxis width (margin.left = 0)
+const PLOT_RIGHT_PAD = 10; // margin.right
 
 function TrendLineChart({
   data,
   metric,
+  minYear,
+  maxYear,
+  selStart,
+  selEnd,
+  onRangeChange,
 }: {
   data: YearData[];
   metric: "records" | "quantity";
+  minYear: number;
+  maxYear: number;
+  selStart: number;
+  selEnd: number;
+  onRangeChange: (start: number, end: number) => void;
 }) {
+  const { resolvedTheme } = useTheme();
+  const dark = resolvedTheme === "dark";
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+  const [dragging, setDragging] = useState<null | "start" | "end">(null);
+
+  // Track container width so we can position the handles over the plot area
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const update = () => setWidth(el.clientWidth);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const span = Math.max(1, maxYear - minYear);
+  const plotWidth = Math.max(0, width - PLOT_LEFT - PLOT_RIGHT_PAD);
+  const canBrush = data.length > 1 && plotWidth > 0;
+
+  const yearToX = useCallback(
+    (year: number) => PLOT_LEFT + (plotWidth * (year - minYear)) / span,
+    [plotWidth, minYear, span]
+  );
+
+  // Drag handling — translate pointer position to the nearest year
+  useEffect(() => {
+    if (!dragging) return;
+    function move(e: PointerEvent) {
+      const el = wrapRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const frac = (e.clientX - rect.left - PLOT_LEFT) / plotWidth;
+      let year = Math.round(minYear + frac * span);
+      year = Math.max(minYear, Math.min(maxYear, year));
+      if (dragging === "start") {
+        onRangeChange(Math.min(year, selEnd), selEnd);
+      } else {
+        onRangeChange(selStart, Math.max(year, selStart));
+      }
+    }
+    function up() {
+      setDragging(null);
+    }
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+    return () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+  }, [dragging, plotWidth, minYear, maxYear, span, selStart, selEnd, onRangeChange]);
+
   if (data.length === 0) return null;
 
+  const dimFill = dark ? "#09090b" : "#71717a";
+  const handleColor = dark ? "#fbbf24" : "#d97706";
+
   return (
-    <ResponsiveContainer width="100%" height={160}>
-      <LineChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
-        <CartesianGrid
-          strokeDasharray="3 3"
-          stroke="currentColor"
-          className="text-zinc-200 dark:text-zinc-700"
-        />
-        <XAxis
-          dataKey="year"
-          tick={{ fontSize: 11, fill: "#a1a1aa" }}
-          tickLine={false}
-          axisLine={false}
-        />
-        <YAxis
-          tick={{ fontSize: 11, fill: "#a1a1aa" }}
-          tickLine={false}
-          axisLine={false}
-          width={45}
-          tickFormatter={(v: number) => fmtQty(v)}
-        />
-        <Tooltip
-          contentStyle={{
-            backgroundColor: "#18181b",
-            border: "1px solid #3f3f46",
-            borderRadius: "8px",
-            fontSize: 12,
-          }}
-          itemStyle={{ color: "#fff" }}
-          labelStyle={{ color: "#a1a1aa" }}
-          formatter={(value: number) => [
-            value.toLocaleString(),
-            metric === "records" ? "Shipments" : "Items",
-          ]}
-        />
-        <Line
-          type="monotone"
-          dataKey={metric}
-          stroke="#3b82f6"
-          strokeWidth={2}
-          dot={{ r: 3, fill: "#3b82f6", strokeWidth: 0 }}
-          activeDot={{ r: 5, fill: "#3b82f6", strokeWidth: 2, stroke: "#fff" }}
-        />
-      </LineChart>
-    </ResponsiveContainer>
+    <div ref={wrapRef} className="relative select-none" style={{ height: CHART_HEIGHT }}>
+      <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+        <LineChart data={data} margin={{ top: 5, right: PLOT_RIGHT_PAD, left: 0, bottom: 5 }}>
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="currentColor"
+            className="text-zinc-200 dark:text-zinc-700"
+          />
+          <XAxis
+            dataKey="year"
+            type="number"
+            domain={[minYear, maxYear]}
+            tick={{ fontSize: 11, fill: "#a1a1aa" }}
+            tickLine={false}
+            axisLine={false}
+            allowDecimals={false}
+          />
+          <YAxis
+            tick={{ fontSize: 11, fill: "#a1a1aa" }}
+            tickLine={false}
+            axisLine={false}
+            width={PLOT_LEFT}
+            tickFormatter={(v: number) => fmtQty(v)}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: "#18181b",
+              border: "1px solid #3f3f46",
+              borderRadius: "8px",
+              fontSize: 12,
+            }}
+            itemStyle={{ color: "#fff" }}
+            labelStyle={{ color: "#a1a1aa" }}
+            formatter={(value: number) => [
+              value.toLocaleString(),
+              metric === "records" ? "Shipments" : "Items",
+            ]}
+          />
+          <Line
+            type="monotone"
+            dataKey={metric}
+            stroke="#3b82f6"
+            strokeWidth={2}
+            dot={{ r: 3, fill: "#3b82f6", strokeWidth: 0 }}
+            activeDot={{ r: 5, fill: "#3b82f6", strokeWidth: 2, stroke: "#fff" }}
+            isAnimationActive={false}
+          />
+          {/* Dim the regions outside the selected year range */}
+          {selStart > minYear && (
+            <ReferenceArea
+              x1={minYear}
+              x2={selStart}
+              fill={dimFill}
+              fillOpacity={0.35}
+              ifOverflow="visible"
+            />
+          )}
+          {selEnd < maxYear && (
+            <ReferenceArea
+              x1={selEnd}
+              x2={maxYear}
+              fill={dimFill}
+              fillOpacity={0.35}
+              ifOverflow="visible"
+            />
+          )}
+        </LineChart>
+      </ResponsiveContainer>
+
+      {/* Draggable trim handles overlaid on the plot area */}
+      {canBrush &&
+        (
+          [
+            { side: "start" as const, year: selStart },
+            { side: "end" as const, year: selEnd },
+          ]
+        ).map(({ side, year }) => {
+          const x = yearToX(year);
+          return (
+            <div
+              key={side}
+              role="slider"
+              aria-label={side === "start" ? "Range start year" : "Range end year"}
+              aria-valuenow={year}
+              aria-valuemin={minYear}
+              aria-valuemax={maxYear}
+              tabIndex={0}
+              onPointerDown={(e) => {
+                e.preventDefault();
+                setDragging(side);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+                  e.preventDefault();
+                  const delta = e.key === "ArrowLeft" ? -1 : 1;
+                  const next = Math.max(minYear, Math.min(maxYear, year + delta));
+                  if (side === "start") onRangeChange(Math.min(next, selEnd), selEnd);
+                  else onRangeChange(selStart, Math.max(next, selStart));
+                }
+              }}
+              className="absolute top-0 flex flex-col items-center cursor-ew-resize touch-none group"
+              style={{ left: x - 7, width: 14, height: CHART_HEIGHT - 22 }}
+            >
+              {/* grip */}
+              <div
+                className="rounded-sm shadow-sm"
+                style={{ width: 8, height: 16, backgroundColor: handleColor }}
+              />
+              {/* line */}
+              <div className="flex-1" style={{ width: 2, backgroundColor: handleColor }} />
+            </div>
+          );
+        })}
+    </div>
   );
 }
 
@@ -366,6 +560,125 @@ function CountryTable({
 }
 
 /* ------------------------------------------------------------------ */
+/*  Aggregation (shared by the chart and the year-trimmed panels)      */
+/* ------------------------------------------------------------------ */
+
+function aggregate(rows: CompactRecord[], yearRange: [number, number]) {
+  // By year — fill every year in range so the chart line is continuous
+  const yearMap = new Map<number, { quantity: number; records: number }>();
+  for (const r of rows) {
+    const entry = yearMap.get(r.y) || { quantity: 0, records: 0 };
+    entry.records++;
+    entry.quantity += r.q;
+    yearMap.set(r.y, entry);
+  }
+  for (let y = yearRange[0]; y <= yearRange[1]; y++) {
+    if (!yearMap.has(y)) yearMap.set(y, { quantity: 0, records: 0 });
+  }
+  const byYear = Array.from(yearMap.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([year, v]) => ({ year, ...v }));
+
+  // By term + unit — never aggregate quantities across units
+  const termUnitMap = new Map<string, TermUnitData>();
+  for (const r of rows) {
+    const key = termKey(r.t, r.u);
+    const entry = termUnitMap.get(key) || { term: r.t, unit: r.u, records: 0, quantity: 0 };
+    entry.records++;
+    entry.quantity += r.q;
+    termUnitMap.set(key, entry);
+  }
+  const topTermUnits = Array.from(termUnitMap.values()).sort((a, b) => b.records - a.records);
+
+  // Sources
+  const sourceMap = new Map<string, number>();
+  for (const r of rows) if (r.s) sourceMap.set(r.s, (sourceMap.get(r.s) || 0) + 1);
+  const topSources = Array.from(sourceMap.entries())
+    .sort(([, a], [, b]) => b - a)
+    .map(([code, records]) => ({ code, label: SOURCE_LABELS[code] || code, records }));
+
+  // Purposes
+  const purposeMap = new Map<string, number>();
+  for (const r of rows) if (r.p) purposeMap.set(r.p, (purposeMap.get(r.p) || 0) + 1);
+  const topPurposes = Array.from(purposeMap.entries())
+    .sort(([, a], [, b]) => b - a)
+    .map(([code, records]) => ({ code, label: PURPOSE_LABELS[code] || code, records }));
+
+  // Exporters / importers
+  const exporterMap = new Map<string, { records: number; quantity: number }>();
+  const importerMap = new Map<string, { records: number; quantity: number }>();
+  for (const r of rows) {
+    if (r.e) {
+      const e = exporterMap.get(r.e) || { records: 0, quantity: 0 };
+      e.records++;
+      e.quantity += r.q;
+      exporterMap.set(r.e, e);
+    }
+    if (r.i) {
+      const e = importerMap.get(r.i) || { records: 0, quantity: 0 };
+      e.records++;
+      e.quantity += r.q;
+      importerMap.set(r.i, e);
+    }
+  }
+  const topExporters = Array.from(exporterMap.entries())
+    .sort(([, a], [, b]) => b.records - a.records)
+    .slice(0, 8)
+    .map(([code, v]) => ({ code, ...v }));
+  const topImporters = Array.from(importerMap.entries())
+    .sort(([, a], [, b]) => b.records - a.records)
+    .slice(0, 8)
+    .map(([code, v]) => ({ code, ...v }));
+
+  // Bilateral flows (exporter → importer)
+  const flowMap = new Map<string, { records: number; quantity: number }>();
+  // Re-export legs (origin → exporter), where goods passed through an intermediary
+  const reexportMap = new Map<string, { records: number; quantity: number }>();
+  for (const r of rows) {
+    if (r.e && r.i) {
+      const key = `${r.e}->${r.i}`;
+      const entry = flowMap.get(key) || { records: 0, quantity: 0 };
+      entry.records++;
+      entry.quantity += r.q;
+      flowMap.set(key, entry);
+    }
+    if (r.o && r.e && r.o !== r.e) {
+      const key = `${r.o}->${r.e}`;
+      const entry = reexportMap.get(key) || { records: 0, quantity: 0 };
+      entry.records++;
+      entry.quantity += r.q;
+      reexportMap.set(key, entry);
+    }
+  }
+  const topFlows = Array.from(flowMap.entries())
+    .sort(([, a], [, b]) => b.records - a.records)
+    .slice(0, 12)
+    .map(([key, v]) => {
+      const [from, to] = key.split("->");
+      return { from, to, ...v };
+    });
+  const reexportFlows = Array.from(reexportMap.entries())
+    .sort(([, a], [, b]) => b.records - a.records)
+    .slice(0, 12)
+    .map(([key, v]) => {
+      const [from, to] = key.split("->");
+      return { from, to, ...v };
+    });
+
+  return {
+    byYear,
+    totalRecords: rows.length,
+    topTermUnits,
+    topSources,
+    topPurposes,
+    topExporters,
+    topImporters,
+    topFlows,
+    reexportFlows,
+  };
+}
+
+/* ------------------------------------------------------------------ */
 /*  Main component                                                     */
 /* ------------------------------------------------------------------ */
 
@@ -391,11 +704,19 @@ export default function CitesTradeSummary({
   // Metric toggle: show records (shipments) or quantity (items)
   const [metric, setMetric] = useState<"records" | "quantity">("records");
 
-  // Filter state — all checked by default
+  // Filter state — all checked by default. Terms are keyed by term+unit.
   const [checkedSources, setCheckedSources] = useState<Record<string, boolean>>({});
   const [checkedPurposes, setCheckedPurposes] = useState<Record<string, boolean>>({});
   const [checkedTerms, setCheckedTerms] = useState<Record<string, boolean>>({});
   const [filtersInitialized, setFiltersInitialized] = useState(false);
+
+  // Commodity search box (filters which term rows are shown in the panel)
+  const [termSearch, setTermSearch] = useState("");
+
+  // Year-range trim selection (null = full range). Set by dragging the
+  // handles on the trade-over-time chart.
+  const [brushStart, setBrushStart] = useState<number | null>(null);
+  const [brushEnd, setBrushEnd] = useState<number | null>(null);
 
   // Use prefetched data from parent when available; fall back to own fetch
   const data = (prefetchedData as TradeData | null) ?? ownData;
@@ -442,9 +763,13 @@ export default function CitesTradeSummary({
       for (const p of data.allPurposes) init[p.code] = true;
       setCheckedPurposes(init);
     }
-    if (data.allTerms) {
+    if (data.allTermsByUnit) {
       const init: Record<string, boolean> = {};
-      for (const t of data.allTerms) init[t.term] = true;
+      for (const t of data.allTermsByUnit) init[termKey(t.term, t.unit)] = true;
+      setCheckedTerms(init);
+    } else if (data.allTerms) {
+      const init: Record<string, boolean> = {};
+      for (const t of data.allTerms) init[termKey(t.term, "")] = true;
       setCheckedTerms(init);
     }
     setFiltersInitialized(true);
@@ -457,175 +782,92 @@ export default function CitesTradeSummary({
   const togglePurpose = useCallback((code: string) => {
     setCheckedPurposes((prev) => ({ ...prev, [code]: !prev[code] }));
   }, []);
-  const toggleTerm = useCallback((term: string) => {
-    setCheckedTerms((prev) => ({ ...prev, [term]: !prev[term] }));
+  const toggleTerm = useCallback((key: string) => {
+    setCheckedTerms((prev) => ({ ...prev, [key]: !prev[key] }));
   }, []);
 
-  // Are any filters active (i.e. something is unchecked)?
+  // Bulk All / None per section
+  const setAll = useCallback(
+    (
+      setter: React.Dispatch<React.SetStateAction<Record<string, boolean>>>,
+      value: boolean,
+      onlyKeys?: string[]
+    ) => {
+      setter((prev) => {
+        const next = { ...prev };
+        const keys = onlyKeys ?? Object.keys(next);
+        for (const k of keys) next[k] = value;
+        return next;
+      });
+    },
+    []
+  );
+
+  // Full year range from the dataset
+  const fullYearRange = useMemo<[number, number]>(
+    () => (data?.yearRange ? [data.yearRange[0], data.yearRange[1]] : [0, 0]),
+    [data?.yearRange]
+  );
+
+  // Effective (selected) year range — clamps to the dataset bounds
+  const selStart = brushStart ?? fullYearRange[0];
+  const selEnd = brushEnd ?? fullYearRange[1];
+  const yearTrimActive =
+    fullYearRange[1] > fullYearRange[0] &&
+    (selStart > fullYearRange[0] || selEnd < fullYearRange[1]);
+
+  const onRangeChange = useCallback((start: number, end: number) => {
+    setBrushStart(start);
+    setBrushEnd(end);
+  }, []);
+
+  // Are any filters active (something unchecked, search text, or year trim)?
   const hasActiveFilters = useMemo(() => {
     const anySourceOff = Object.values(checkedSources).some((v) => !v);
     const anyPurposeOff = Object.values(checkedPurposes).some((v) => !v);
     const anyTermOff = Object.values(checkedTerms).some((v) => !v);
-    return anySourceOff || anyPurposeOff || anyTermOff;
-  }, [checkedSources, checkedPurposes, checkedTerms]);
+    return anySourceOff || anyPurposeOff || anyTermOff || yearTrimActive || termSearch.trim() !== "";
+  }, [checkedSources, checkedPurposes, checkedTerms, yearTrimActive, termSearch]);
 
-  // Clear all filters (re-check everything)
+  // Clear all filters (re-check everything, reset year trim + search)
   const clearFilters = useCallback(() => {
-    setCheckedSources((prev) => {
+    const recheck = (prev: Record<string, boolean>) => {
       const next = { ...prev };
       for (const k of Object.keys(next)) next[k] = true;
       return next;
-    });
-    setCheckedPurposes((prev) => {
-      const next = { ...prev };
-      for (const k of Object.keys(next)) next[k] = true;
-      return next;
-    });
-    setCheckedTerms((prev) => {
-      const next = { ...prev };
-      for (const k of Object.keys(next)) next[k] = true;
-      return next;
-    });
+    };
+    setCheckedSources(recheck);
+    setCheckedPurposes(recheck);
+    setCheckedTerms(recheck);
+    setBrushStart(null);
+    setBrushEnd(null);
+    setTermSearch("");
   }, []);
 
-  // Filter shipments and recompute all derived data
-  const filtered = useMemo(() => {
-    if (!data?.found || !data.shipments) {
-      return {
-        byYear: data?.byYear || [],
-        totalRecords: data?.totalRecords || 0,
-        totalQty: data?.byYear?.reduce((s, d) => s + d.quantity, 0) || 0,
-        topTerms: data?.topTerms || [],
-        topSources: data?.topSources || [],
-        topPurposes: data?.topPurposes || [],
-        topExporters: data?.topExporters || [],
-        topImporters: data?.topImporters || [],
-        topFlows: data?.topFlows || [],
-      };
-    }
-
-    const rows = data.shipments.filter((r) => {
-      if (!checkedSources[r.s] && r.s) return false;
-      if (!checkedPurposes[r.p] && r.p) return false;
-      if (!checkedTerms[r.t]) return false;
+  // Rows passing the source/purpose/term filters (but NOT the year trim)
+  const baseRows = useMemo(() => {
+    if (!data?.found || !data.shipments) return [];
+    return data.shipments.filter((r) => {
+      if (r.s && checkedSources[r.s] === false) return false;
+      if (r.p && checkedPurposes[r.p] === false) return false;
+      if (checkedTerms[termKey(r.t, r.u)] === false) return false;
       return true;
     });
-
-    // byYear
-    const yearMap = new Map<number, { quantity: number; records: number }>();
-    for (const r of rows) {
-      const entry = yearMap.get(r.y) || { quantity: 0, records: 0 };
-      entry.records++;
-      entry.quantity += r.q;
-      yearMap.set(r.y, entry);
-    }
-    // Ensure all years in range are present (even if 0)
-    if (data.yearRange) {
-      for (let y = data.yearRange[0]; y <= data.yearRange[1]; y++) {
-        if (!yearMap.has(y)) yearMap.set(y, { quantity: 0, records: 0 });
-      }
-    }
-    const byYear = Array.from(yearMap.entries())
-      .sort(([a], [b]) => a - b)
-      .map(([year, v]) => ({ year, ...v }));
-
-    // terms
-    const termMap = new Map<string, { quantity: number; records: number }>();
-    for (const r of rows) {
-      const entry = termMap.get(r.t) || { quantity: 0, records: 0 };
-      entry.records++;
-      entry.quantity += r.q;
-      termMap.set(r.t, entry);
-    }
-    const topTerms = Array.from(termMap.entries())
-      .sort(([, a], [, b]) => b.records - a.records)
-      .slice(0, 8)
-      .map(([term, v]) => ({ term, ...v }));
-
-    // sources
-    const sourceMap = new Map<string, number>();
-    for (const r of rows) {
-      if (r.s) sourceMap.set(r.s, (sourceMap.get(r.s) || 0) + 1);
-    }
-    const topSources = Array.from(sourceMap.entries())
-      .sort(([, a], [, b]) => b - a)
-      .map(([code, records]) => ({
-        code,
-        label: SOURCE_LABELS[code] || code,
-        records,
-      }));
-
-    // purposes
-    const purposeMap = new Map<string, number>();
-    for (const r of rows) {
-      if (r.p) purposeMap.set(r.p, (purposeMap.get(r.p) || 0) + 1);
-    }
-    const topPurposes = Array.from(purposeMap.entries())
-      .sort(([, a], [, b]) => b - a)
-      .map(([code, records]) => ({
-        code,
-        label: PURPOSE_LABELS[code] || code,
-        records,
-      }));
-
-    // exporters
-    const exporterMap = new Map<string, { records: number; quantity: number }>();
-    for (const r of rows) {
-      if (!r.e) continue;
-      const entry = exporterMap.get(r.e) || { records: 0, quantity: 0 };
-      entry.records++;
-      entry.quantity += r.q;
-      exporterMap.set(r.e, entry);
-    }
-    const topExporters = Array.from(exporterMap.entries())
-      .sort(([, a], [, b]) => b.records - a.records)
-      .slice(0, 8)
-      .map(([code, v]) => ({ code, ...v }));
-
-    // importers
-    const importerMap = new Map<string, { records: number; quantity: number }>();
-    for (const r of rows) {
-      if (!r.i) continue;
-      const entry = importerMap.get(r.i) || { records: 0, quantity: 0 };
-      entry.records++;
-      entry.quantity += r.q;
-      importerMap.set(r.i, entry);
-    }
-    const topImporters = Array.from(importerMap.entries())
-      .sort(([, a], [, b]) => b.records - a.records)
-      .slice(0, 8)
-      .map(([code, v]) => ({ code, ...v }));
-
-    // flows
-    const flowMap = new Map<string, { records: number; quantity: number }>();
-    for (const r of rows) {
-      if (!r.e || !r.i) continue;
-      const key = `${r.e}->${r.i}`;
-      const entry = flowMap.get(key) || { records: 0, quantity: 0 };
-      entry.records++;
-      entry.quantity += r.q;
-      flowMap.set(key, entry);
-    }
-    const topFlows = Array.from(flowMap.entries())
-      .sort(([, a], [, b]) => b.records - a.records)
-      .slice(0, 12)
-      .map(([key, v]) => {
-        const [from, to] = key.split("->");
-        return { from, to, ...v };
-      });
-
-    return {
-      byYear,
-      totalRecords: rows.length,
-      totalQty: rows.reduce((s, r) => s + r.q, 0),
-      topTerms,
-      topSources,
-      topPurposes,
-      topExporters,
-      topImporters,
-      topFlows,
-    };
   }, [data, checkedSources, checkedPurposes, checkedTerms]);
+
+  // Chart data spans the full year range (so the trim handles stay anchored)
+  const chartByYear = useMemo(
+    () => aggregate(baseRows, fullYearRange).byYear,
+    [baseRows, fullYearRange]
+  );
+
+  // Everything else reflects the trimmed year range
+  const display = useMemo(() => {
+    const rows = yearTrimActive
+      ? baseRows.filter((r) => r.y >= selStart && r.y <= selEnd)
+      : baseRows;
+    return aggregate(rows, [selStart, selEnd]);
+  }, [baseRows, yearTrimActive, selStart, selEnd]);
 
   /* ---------------------------------------------------------------- */
   /*  Render                                                           */
@@ -664,25 +906,37 @@ export default function CitesTradeSummary({
 
   const hasShipments = !!data.shipments && data.shipments.length > 0;
 
+  // Term+unit rows for the filter panel (prefer the unit-aware list)
+  const allTermUnitRows: TermUnitData[] =
+    data.allTermsByUnit ??
+    (data.allTerms?.map((t) => ({ term: t.term, unit: "", records: t.records, quantity: 0 })) ??
+      []);
+  const termSearchLower = termSearch.trim().toLowerCase();
+  const visibleTermRows = termSearchLower
+    ? allTermUnitRows.filter(
+        (t) =>
+          t.term.toLowerCase().includes(termSearchLower) ||
+          t.unit.toLowerCase().includes(termSearchLower)
+      )
+    : allTermUnitRows;
+  const sourceKeys = (data.allSources ?? []).map((s) => s.code);
+  const purposeKeys = (data.allPurposes ?? []).map((p) => p.code);
+  const termKeys = allTermUnitRows.map((t) => termKey(t.term, t.unit));
+
   return (
     <div className="space-y-4">
       {/* Headline + trend */}
       <div className="flex items-baseline gap-3 flex-wrap">
         <span className="text-sm text-zinc-700 dark:text-zinc-200">
           <span className="font-semibold tabular-nums">
-            {filtered.totalRecords.toLocaleString()}
+            {display.totalRecords.toLocaleString()}
           </span>{" "}
           shipments
-          <span className="text-zinc-400 dark:text-zinc-500 mx-1">/</span>
-          <span className="font-semibold tabular-nums">
-            {fmtQty(filtered.totalQty)}
-          </span>{" "}
-          reported items
           <span className="text-zinc-400 dark:text-zinc-500 ml-1">
-            {data.yearRange[0]}–{data.yearRange[1]}
+            {selStart}–{selEnd}
           </span>
         </span>
-        <TrendSummary data={filtered.byYear} metric={metric} />
+        <TrendSummary data={display.byYear} metric={metric} />
         {hasActiveFilters && (
           <button
             className="text-[11px] text-blue-600 dark:text-blue-400 hover:underline ml-auto"
@@ -694,11 +948,12 @@ export default function CitesTradeSummary({
       </div>
 
       {/* Trade flow map */}
-      {filtered.topFlows && filtered.topFlows.length > 0 && (
+      {display.topFlows && display.topFlows.length > 0 && (
         <div>
           <div className="border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden bg-zinc-50 dark:bg-zinc-800/30">
             <TradeFlowMap
-              flows={filtered.topFlows}
+              flows={display.topFlows}
+              reexportFlows={display.reexportFlows}
               suspensionCountries={suspensionCountries}
               countryAnnotations={countryAnnotations}
             />
@@ -708,8 +963,8 @@ export default function CitesTradeSummary({
 
       {/* Exporters & Importers */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <CountryTable data={filtered.topExporters} label="Top exporters" />
-        <CountryTable data={filtered.topImporters} label="Top importers" />
+        <CountryTable data={display.topExporters} label="Top exporters" />
+        <CountryTable data={display.topImporters} label="Top importers" />
       </div>
 
       {/* Filters + Chart side by side */}
@@ -720,9 +975,11 @@ export default function CitesTradeSummary({
             {/* Source filters */}
             {data.allSources && data.allSources.length > 0 && (
               <div>
-                <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
-                  Source
-                </h5>
+                <SectionHeader
+                  title="Source"
+                  onAll={() => setAll(setCheckedSources, true, sourceKeys)}
+                  onNone={() => setAll(setCheckedSources, false, sourceKeys)}
+                />
                 <div className="space-y-1">
                   {data.allSources.map((s) => (
                     <FilterCheckbox
@@ -742,9 +999,11 @@ export default function CitesTradeSummary({
             {/* Purpose filters */}
             {data.allPurposes && data.allPurposes.length > 0 && (
               <div>
-                <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
-                  Purpose
-                </h5>
+                <SectionHeader
+                  title="Purpose"
+                  onAll={() => setAll(setCheckedPurposes, true, purposeKeys)}
+                  onNone={() => setAll(setCheckedPurposes, false, purposeKeys)}
+                />
                 <div className="space-y-1">
                   {data.allPurposes.map((p) => (
                     <FilterCheckbox
@@ -761,26 +1020,41 @@ export default function CitesTradeSummary({
               </div>
             )}
 
-            {/* Term/commodity filters */}
-            {data.allTerms && data.allTerms.length > 0 && (
+            {/* Term/commodity filters — searchable, keyed by term+unit */}
+            {allTermUnitRows.length > 0 && (
               <div>
-                <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
-                  Commodity
-                </h5>
+                <SectionHeader
+                  title="Commodity"
+                  onAll={() => setAll(setCheckedTerms, true, termKeys)}
+                  onNone={() => setAll(setCheckedTerms, false, termKeys)}
+                />
+                {allTermUnitRows.length > 6 && (
+                  <input
+                    type="text"
+                    value={termSearch}
+                    onChange={(e) => setTermSearch(e.target.value)}
+                    placeholder="Search commodities…"
+                    className="w-full mb-1.5 px-2 py-1 text-xs rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-200 placeholder:text-zinc-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  />
+                )}
                 <div className="space-y-1">
-                  {data.allTerms.slice(0, 10).map((t) => (
-                    <FilterCheckbox
-                      key={t.term}
-                      label={t.term}
-                      count={t.records}
-                      checked={checkedTerms[t.term] ?? true}
-                      onChange={() => toggleTerm(t.term)}
-                      color="#8b5cf6"
-                    />
-                  ))}
-                  {data.allTerms.length > 10 && (
+                  {visibleTermRows.map((t) => {
+                    const key = termKey(t.term, t.unit);
+                    return (
+                      <FilterCheckbox
+                        key={key}
+                        label={t.term}
+                        sublabel={t.unit || undefined}
+                        count={t.records}
+                        checked={checkedTerms[key] ?? true}
+                        onChange={() => toggleTerm(key)}
+                        color="#8b5cf6"
+                      />
+                    );
+                  })}
+                  {visibleTermRows.length === 0 && (
                     <span className="text-[10px] text-zinc-400 dark:text-zinc-500">
-                      +{data.allTerms.length - 10} more
+                      No commodities match “{termSearch}”.
                     </span>
                   )}
                 </div>
@@ -797,6 +1071,11 @@ export default function CitesTradeSummary({
               <span className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
                 Trade over time
               </span>
+              {yearTrimActive && (
+                <span className="text-[11px] text-amber-600 dark:text-amber-400 tabular-nums">
+                  {selStart}–{selEnd}
+                </span>
+              )}
               <div className="flex items-center gap-1 ml-auto bg-zinc-100 dark:bg-zinc-800 rounded-md p-0.5">
                 <button
                   className={`px-2 py-0.5 text-[11px] rounded ${
@@ -820,21 +1099,34 @@ export default function CitesTradeSummary({
                 </button>
               </div>
             </div>
-            <TrendLineChart data={filtered.byYear} metric={metric} />
+            <TrendLineChart
+              data={chartByYear}
+              metric={metric}
+              minYear={fullYearRange[0]}
+              maxYear={fullYearRange[1]}
+              selStart={selStart}
+              selEnd={selEnd}
+              onRangeChange={onRangeChange}
+            />
+            {data.yearRange[1] > data.yearRange[0] && (
+              <p className="text-[10px] text-zinc-400 dark:text-zinc-500 mt-1">
+                Drag the handles to trim the year range.
+              </p>
+            )}
           </div>
 
           {/* Source breakdown — most important for assessors */}
-          {filtered.topSources.length > 0 && (
+          {display.topSources.length > 0 && (
             <div>
               <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
                 Wild vs. Captive
               </h5>
-              <SourceBreakdown sources={filtered.topSources} />
+              <SourceBreakdown sources={display.topSources} />
             </div>
           )}
 
-          {/* Commodities — table with quantities */}
-          {filtered.topTerms.length > 0 && (
+          {/* Commodities — one row per term+unit (units are never aggregated) */}
+          {display.topTermUnits.length > 0 && (
             <div>
               <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
                 Commodities
@@ -843,20 +1135,22 @@ export default function CitesTradeSummary({
                 <thead>
                   <tr className="text-left text-zinc-400 dark:text-zinc-500">
                     <th className="font-medium pb-1 pr-2">Term</th>
-                    <th className="font-medium pb-1 pr-2 text-right">
-                      Records
-                    </th>
+                    <th className="font-medium pb-1 pr-2">Unit</th>
+                    <th className="font-medium pb-1 pr-2 text-right">Records</th>
                     <th className="font-medium pb-1 text-right">Quantity</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {filtered.topTerms.slice(0, 6).map((t) => (
+                  {display.topTermUnits.slice(0, 8).map((t) => (
                     <tr
-                      key={t.term}
+                      key={termKey(t.term, t.unit)}
                       className="border-t border-zinc-100 dark:border-zinc-800/50"
                     >
                       <td className="py-1 pr-2 text-zinc-700 dark:text-zinc-300 capitalize">
                         {t.term}
+                      </td>
+                      <td className="py-1 pr-2 text-zinc-500 dark:text-zinc-400">
+                        {t.unit || <span className="text-zinc-300 dark:text-zinc-600">items</span>}
                       </td>
                       <td className="py-1 pr-2 text-right text-zinc-500 dark:text-zinc-400 tabular-nums">
                         {t.records.toLocaleString()}
@@ -872,13 +1166,13 @@ export default function CitesTradeSummary({
           )}
 
           {/* Purpose */}
-          {filtered.topPurposes.length > 0 && (
+          {display.topPurposes.length > 0 && (
             <div>
               <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
                 Purpose
               </h5>
               <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-600 dark:text-zinc-300">
-                {filtered.topPurposes.map((p) => (
+                {display.topPurposes.map((p) => (
                   <span key={p.code} className="tabular-nums">
                     {p.label}{" "}
                     <span className="text-zinc-400 dark:text-zinc-500">

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -142,7 +142,7 @@ function endAngle(from: [number, number], to: [number, number], curvature = 0.25
   return (Math.atan2(tdy, tdx) * 180) / Math.PI;
 }
 
-interface TradeFlow {
+export interface TradeFlow {
   from: string;
   to: string;
   records: number;
@@ -156,15 +156,21 @@ export interface CountryAnnotation {
 
 interface TradeFlowMapProps {
   flows: TradeFlow[];
+  /**
+   * Re-export legs (origin → exporter) where goods passed through an
+   * intermediary country before the reported export. Drawn as dashed arcs.
+   */
+  reexportFlows?: TradeFlow[];
   /** ISO alpha-2 codes of countries with active trade suspensions */
   suspensionCountries?: Set<string>;
   /** Per-country suspension/quota annotations for hover tooltip */
   countryAnnotations?: Record<string, CountryAnnotation>;
 }
 
-function TradeFlowMap({ flows, suspensionCountries, countryAnnotations }: TradeFlowMapProps) {
+function TradeFlowMap({ flows, reexportFlows, suspensionCountries, countryAnnotations }: TradeFlowMapProps) {
   const { resolvedTheme } = useTheme();
   const [hoveredFlow, setHoveredFlow] = useState<number | null>(null);
+  const [hoveredReexport, setHoveredReexport] = useState<number | null>(null);
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
   const [selectedCountry, setSelectedCountry] = useState<string | null>(null);
 
@@ -172,6 +178,10 @@ function TradeFlowMap({ flows, suspensionCountries, countryAnnotations }: TradeF
   const renderableFlows = useMemo(
     () => flows.filter((f) => COUNTRY_CENTROIDS[f.from] && COUNTRY_CENTROIDS[f.to]),
     [flows]
+  );
+  const renderableReexports = useMemo(
+    () => (reexportFlows ?? []).filter((f) => COUNTRY_CENTROIDS[f.from] && COUNTRY_CENTROIDS[f.to]),
+    [reexportFlows]
   );
 
   if (renderableFlows.length === 0) return null;
@@ -182,6 +192,9 @@ function TradeFlowMap({ flows, suspensionCountries, countryAnnotations }: TradeF
   const visibleFlows = selectedCountry
     ? renderableFlows.filter((f) => f.from === selectedCountry || f.to === selectedCountry)
     : renderableFlows;
+  const visibleReexports = selectedCountry
+    ? renderableReexports.filter((f) => f.from === selectedCountry || f.to === selectedCountry)
+    : renderableReexports;
 
   // Collect unique exporter/importer codes from visible flows
   const exporterCodes = new Set(visibleFlows.map((f) => f.from));
@@ -191,10 +204,11 @@ function TradeFlowMap({ flows, suspensionCountries, countryAnnotations }: TradeF
 
   // Theme-aware colors for SVG fills (can't use Tailwind classes in SVG)
   const colors = dark
-    ? { base: "#18181b", exporter: "#7f1d1d", importer: "#1e3a5f", both: "#312e81", stroke: "#27272a", suspension: "#991b1b", arcDefault: "#f87171", arcHover: "#fbbf24" }
-    : { base: "#f4f4f5", exporter: "#fee2e2", importer: "#dbeafe", both: "#e0e7ff", stroke: "#d4d4d8", suspension: "#fecaca", arcDefault: "#ef4444", arcHover: "#f59e0b" };
+    ? { base: "#18181b", exporter: "#7f1d1d", importer: "#1e3a5f", both: "#312e81", stroke: "#27272a", suspension: "#991b1b", arcDefault: "#f87171", arcHover: "#fbbf24", reexport: "#fb923c" }
+    : { base: "#f4f4f5", exporter: "#fee2e2", importer: "#dbeafe", both: "#e0e7ff", stroke: "#d4d4d8", suspension: "#fecaca", arcDefault: "#ef4444", arcHover: "#f59e0b", reexport: "#ea580c" };
 
   const hoveredFlowData = hoveredFlow !== null ? visibleFlows[hoveredFlow] : null;
+  const hoveredReexportData = hoveredReexport !== null ? visibleReexports[hoveredReexport] : null;
 
   return (
     <div className="relative">
@@ -219,8 +233,21 @@ function TradeFlowMap({ flows, suspensionCountries, countryAnnotations }: TradeF
         </div>
       )}
 
+      {/* Re-export leg tooltip */}
+      {hoveredReexportData && !hoveredFlowData && (
+        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 bg-zinc-800 dark:bg-zinc-700 text-white text-[11px] px-3 py-1.5 rounded-lg shadow-lg pointer-events-none whitespace-nowrap">
+          <span className="text-orange-300 mr-1.5">Re-export origin:</span>
+          <span className="font-medium">{countryName(hoveredReexportData.from)}</span>
+          <span className="text-zinc-300 mx-1.5">&rarr;</span>
+          <span className="font-medium">{countryName(hoveredReexportData.to)}</span>
+          <span className="text-zinc-400 ml-2">
+            {hoveredReexportData.records.toLocaleString()} records
+          </span>
+        </div>
+      )}
+
       {/* Country annotation tooltip (suspensions/quotas) */}
-      {hoveredCountry && !hoveredFlowData && countryAnnotations?.[hoveredCountry] && (
+      {hoveredCountry && !hoveredFlowData && !hoveredReexportData && countryAnnotations?.[hoveredCountry] && (
         <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 bg-zinc-800 dark:bg-zinc-700 text-white text-[11px] px-3 py-2 rounded-lg shadow-lg pointer-events-none max-w-[280px]">
           <div className="font-medium mb-1">{countryName(hoveredCountry)}</div>
           {countryAnnotations[hoveredCountry].suspensions && countryAnnotations[hoveredCountry].suspensions!.length > 0 && (
@@ -346,6 +373,44 @@ function TradeFlowMap({ flows, suspensionCountries, countryAnnotations }: TradeF
           );
         })}
 
+        {/* Re-export legs (origin → exporter) as dashed orange arcs */}
+        {visibleReexports.map((flow, i) => {
+          const from = COUNTRY_CENTROIDS[flow.from];
+          const to = COUNTRY_CENTROIDS[flow.to];
+          // Curve the other way (negative curvature) so re-export legs are
+          // visually distinct from the direct-export arcs
+          const path = arcPath(from, to, -0.25);
+          if (!path) return null;
+          const isHovered = hoveredReexport === i;
+          const dest = project(to);
+          const angle = endAngle(from, to, -0.25);
+
+          return (
+            <g key={`reexport-${flow.from}-${flow.to}`}>
+              <path
+                d={path}
+                fill="none"
+                stroke={colors.reexport}
+                strokeWidth={isHovered ? 3 : 2}
+                strokeLinecap="round"
+                strokeDasharray="5,4"
+                strokeOpacity={isHovered ? 0.95 : dark ? 0.75 : 0.6}
+                onMouseEnter={() => setHoveredReexport(i)}
+                onMouseLeave={() => setHoveredReexport(null)}
+                style={{ cursor: "pointer" }}
+              />
+              {dest && (
+                <polygon
+                  points="-5,-3 0,0 -5,3"
+                  fill={colors.reexport}
+                  fillOpacity={isHovered ? 0.95 : 0.75}
+                  transform={`translate(${dest[0]},${dest[1]}) rotate(${angle})`}
+                />
+              )}
+            </g>
+          );
+        })}
+
         {/* Endpoint markers (deduplicated) — clickable for filtering */}
         <g transform={`translate(${MAP_OFFSET[0]}, ${MAP_OFFSET[1]})`}>
           {(() => {
@@ -411,6 +476,15 @@ function TradeFlowMap({ flows, suspensionCountries, countryAnnotations }: TradeF
           </svg>
           Flow direction
         </span>
+        {visibleReexports.length > 0 && (
+          <span className="flex items-center gap-1">
+            <svg width="16" height="8" className="inline-block">
+              <line x1="0" y1="4" x2="12" y2="4" stroke={dark ? "#fb923c" : "#ea580c"} strokeWidth="2" strokeDasharray="3,2" strokeOpacity="0.8" />
+              <polygon points="12,1.5 16,4 12,6.5" fill={dark ? "#fb923c" : "#ea580c"} fillOpacity="0.8" />
+            </svg>
+            Re-export origin
+          </span>
+        )}
         {suspensionCountries && suspensionCountries.size > 0 && (
           <span className="flex items-center gap-1">
             <span className="inline-block w-3 h-2 rounded-sm border border-dashed border-red-500 bg-red-100 dark:bg-red-900/30" />


### PR DESCRIPTION
Consolidates all CITES improvements from issue #300 into one branch.

## Changes

- **No min year cutoff**: fetch full history back to 1975 (CITES inception)—early records (e.g. Panthera leo from 1977) no longer cut off.
- **Exporter-preferred quantity** per the CITES Trade Database Guide (falls back to importer only when absent).
- **Unit-aware commodities**: group by term+unit; quantities are never aggregated across incompatible units (kg, m³, pieces, unit-less).
- **Searchable commodity filter** with All/None bulk-select per section.
- **Year-range trimming** via draggable handles on the trade-over-time chart; the original chart is unchanged and out-of-range regions are dimmed.
- **Re-export arcs**: origin→exporter legs drawn as dashed orange arcs with tooltip + legend.

Note: lint/tests were not run locally (sandbox blocked npm); CI will validate.

Closes #300

Generated with [Claude Code](https://claude.ai/code)