### PR TITLE
CITES trade improvements: full history, unit-aware commodities, year trimming, clearer re-exports

### DIFF
--- a/app/src/app/api/cites/trade/__tests__/route.test.ts
+++ b/app/src/app/api/cites/trade/__tests__/route.test.ts
@@ -41,6 +41,24 @@ function jsonResponse(data: unknown, status = 200): Response {
   } as unknown as Response;
 }
 
+// The route fetches the history in year-windows, so a fetch mock must return
+// only the rows whose Year falls inside the requested time range — otherwise
+// every window would return the full set and rows would be duplicated.
+function rangeAwareFetch(rows: Array<Record<string, unknown>>) {
+  return vi.fn((url: string) => {
+    const params = new URL(url).searchParams;
+    const start = Number(params.get("filters[time_range_start]"));
+    const end = Number(params.get("filters[time_range_end]"));
+    const inRange = rows.filter((r) => {
+      const y = r.Year as number;
+      return y >= start && y <= end;
+    });
+    return Promise.resolve(
+      jsonResponse({ shipment_comptab_export: { rows: inRange } })
+    );
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -149,12 +167,7 @@ describe("/api/cites/trade", () => {
       makeTradeRow({ Year: 2023, Exporter: "GH", Importer: "US", "Importer reported quantity": "10", Purpose: "S", Source: "W", Term: "specimens" }),
     ];
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        jsonResponse({ shipment_comptab_export: { rows } })
-      )
-    );
+    vi.stubGlobal("fetch", rangeAwareFetch(rows));
     const { GET } = await importRoute();
     const res = await GET(makeRequest({ taxon_id: "11136" }));
     const body = await res.json();
@@ -207,12 +220,7 @@ describe("/api/cites/trade", () => {
       }),
     ];
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        jsonResponse({ shipment_comptab_export: { rows } })
-      )
-    );
+    vi.stubGlobal("fetch", rangeAwareFetch(rows));
     const { GET } = await importRoute();
     const res = await GET(makeRequest({ taxon_id: "11136" }));
     const body = await res.json();
@@ -228,12 +236,7 @@ describe("/api/cites/trade", () => {
       }),
     ];
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        jsonResponse({ shipment_comptab_export: { rows } })
-      )
-    );
+    vi.stubGlobal("fetch", rangeAwareFetch(rows));
     const { GET } = await importRoute();
     const res = await GET(makeRequest({ taxon_id: "11136" }));
     const body = await res.json();
@@ -248,12 +251,7 @@ describe("/api/cites/trade", () => {
       makeTradeRow({ Term: "leather", Unit: "m", "Exporter reported quantity": "7" }),
     ];
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        jsonResponse({ shipment_comptab_export: { rows } })
-      )
-    );
+    vi.stubGlobal("fetch", rangeAwareFetch(rows));
     const { GET } = await importRoute();
     const res = await GET(makeRequest({ taxon_id: "11136" }));
     const body = await res.json();
@@ -277,12 +275,7 @@ describe("/api/cites/trade", () => {
       }),
     ];
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        jsonResponse({ shipment_comptab_export: { rows } })
-      )
-    );
+    vi.stubGlobal("fetch", rangeAwareFetch(rows));
     const { GET } = await importRoute();
     const res = await GET(makeRequest({ taxon_id: "11136" }));
     const body = await res.json();
@@ -297,16 +290,15 @@ describe("/api/cites/trade", () => {
 
   it("caches results on repeated requests", async () => {
     const rows = [makeTradeRow()];
-    const fetchMock = vi.fn().mockResolvedValue(
-      jsonResponse({ shipment_comptab_export: { rows } })
-    );
+    const fetchMock = rangeAwareFetch(rows);
     vi.stubGlobal("fetch", fetchMock);
     const { GET } = await importRoute();
 
     await GET(makeRequest({ taxon_id: "11136" }));
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const callsAfterFirst = fetchMock.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0); // one request per year-window
 
     await GET(makeRequest({ taxon_id: "11136" }));
-    expect(fetchMock).toHaveBeenCalledTimes(1); // no new calls
+    expect(fetchMock).toHaveBeenCalledTimes(callsAfterFirst); // served from cache
   });
 });

--- a/app/src/app/api/cites/trade/__tests__/route.test.ts
+++ b/app/src/app/api/cites/trade/__tests__/route.test.ts
@@ -189,16 +189,17 @@ describe("/api/cites/trade", () => {
     // shipments (compact records)
     expect(body.shipments).toHaveLength(3);
     expect(body.shipments[0]).toEqual(
-      expect.objectContaining({ y: 2022, s: "W", p: "S", t: "specimens" })
+      expect.objectContaining({ y: 2022, s: "W", p: "S", t: "specimens", u: "", o: "" })
     );
 
-    // allSources / allPurposes / allTerms present
+    // allSources / allPurposes / allTerms / allTermsByUnit present
     expect(body.allSources.length).toBeGreaterThan(0);
     expect(body.allPurposes.length).toBeGreaterThan(0);
     expect(body.allTerms.length).toBeGreaterThan(0);
+    expect(body.allTermsByUnit.length).toBeGreaterThan(0);
   });
 
-  it("uses max of importer/exporter reported quantity", async () => {
+  it("prefers exporter-reported quantity over importer-reported", async () => {
     const rows = [
       makeTradeRow({
         "Importer reported quantity": "20",
@@ -216,7 +217,56 @@ describe("/api/cites/trade", () => {
     const res = await GET(makeRequest({ taxon_id: "11136" }));
     const body = await res.json();
 
-    expect(body.byYear[0].quantity).toBe(20); // max(20, 15)
+    expect(body.byYear[0].quantity).toBe(15); // exporter-preferred, not max(20, 15)
+  });
+
+  it("falls back to importer quantity when the exporter did not report", async () => {
+    const rows = [
+      makeTradeRow({
+        "Importer reported quantity": "20",
+        "Exporter reported quantity": null,
+      }),
+    ];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({ shipment_comptab_export: { rows } })
+      )
+    );
+    const { GET } = await importRoute();
+    const res = await GET(makeRequest({ taxon_id: "11136" }));
+    const body = await res.json();
+
+    expect(body.byYear[0].quantity).toBe(20);
+  });
+
+  it("groups terms by unit without aggregating across units", async () => {
+    const rows = [
+      makeTradeRow({ Term: "tusks", Unit: "kg", "Exporter reported quantity": "100" }),
+      makeTradeRow({ Term: "tusks", Unit: null, "Exporter reported quantity": "4" }),
+      makeTradeRow({ Term: "leather", Unit: "m", "Exporter reported quantity": "7" }),
+    ];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({ shipment_comptab_export: { rows } })
+      )
+    );
+    const { GET } = await importRoute();
+    const res = await GET(makeRequest({ taxon_id: "11136" }));
+    const body = await res.json();
+
+    // "tusks / kg" and "tusks / (no unit)" must be separate rows
+    const tusksKg = body.allTermsByUnit.find(
+      (t: { term: string; unit: string }) => t.term === "tusks" && t.unit === "kg"
+    );
+    const tusksNoUnit = body.allTermsByUnit.find(
+      (t: { term: string; unit: string }) => t.term === "tusks" && t.unit === ""
+    );
+    expect(tusksKg?.quantity).toBe(100);
+    expect(tusksNoUnit?.quantity).toBe(4);
   });
 
   it("handles null quantities gracefully", async () => {

--- a/app/src/app/api/cites/trade/route.ts
+++ b/app/src/app/api/cites/trade/route.ts
@@ -10,6 +10,27 @@ const TRADE_API = "https://trade.cites.org/en/cites_trade/shipments";
 const tradeCache = new Map<string, { data: object; timestamp: number }>();
 const CACHE_DURATION = 60 * 60 * 1000;
 
+// CITES entered into force in 1975, so there is no trade data before then.
+const FETCH_START_YEAR = 1975;
+// The CITES endpoint returns inconsistent / partially-truncated results when a
+// single request spans the full history (a 50-year pull for a heavily-traded
+// species can silently drop thousands of rows, including whole recent years).
+// We therefore fetch in small year-windows and concatenate — each window is
+// small enough to return complete, reproducible data.
+const FETCH_CHUNK_YEARS = 5;
+
+/** Error that carries the upstream HTTP status so the route can propagate it. */
+class CitesTradeError extends Error {
+  status: number;
+  constructor(status: number) {
+    super(`CITES Trade DB error: ${status}`);
+    this.status = status;
+  }
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+
 interface TradeRow {
   Year: number;
   "App.": string;
@@ -298,6 +319,46 @@ function summarize(rows: TradeRow[]): TradeSummary {
 }
 
 /**
+ * Fetch one year-window of comparative-tabulation rows for a taxon, with a few
+ * retries for transient upstream errors.
+ */
+async function fetchTradeChunk(
+  taxonId: string,
+  startYear: number,
+  endYear: number
+): Promise<TradeRow[]> {
+  const params = new URLSearchParams({
+    "filters[taxon_concepts_ids][]": taxonId,
+    "filters[report_type]": "comptab",
+    "filters[time_range_start]": String(startYear),
+    "filters[time_range_end]": String(endYear),
+    "filters[exporters_ids][]": "all_exp",
+    "filters[importers_ids][]": "all_imp",
+    "filters[sources_ids][]": "all_sou",
+    "filters[purposes_ids][]": "all_pur",
+    "filters[terms_ids][]": "all_ter",
+    "filters[selection_taxon]": "taxonomic_cascade",
+  });
+  const url = `${TRADE_API}?${params.toString()}`;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    if (attempt > 0) await sleep(300 * attempt);
+    try {
+      const resp = await fetch(url, { headers: { Accept: "application/json" } });
+      if (!resp.ok) throw new CitesTradeError(resp.status);
+      const data = await resp.json();
+      return (data?.shipment_comptab_export?.rows as TradeRow[]) ?? [];
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("CITES Trade DB request failed");
+}
+
+/**
  * GET /api/cites/trade?taxon_id=<citesId>
  *
  * Fetches comparative tabulation data from the CITES Trade Database
@@ -320,39 +381,21 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    // Fetch the full available history. CITES entered into force in 1975, so
-    // there is no trade data before then. Using a fixed early start (rather
-    // than a rolling N-year window) means early records — e.g. Panthera leo
-    // back to 1977 — are no longer cut off.
+    // Fetch the full available history (1975 → present) in small year-windows.
+    // The upstream endpoint truncates large single-shot pulls non-determinist-
+    // ically, so chunking is what makes the recent years (and the totals)
+    // reliable — e.g. Panthera leo back to 1977 with complete recent data.
     const currentYear = new Date().getFullYear();
-    const startYear = 1975;
 
-    const params = new URLSearchParams({
-      "filters[taxon_concepts_ids][]": taxonId,
-      "filters[report_type]": "comptab",
-      "filters[time_range_start]": String(startYear),
-      "filters[time_range_end]": String(currentYear),
-      "filters[exporters_ids][]": "all_exp",
-      "filters[importers_ids][]": "all_imp",
-      "filters[sources_ids][]": "all_sou",
-      "filters[purposes_ids][]": "all_pur",
-      "filters[terms_ids][]": "all_ter",
-      "filters[selection_taxon]": "taxonomic_cascade",
-    });
-
-    const resp = await fetch(`${TRADE_API}?${params.toString()}`, {
-      headers: { Accept: "application/json" },
-    });
-
-    if (!resp.ok) {
-      return NextResponse.json(
-        { error: `CITES Trade DB error: ${resp.status}` },
-        { status: resp.status }
-      );
+    const ranges: [number, number][] = [];
+    for (let s = FETCH_START_YEAR; s <= currentYear; s += FETCH_CHUNK_YEARS) {
+      ranges.push([s, Math.min(s + FETCH_CHUNK_YEARS - 1, currentYear)]);
     }
 
-    const data = await resp.json();
-    const rows: TradeRow[] = data?.shipment_comptab_export?.rows || [];
+    const chunks = await Promise.all(
+      ranges.map(([a, b]) => fetchTradeChunk(taxonId, a, b))
+    );
+    const rows: TradeRow[] = chunks.flat();
 
     if (rows.length === 0) {
       const result = { found: false, taxonId };
@@ -366,9 +409,10 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(result, { headers: CACHE_1H });
   } catch (error) {
     console.error("Error fetching CITES trade data:", error);
+    const status = error instanceof CitesTradeError ? error.status : 500;
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Unknown error" },
-      { status: 500 }
+      { status }
     );
   }
 }

--- a/app/src/app/api/cites/trade/route.ts
+++ b/app/src/app/api/cites/trade/route.ts
@@ -61,15 +61,17 @@ interface CompactRecord {
   s: string;   // source code
   p: string;   // purpose code
   t: string;   // term
-  q: number;   // quantity (max of importer/exporter reported)
+  u: string;   // unit (empty string = unit-less / "number of specimens")
+  q: number;   // quantity (exporter-reported preferred, per CITES guide)
   e: string;   // exporter country code
   i: string;   // importer country code
+  o: string;   // origin country code (for re-export pathways; empty if same as exporter)
 }
 
 interface TradeSummary {
   totalRecords: number;
   yearRange: [number, number];
-  /** Total quantities by year (max of importer/exporter reported) */
+  /** Total quantities by year (exporter-reported preferred) */
   byYear: { year: number; quantity: number; records: number }[];
   /** Top traded terms (e.g. "live", "skins", "trophies") */
   topTerms: { term: string; quantity: number; records: number }[];
@@ -91,12 +93,30 @@ interface TradeSummary {
   allPurposes: { code: string; label: string; records: number }[];
   /** All unique terms with record counts */
   allTerms: { term: string; records: number }[];
+  /**
+   * Terms grouped by term + unit. Quantities are NEVER aggregated across
+   * different units (kg, m³, pieces, unit-less) — each term+unit is its own row.
+   */
+  allTermsByUnit: { term: string; unit: string; records: number; quantity: number }[];
 }
 
 function parseQty(val: string | null): number {
   if (!val) return 0;
   const n = parseFloat(val);
   return isNaN(n) ? 0 : n;
+}
+
+/**
+ * Pick the reported quantity for a row. The CITES Trade Database Guide treats
+ * importer- and exporter-reported figures as two independent reports of the
+ * same trade — they must never be summed. We prefer the exporter-reported
+ * quantity (the re-exporter is the authority on what left their territory),
+ * falling back to the importer figure only when the exporter did not report.
+ */
+function pickQty(r: TradeRow): number {
+  const exporter = parseQty(r["Exporter reported quantity"]);
+  if (exporter > 0) return exporter;
+  return parseQty(r["Importer reported quantity"]);
 }
 
 function summarize(rows: TradeRow[]): TradeSummary {
@@ -108,10 +128,7 @@ function summarize(rows: TradeRow[]): TradeSummary {
   for (const r of rows) {
     const entry = yearMap.get(r.Year) || { quantity: 0, records: 0 };
     entry.records++;
-    entry.quantity += Math.max(
-      parseQty(r["Importer reported quantity"]),
-      parseQty(r["Exporter reported quantity"])
-    );
+    entry.quantity += pickQty(r);
     yearMap.set(r.Year, entry);
   }
   const byYear = Array.from(yearMap.entries())
@@ -124,10 +141,7 @@ function summarize(rows: TradeRow[]): TradeSummary {
     const term = r.Term || "unspecified";
     const entry = termMap.get(term) || { quantity: 0, records: 0 };
     entry.records++;
-    entry.quantity += Math.max(
-      parseQty(r["Importer reported quantity"]),
-      parseQty(r["Exporter reported quantity"])
-    );
+    entry.quantity += pickQty(r);
     termMap.set(term, entry);
   }
   const topTerms = Array.from(termMap.entries())
@@ -169,10 +183,7 @@ function summarize(rows: TradeRow[]): TradeSummary {
     if (!r.Exporter) continue;
     const entry = exporterMap.get(r.Exporter) || { records: 0, quantity: 0 };
     entry.records++;
-    entry.quantity += Math.max(
-      parseQty(r["Importer reported quantity"]),
-      parseQty(r["Exporter reported quantity"])
-    );
+    entry.quantity += pickQty(r);
     exporterMap.set(r.Exporter, entry);
   }
   const topExporters = Array.from(exporterMap.entries())
@@ -186,10 +197,7 @@ function summarize(rows: TradeRow[]): TradeSummary {
     if (!r.Importer) continue;
     const entry = importerMap.get(r.Importer) || { records: 0, quantity: 0 };
     entry.records++;
-    entry.quantity += Math.max(
-      parseQty(r["Importer reported quantity"]),
-      parseQty(r["Exporter reported quantity"])
-    );
+    entry.quantity += pickQty(r);
     importerMap.set(r.Importer, entry);
   }
   const topImporters = Array.from(importerMap.entries())
@@ -204,10 +212,7 @@ function summarize(rows: TradeRow[]): TradeSummary {
     const key = `${r.Exporter}->${r.Importer}`;
     const entry = flowMap.get(key) || { records: 0, quantity: 0 };
     entry.records++;
-    entry.quantity += Math.max(
-      parseQty(r["Importer reported quantity"]),
-      parseQty(r["Exporter reported quantity"])
-    );
+    entry.quantity += pickQty(r);
     flowMap.set(key, entry);
   }
   const topFlows = Array.from(flowMap.entries())
@@ -224,12 +229,13 @@ function summarize(rows: TradeRow[]): TradeSummary {
     s: r.Source || "",
     p: r.Purpose || "",
     t: r.Term || "unspecified",
-    q: Math.max(
-      parseQty(r["Importer reported quantity"]),
-      parseQty(r["Exporter reported quantity"])
-    ),
+    u: r.Unit || "",
+    q: pickQty(r),
     e: r.Exporter || "",
     i: r.Importer || "",
+    // Origin only carried when it's a genuine re-export (origin differs from
+    // the exporter); otherwise empty to keep the payload small.
+    o: r.Origin && r.Origin !== r.Exporter ? r.Origin : "",
   }));
 
   // All unique sources (not just top 6)
@@ -255,6 +261,24 @@ function summarize(rows: TradeRow[]): TradeSummary {
     .sort(([, a], [, b]) => b.records - a.records)
     .map(([term, v]) => ({ term, records: v.records }));
 
+  // Terms grouped by term + unit — quantities are never summed across units.
+  const termUnitMap = new Map<
+    string,
+    { term: string; unit: string; quantity: number; records: number }
+  >();
+  for (const r of rows) {
+    const term = r.Term || "unspecified";
+    const unit = r.Unit || "";
+    const key = `${term} ${unit}`;
+    const entry = termUnitMap.get(key) || { term, unit, quantity: 0, records: 0 };
+    entry.records++;
+    entry.quantity += pickQty(r);
+    termUnitMap.set(key, entry);
+  }
+  const allTermsByUnit = Array.from(termUnitMap.values()).sort(
+    (a, b) => b.records - a.records
+  );
+
   return {
     totalRecords: rows.length,
     yearRange,
@@ -269,6 +293,7 @@ function summarize(rows: TradeRow[]): TradeSummary {
     allSources,
     allPurposes,
     allTerms,
+    allTermsByUnit,
   };
 }
 
@@ -295,9 +320,12 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    // Fetch last 10 years of comparative tabulation data
+    // Fetch the full available history. CITES entered into force in 1975, so
+    // there is no trade data before then. Using a fixed early start (rather
+    // than a rolling N-year window) means early records — e.g. Panthera leo
+    // back to 1977 — are no longer cut off.
     const currentYear = new Date().getFullYear();
-    const startYear = currentYear - 10;
+    const startYear = 1975;
 
     const params = new URLSearchParams({
       "filters[taxon_concepts_ids][]": taxonId,

--- a/app/src/components/CitesSummary.tsx
+++ b/app/src/components/CitesSummary.tsx
@@ -262,6 +262,73 @@ export default function CitesSummary({
         </div>
       )}
 
+      {/* Current listings detail — below trade overview, above suspensions/quotas */}
+      {data.currentListings && data.currentListings.length > 0 && (
+        <div>
+          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
+            Current Listings
+          </h4>
+          <div className="space-y-2">
+            {data.currentListings.map((listing, i) => (
+              <div
+                key={i}
+                className="flex flex-wrap items-start gap-2 text-sm"
+              >
+                <AppendixBadge appendix={listing.appendix} />
+                <span className="text-zinc-500 dark:text-zinc-400 text-xs mt-0.5">
+                  since{" "}
+                  {new Date(listing.effectiveAt).toLocaleDateString("en-GB", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </span>
+                {listing.annotation && (
+                  <p className="w-full text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 pl-0.5">
+                    {listing.annotation}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Reservations — country-specific opt-outs from a listing */}
+      {data.reservations && data.reservations.length > 0 && (
+        <div>
+          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
+            Reservations ({data.reservations.length})
+          </h4>
+          <div className="space-y-2">
+            {data.reservations.map((r, i) => (
+              <div
+                key={i}
+                className="flex flex-wrap items-start gap-2 text-sm"
+              >
+                <AppendixBadge appendix={r.appendix} />
+                <span className="text-zinc-700 dark:text-zinc-300">
+                  {r.country || r.countryCode || "Unknown party"}
+                </span>
+                <span className="text-zinc-500 dark:text-zinc-400 text-xs mt-0.5">
+                  since{" "}
+                  {new Date(r.effectiveAt).toLocaleDateString("en-GB", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </span>
+                {r.annotation && (
+                  <p className="w-full text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 pl-0.5">
+                    {r.annotation}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Trade suspensions */}
       {data.suspensions && data.suspensions.length > 0 && (
         <div>
@@ -387,73 +454,6 @@ export default function CitesSummary({
                   : `Show all ${data.quotas.length} quotas`}
               </button>
             )}
-          </div>
-        </div>
-      )}
-
-      {/* Current listings detail — shown below the trade info */}
-      {data.currentListings && data.currentListings.length > 0 && (
-        <div>
-          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-            Current Listings
-          </h4>
-          <div className="space-y-2">
-            {data.currentListings.map((listing, i) => (
-              <div
-                key={i}
-                className="flex flex-wrap items-start gap-2 text-sm"
-              >
-                <AppendixBadge appendix={listing.appendix} />
-                <span className="text-zinc-500 dark:text-zinc-400 text-xs mt-0.5">
-                  since{" "}
-                  {new Date(listing.effectiveAt).toLocaleDateString("en-GB", {
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                  })}
-                </span>
-                {listing.annotation && (
-                  <p className="w-full text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 pl-0.5">
-                    {listing.annotation}
-                  </p>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Reservations — country-specific opt-outs from a listing */}
-      {data.reservations && data.reservations.length > 0 && (
-        <div>
-          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-            Reservations ({data.reservations.length})
-          </h4>
-          <div className="space-y-2">
-            {data.reservations.map((r, i) => (
-              <div
-                key={i}
-                className="flex flex-wrap items-start gap-2 text-sm"
-              >
-                <AppendixBadge appendix={r.appendix} />
-                <span className="text-zinc-700 dark:text-zinc-300">
-                  {r.country || r.countryCode || "Unknown party"}
-                </span>
-                <span className="text-zinc-500 dark:text-zinc-400 text-xs mt-0.5">
-                  since{" "}
-                  {new Date(r.effectiveAt).toLocaleDateString("en-GB", {
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                  })}
-                </span>
-                {r.annotation && (
-                  <p className="w-full text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 pl-0.5">
-                    {r.annotation}
-                  </p>
-                )}
-              </div>
-            ))}
           </div>
         </div>
       )}

--- a/app/src/components/CitesSummary.tsx
+++ b/app/src/components/CitesSummary.tsx
@@ -252,73 +252,6 @@ export default function CitesSummary({
         </div>
       </div>
 
-      {/* Current listings detail */}
-      {data.currentListings && data.currentListings.length > 0 && (
-        <div>
-          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-            Current Listings
-          </h4>
-          <div className="space-y-2">
-            {data.currentListings.map((listing, i) => (
-              <div
-                key={i}
-                className="flex flex-wrap items-start gap-2 text-sm"
-              >
-                <AppendixBadge appendix={listing.appendix} />
-                <span className="text-zinc-500 dark:text-zinc-400 text-xs mt-0.5">
-                  since{" "}
-                  {new Date(listing.effectiveAt).toLocaleDateString("en-GB", {
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                  })}
-                </span>
-                {listing.annotation && (
-                  <p className="w-full text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 pl-0.5">
-                    {listing.annotation}
-                  </p>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Reservations — country-specific opt-outs from a listing */}
-      {data.reservations && data.reservations.length > 0 && (
-        <div>
-          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-            Reservations ({data.reservations.length})
-          </h4>
-          <div className="space-y-2">
-            {data.reservations.map((r, i) => (
-              <div
-                key={i}
-                className="flex flex-wrap items-start gap-2 text-sm"
-              >
-                <AppendixBadge appendix={r.appendix} />
-                <span className="text-zinc-700 dark:text-zinc-300">
-                  {r.country || r.countryCode || "Unknown party"}
-                </span>
-                <span className="text-zinc-500 dark:text-zinc-400 text-xs mt-0.5">
-                  since{" "}
-                  {new Date(r.effectiveAt).toLocaleDateString("en-GB", {
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                  })}
-                </span>
-                {r.annotation && (
-                  <p className="w-full text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 pl-0.5">
-                    {r.annotation}
-                  </p>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
       {/* Trade overview from CITES Trade Database */}
       {data.citesId && (
         <div>
@@ -454,6 +387,73 @@ export default function CitesSummary({
                   : `Show all ${data.quotas.length} quotas`}
               </button>
             )}
+          </div>
+        </div>
+      )}
+
+      {/* Current listings detail — shown below the trade info */}
+      {data.currentListings && data.currentListings.length > 0 && (
+        <div>
+          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
+            Current Listings
+          </h4>
+          <div className="space-y-2">
+            {data.currentListings.map((listing, i) => (
+              <div
+                key={i}
+                className="flex flex-wrap items-start gap-2 text-sm"
+              >
+                <AppendixBadge appendix={listing.appendix} />
+                <span className="text-zinc-500 dark:text-zinc-400 text-xs mt-0.5">
+                  since{" "}
+                  {new Date(listing.effectiveAt).toLocaleDateString("en-GB", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </span>
+                {listing.annotation && (
+                  <p className="w-full text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 pl-0.5">
+                    {listing.annotation}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Reservations — country-specific opt-outs from a listing */}
+      {data.reservations && data.reservations.length > 0 && (
+        <div>
+          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
+            Reservations ({data.reservations.length})
+          </h4>
+          <div className="space-y-2">
+            {data.reservations.map((r, i) => (
+              <div
+                key={i}
+                className="flex flex-wrap items-start gap-2 text-sm"
+              >
+                <AppendixBadge appendix={r.appendix} />
+                <span className="text-zinc-700 dark:text-zinc-300">
+                  {r.country || r.countryCode || "Unknown party"}
+                </span>
+                <span className="text-zinc-500 dark:text-zinc-400 text-xs mt-0.5">
+                  since{" "}
+                  {new Date(r.effectiveAt).toLocaleDateString("en-GB", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </span>
+                {r.annotation && (
+                  <p className="w-full text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 pl-0.5">
+                    {r.annotation}
+                  </p>
+                )}
+              </div>
+            ))}
           </div>
         </div>
       )}

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+} from "react";
 import dynamic from "next/dynamic";
 import {
   LineChart,
@@ -12,7 +18,7 @@ import {
   CartesianGrid,
 } from "recharts";
 import { countryName, fmtQty } from "./cites-utils";
-import type { CountryAnnotation } from "./TradeFlowMap";
+import type { CountryAnnotation, TradeFlow } from "./TradeFlowMap";
 
 const TradeFlowMap = dynamic(() => import("./TradeFlowMap"), { ssr: false });
 
@@ -25,19 +31,15 @@ interface CompactRecord {
   s: string;
   p: string;
   t: string;
+  u: string; // unit ("" = unit-less)
   q: number;
   e: string;
   i: string;
+  o: string; // origin (re-export) — "" when same as exporter
 }
 
 interface YearData {
   year: number;
-  quantity: number;
-  records: number;
-}
-
-interface TermData {
-  term: string;
   quantity: number;
   records: number;
 }
@@ -53,15 +55,15 @@ interface TermCount {
   records: number;
 }
 
-interface CountryData {
-  code: string;
+interface TermUnitData {
+  term: string;
+  unit: string;
   records: number;
   quantity: number;
 }
 
-interface FlowData {
-  from: string;
-  to: string;
+interface CountryData {
+  code: string;
   records: number;
   quantity: number;
 }
@@ -72,16 +74,16 @@ interface TradeData {
   totalRecords: number;
   yearRange: [number, number];
   byYear: YearData[];
-  topTerms: TermData[];
   topPurposes: CodedData[];
   topSources: CodedData[];
   topExporters: CountryData[];
   topImporters: CountryData[];
-  topFlows?: FlowData[];
+  topFlows?: TradeFlow[];
   shipments?: CompactRecord[];
   allSources?: CodedData[];
   allPurposes?: CodedData[];
   allTerms?: TermCount[];
+  allTermsByUnit?: TermUnitData[];
 }
 
 // Sources that indicate wild take — key concern for assessors
@@ -114,6 +116,155 @@ const PURPOSE_LABELS: Record<string, string> = {
   T: "Commercial",
   Z: "Zoo",
 };
+
+/**
+ * Number of most-recent calendar years to treat as "provisional". CITES annual
+ * reports for year Y aren't due until 31 Oct of Y+1 and many Parties run years
+ * behind, so the most recent years are always under-reported. We draw them
+ * dashed + caption them rather than letting the line mislead readers into
+ * thinking trade collapsed.
+ */
+const PROVISIONAL_YEARS = 3;
+
+/** Stable key for a term+unit combination. */
+function termUnitKey(term: string, unit: string): string {
+  return `${term}|${unit}`;
+}
+
+function unitLabel(unit: string): string {
+  return unit || "no unit";
+}
+
+/* ------------------------------------------------------------------ */
+/*  Aggregation                                                        */
+/* ------------------------------------------------------------------ */
+
+interface Aggregated {
+  totalRecords: number;
+  byYear: YearData[];
+  topSources: CodedData[];
+  topPurposes: CodedData[];
+  topExporters: CountryData[];
+  topImporters: CountryData[];
+  topFlows: TradeFlow[];
+  reExportFlows: TradeFlow[];
+  termsByUnit: TermUnitData[];
+}
+
+/** Aggregate a set of compact shipment records into the derived views. */
+function aggregateShipments(rows: CompactRecord[]): Aggregated {
+  const yearMap = new Map<number, { quantity: number; records: number }>();
+  const sourceMap = new Map<string, number>();
+  const purposeMap = new Map<string, number>();
+  const exporterMap = new Map<string, { records: number; quantity: number }>();
+  const importerMap = new Map<string, { records: number; quantity: number }>();
+  const flowMap = new Map<string, { records: number; quantity: number }>();
+  const reExportMap = new Map<string, { records: number; quantity: number }>();
+  const termUnitMap = new Map<string, TermUnitData>();
+
+  for (const r of rows) {
+    const yEntry = yearMap.get(r.y) || { quantity: 0, records: 0 };
+    yEntry.records++;
+    yEntry.quantity += r.q;
+    yearMap.set(r.y, yEntry);
+
+    if (r.s) sourceMap.set(r.s, (sourceMap.get(r.s) || 0) + 1);
+    if (r.p) purposeMap.set(r.p, (purposeMap.get(r.p) || 0) + 1);
+
+    if (r.e) {
+      const e = exporterMap.get(r.e) || { records: 0, quantity: 0 };
+      e.records++;
+      e.quantity += r.q;
+      exporterMap.set(r.e, e);
+    }
+    if (r.i) {
+      const e = importerMap.get(r.i) || { records: 0, quantity: 0 };
+      e.records++;
+      e.quantity += r.q;
+      importerMap.set(r.i, e);
+    }
+    if (r.e && r.i) {
+      const key = `${r.e}->${r.i}`;
+      const e = flowMap.get(key) || { records: 0, quantity: 0 };
+      e.records++;
+      e.quantity += r.q;
+      flowMap.set(key, e);
+    }
+    // Re-export leg: where specimens originated (origin) before the exporter
+    if (r.o && r.e) {
+      const key = `${r.o}->${r.e}`;
+      const e = reExportMap.get(key) || { records: 0, quantity: 0 };
+      e.records++;
+      e.quantity += r.q;
+      reExportMap.set(key, e);
+    }
+
+    const tuKey = termUnitKey(r.t, r.u);
+    const tu = termUnitMap.get(tuKey) || {
+      term: r.t,
+      unit: r.u,
+      records: 0,
+      quantity: 0,
+    };
+    tu.records++;
+    tu.quantity += r.q;
+    termUnitMap.set(tuKey, tu);
+  }
+
+  const byYear = Array.from(yearMap.entries())
+    .sort(([a], [b]) => a - b)
+    .map(([year, v]) => ({ year, ...v }));
+
+  const topSources = Array.from(sourceMap.entries())
+    .sort(([, a], [, b]) => b - a)
+    .map(([code, records]) => ({ code, label: SOURCE_LABELS[code] || code, records }));
+
+  const topPurposes = Array.from(purposeMap.entries())
+    .sort(([, a], [, b]) => b - a)
+    .map(([code, records]) => ({ code, label: PURPOSE_LABELS[code] || code, records }));
+
+  const topExporters = Array.from(exporterMap.entries())
+    .sort(([, a], [, b]) => b.records - a.records)
+    .slice(0, 8)
+    .map(([code, v]) => ({ code, ...v }));
+
+  const topImporters = Array.from(importerMap.entries())
+    .sort(([, a], [, b]) => b.records - a.records)
+    .slice(0, 8)
+    .map(([code, v]) => ({ code, ...v }));
+
+  const topFlows = Array.from(flowMap.entries())
+    .sort(([, a], [, b]) => b.records - a.records)
+    .slice(0, 12)
+    .map(([key, v]) => {
+      const [from, to] = key.split("->");
+      return { from, to, ...v };
+    });
+
+  const reExportFlows = Array.from(reExportMap.entries())
+    .sort(([, a], [, b]) => b.records - a.records)
+    .slice(0, 12)
+    .map(([key, v]) => {
+      const [from, to] = key.split("->");
+      return { from, to, ...v };
+    });
+
+  const termsByUnit = Array.from(termUnitMap.values()).sort(
+    (a, b) => b.records - a.records
+  );
+
+  return {
+    totalRecords: rows.length,
+    byYear,
+    topSources,
+    topPurposes,
+    topExporters,
+    topImporters,
+    topFlows,
+    reExportFlows,
+    termsByUnit,
+  };
+}
 
 /* ------------------------------------------------------------------ */
 /*  Filter checkbox row                                                */
@@ -149,10 +300,10 @@ function FilterCheckbox({
         className="w-3.5 h-3.5 rounded shrink-0"
         style={color ? { accentColor: color } : undefined}
       />
-      <span className="flex-1 text-xs text-zinc-700 dark:text-zinc-300 truncate">
+      <span className="flex-1 text-xs text-zinc-700 dark:text-zinc-300 truncate capitalize">
         {label}
         {sublabel && (
-          <span className="text-zinc-400 dark:text-zinc-500 ml-1">
+          <span className="text-zinc-400 dark:text-zinc-500 ml-1 normal-case">
             ({sublabel})
           </span>
         )}
@@ -164,64 +315,316 @@ function FilterCheckbox({
   );
 }
 
+/** Section header with All / None bulk-select buttons. */
+function FilterSectionHeader({
+  title,
+  onAll,
+  onNone,
+}: {
+  title: string;
+  onAll: () => void;
+  onNone: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between mb-1.5">
+      <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+        {title}
+      </h5>
+      <div className="flex items-center gap-1 text-[10px]">
+        <button
+          className="text-blue-600 dark:text-blue-400 hover:underline"
+          onClick={onAll}
+        >
+          All
+        </button>
+        <span className="text-zinc-300 dark:text-zinc-600">/</span>
+        <button
+          className="text-blue-600 dark:text-blue-400 hover:underline"
+          onClick={onNone}
+        >
+          None
+        </button>
+      </div>
+    </div>
+  );
+}
+
 /* ------------------------------------------------------------------ */
-/*  Trend line chart                                                   */
+/*  Trend line chart with draggable year-range trim handles            */
 /* ------------------------------------------------------------------ */
+
+interface ChartPoint {
+  year: number;
+  solid: number | null;
+  prov: number | null;
+}
+
+function ChartTooltip({
+  active,
+  payload,
+  label,
+  metric,
+  provisionalFromYear,
+}: {
+  active?: boolean;
+  payload?: { value: number | null; dataKey: string }[];
+  label?: number;
+  metric: "records" | "quantity";
+  provisionalFromYear: number;
+}) {
+  if (!active || !payload || payload.length === 0) return null;
+  const point = payload.find((p) => p.value != null);
+  if (!point) return null;
+  const isProvisional = label != null && label >= provisionalFromYear;
+  return (
+    <div className="bg-zinc-900 border border-zinc-700 rounded-lg text-xs px-2.5 py-1.5">
+      <div className="text-zinc-400">{label}</div>
+      <div className="text-white tabular-nums">
+        {(point.value ?? 0).toLocaleString()}{" "}
+        {metric === "records" ? "shipments" : "items"}
+      </div>
+      {isProvisional && (
+        <div className="text-amber-400 text-[10px] mt-0.5">
+          provisional — incomplete reporting
+        </div>
+      )}
+    </div>
+  );
+}
 
 function TrendLineChart({
   data,
   metric,
+  minYear,
+  maxYear,
+  brush,
+  onBrushChange,
+  provisionalFromYear,
 }: {
   data: YearData[];
   metric: "records" | "quantity";
+  minYear: number;
+  maxYear: number;
+  brush: [number, number] | null;
+  onBrushChange: (range: [number, number] | null) => void;
+  provisionalFromYear: number;
 }) {
-  if (data.length === 0) return null;
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+  const dragging = useRef<null | "start" | "end">(null);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    setWidth(el.clientWidth);
+    const ro = new ResizeObserver((entries) => {
+      for (const e of entries) setWidth(e.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Chart geometry must mirror the recharts margins + YAxis width below.
+  const HEIGHT = 160;
+  const PLOT_LEFT = 45; // YAxis width
+  const PLOT_RIGHT_PAD = 10; // margin.right
+  const TRACK_TOP = 4;
+  const TRACK_BOTTOM = 132; // leave room for x-axis labels
+  const plotRight = Math.max(PLOT_LEFT + 1, width - PLOT_RIGHT_PAD);
+  const plotW = plotRight - PLOT_LEFT;
+  const span = Math.max(1, maxYear - minYear);
+
+  const xOf = useCallback(
+    (year: number) => PLOT_LEFT + ((year - minYear) / span) * plotW,
+    [minYear, span, plotW]
+  );
+  const yearOf = useCallback(
+    (px: number) => {
+      const clamped = Math.min(plotRight, Math.max(PLOT_LEFT, px));
+      return Math.round(minYear + ((clamped - PLOT_LEFT) / plotW) * span);
+    },
+    [minYear, span, plotW, plotRight]
+  );
+
+  const start = brush ? brush[0] : minYear;
+  const end = brush ? brush[1] : maxYear;
+
+  // Build chart series: solid up to the last complete year, dashed beyond.
+  const lastComplete = provisionalFromYear - 1;
+  const lookup = new Map(data.map((d) => [d.year, d[metric]]));
+  const chartData: ChartPoint[] = [];
+  for (let y = minYear; y <= maxYear; y++) {
+    const v = lookup.get(y) ?? 0;
+    chartData.push({
+      year: y,
+      solid: y <= lastComplete ? v : null,
+      // include the junction year so the dashed segment connects to the solid one
+      prov: y >= lastComplete ? v : null,
+    });
+  }
+  const hasProvisional = maxYear >= provisionalFromYear;
+
+  function onHandleDown(which: "start" | "end") {
+    return (e: React.PointerEvent) => {
+      e.preventDefault();
+      dragging.current = which;
+      (e.target as Element).setPointerCapture(e.pointerId);
+    };
+  }
+  function onHandleMove(e: React.PointerEvent) {
+    if (!dragging.current || !wrapRef.current) return;
+    const rect = wrapRef.current.getBoundingClientRect();
+    const year = yearOf(e.clientX - rect.left);
+    let nextStart = start;
+    let nextEnd = end;
+    if (dragging.current === "start") nextStart = Math.min(year, end);
+    else nextEnd = Math.max(year, start);
+    if (nextStart <= minYear && nextEnd >= maxYear) onBrushChange(null);
+    else onBrushChange([nextStart, nextEnd]);
+  }
+  function onHandleUp() {
+    dragging.current = null;
+  }
+
+  const startX = xOf(start);
+  const endX = xOf(end);
+  const active = brush !== null;
 
   return (
-    <ResponsiveContainer width="100%" height={160}>
-      <LineChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
-        <CartesianGrid
-          strokeDasharray="3 3"
-          stroke="currentColor"
-          className="text-zinc-200 dark:text-zinc-700"
-        />
-        <XAxis
-          dataKey="year"
-          tick={{ fontSize: 11, fill: "#a1a1aa" }}
-          tickLine={false}
-          axisLine={false}
-        />
-        <YAxis
-          tick={{ fontSize: 11, fill: "#a1a1aa" }}
-          tickLine={false}
-          axisLine={false}
-          width={45}
-          tickFormatter={(v: number) => fmtQty(v)}
-        />
-        <Tooltip
-          contentStyle={{
-            backgroundColor: "#18181b",
-            border: "1px solid #3f3f46",
-            borderRadius: "8px",
-            fontSize: 12,
-          }}
-          itemStyle={{ color: "#fff" }}
-          labelStyle={{ color: "#a1a1aa" }}
-          formatter={(value: number) => [
-            value.toLocaleString(),
-            metric === "records" ? "Shipments" : "Items",
-          ]}
-        />
-        <Line
-          type="monotone"
-          dataKey={metric}
-          stroke="#3b82f6"
-          strokeWidth={2}
-          dot={{ r: 3, fill: "#3b82f6", strokeWidth: 0 }}
-          activeDot={{ r: 5, fill: "#3b82f6", strokeWidth: 2, stroke: "#fff" }}
-        />
-      </LineChart>
-    </ResponsiveContainer>
+    <div ref={wrapRef} className="relative" style={{ touchAction: "none" }}>
+      <ResponsiveContainer width="100%" height={HEIGHT}>
+        <LineChart
+          data={chartData}
+          margin={{ top: 5, right: PLOT_RIGHT_PAD, left: 0, bottom: 5 }}
+        >
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="currentColor"
+            className="text-zinc-200 dark:text-zinc-700"
+          />
+          <XAxis
+            dataKey="year"
+            type="number"
+            domain={[minYear, maxYear]}
+            allowDecimals={false}
+            tick={{ fontSize: 11, fill: "#a1a1aa" }}
+            tickLine={false}
+            axisLine={false}
+          />
+          <YAxis
+            tick={{ fontSize: 11, fill: "#a1a1aa" }}
+            tickLine={false}
+            axisLine={false}
+            width={PLOT_LEFT}
+            tickFormatter={(v: number) => fmtQty(v)}
+          />
+          <Tooltip
+            content={
+              <ChartTooltip
+                metric={metric}
+                provisionalFromYear={provisionalFromYear}
+              />
+            }
+          />
+          <Line
+            type="monotone"
+            dataKey="solid"
+            stroke="#3b82f6"
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 4, fill: "#3b82f6", strokeWidth: 2, stroke: "#fff" }}
+            connectNulls={false}
+            isAnimationActive={false}
+          />
+          {hasProvisional && (
+            <Line
+              type="monotone"
+              dataKey="prov"
+              stroke="#3b82f6"
+              strokeWidth={2}
+              strokeDasharray="4 3"
+              strokeOpacity={0.55}
+              dot={false}
+              activeDot={{ r: 4, fill: "#3b82f6", strokeWidth: 2, stroke: "#fff" }}
+              connectNulls={false}
+              isAnimationActive={false}
+            />
+          )}
+        </LineChart>
+      </ResponsiveContainer>
+
+      {/* Trim overlay: dimmed regions outside the selected range + drag handles */}
+      {width > 0 && (
+        <svg
+          ref={svgRef}
+          className="absolute inset-0"
+          width={width}
+          height={HEIGHT}
+          style={{ pointerEvents: "none" }}
+        >
+          {active && startX > PLOT_LEFT && (
+            <rect
+              x={PLOT_LEFT}
+              y={TRACK_TOP}
+              width={Math.max(0, startX - PLOT_LEFT)}
+              height={TRACK_BOTTOM - TRACK_TOP}
+              className="fill-zinc-400/15 dark:fill-zinc-900/40"
+            />
+          )}
+          {active && endX < plotRight && (
+            <rect
+              x={endX}
+              y={TRACK_TOP}
+              width={Math.max(0, plotRight - endX)}
+              height={TRACK_BOTTOM - TRACK_TOP}
+              className="fill-zinc-400/15 dark:fill-zinc-900/40"
+            />
+          )}
+          {/* Handles */}
+          {[
+            { which: "start" as const, x: startX },
+            { which: "end" as const, x: endX },
+          ].map(({ which, x }) => (
+            <g
+              key={which}
+              transform={`translate(${x},0)`}
+              style={{ cursor: "ew-resize", pointerEvents: "all" }}
+              onPointerDown={onHandleDown(which)}
+              onPointerMove={onHandleMove}
+              onPointerUp={onHandleUp}
+            >
+              {/* wide invisible hit target */}
+              <rect
+                x={-7}
+                y={TRACK_TOP}
+                width={14}
+                height={TRACK_BOTTOM - TRACK_TOP}
+                fill="transparent"
+              />
+              <line
+                x1={0}
+                y1={TRACK_TOP}
+                x2={0}
+                y2={TRACK_BOTTOM}
+                stroke="#3b82f6"
+                strokeWidth={active ? 2 : 1.5}
+                strokeOpacity={active ? 0.9 : 0.5}
+              />
+              <rect
+                x={-3}
+                y={TRACK_TOP}
+                width={6}
+                height={16}
+                rx={2}
+                fill="#3b82f6"
+                fillOpacity={active ? 1 : 0.6}
+              />
+            </g>
+          ))}
+        </svg>
+      )}
+    </div>
   );
 }
 
@@ -229,14 +632,21 @@ function TrendLineChart({
 /*  Trend summary text                                                 */
 /* ------------------------------------------------------------------ */
 
-function TrendSummary({ data, metric }: { data: YearData[]; metric: "records" | "quantity" }) {
+function TrendSummary({
+  data,
+  metric,
+}: {
+  data: YearData[];
+  metric: "records" | "quantity";
+}) {
   if (data.length < 4) return null;
   const mid = Math.floor(data.length / 2);
   const firstHalf = data.slice(0, mid);
   const secondHalf = data.slice(mid);
   const key = metric;
   const avgFirst = firstHalf.reduce((s, d) => s + d[key], 0) / firstHalf.length;
-  const avgSecond = secondHalf.reduce((s, d) => s + d[key], 0) / secondHalf.length;
+  const avgSecond =
+    secondHalf.reduce((s, d) => s + d[key], 0) / secondHalf.length;
   if (avgFirst === 0 && avgSecond === 0) return null;
   const pctChange = avgFirst === 0 ? 100 : ((avgSecond - avgFirst) / avgFirst) * 100;
 
@@ -316,15 +726,9 @@ function SourceBreakdown({ sources }: { sources: CodedData[] }) {
 /*  Country table                                                      */
 /* ------------------------------------------------------------------ */
 
-function CountryTable({
-  data,
-  label,
-}: {
-  data: CountryData[];
-  label: string;
-}) {
+function CountryTable({ data, label }: { data: CountryData[]; label: string }) {
   if (data.length === 0) return null;
-  const top = [...data].sort((a, b) => b.quantity - a.quantity).slice(0, 5);
+  const top = [...data].sort((a, b) => b.records - a.records).slice(0, 5);
 
   return (
     <div>
@@ -335,8 +739,7 @@ function CountryTable({
         <thead>
           <tr className="text-left text-zinc-400 dark:text-zinc-500">
             <th className="font-medium pb-1 pr-2">Country</th>
-            <th className="font-medium pb-1 pr-2 text-right">Records</th>
-            <th className="font-medium pb-1 text-right">Quantity</th>
+            <th className="font-medium pb-1 text-right">Records</th>
           </tr>
         </thead>
         <tbody>
@@ -351,11 +754,8 @@ function CountryTable({
                   ({c.code})
                 </span>
               </td>
-              <td className="py-1 pr-2 text-right text-zinc-500 dark:text-zinc-400 tabular-nums">
-                {c.records.toLocaleString()}
-              </td>
               <td className="py-1 text-right text-zinc-500 dark:text-zinc-400 tabular-nums">
-                {fmtQty(c.quantity)}
+                {c.records.toLocaleString()}
               </td>
             </tr>
           ))}
@@ -396,6 +796,10 @@ export default function CitesTradeSummary({
   const [checkedPurposes, setCheckedPurposes] = useState<Record<string, boolean>>({});
   const [checkedTerms, setCheckedTerms] = useState<Record<string, boolean>>({});
   const [filtersInitialized, setFiltersInitialized] = useState(false);
+  const [termSearch, setTermSearch] = useState("");
+
+  // Year-range trim (null = full range)
+  const [brush, setBrush] = useState<[number, number] | null>(null);
 
   // Use prefetched data from parent when available; fall back to own fetch
   const data = (prefetchedData as TradeData | null) ?? ownData;
@@ -442,9 +846,9 @@ export default function CitesTradeSummary({
       for (const p of data.allPurposes) init[p.code] = true;
       setCheckedPurposes(init);
     }
-    if (data.allTerms) {
+    if (data.allTermsByUnit) {
       const init: Record<string, boolean> = {};
-      for (const t of data.allTerms) init[t.term] = true;
+      for (const t of data.allTermsByUnit) init[termUnitKey(t.term, t.unit)] = true;
       setCheckedTerms(init);
     }
     setFiltersInitialized(true);
@@ -457,19 +861,44 @@ export default function CitesTradeSummary({
   const togglePurpose = useCallback((code: string) => {
     setCheckedPurposes((prev) => ({ ...prev, [code]: !prev[code] }));
   }, []);
-  const toggleTerm = useCallback((term: string) => {
-    setCheckedTerms((prev) => ({ ...prev, [term]: !prev[term] }));
+  const toggleTerm = useCallback((key: string) => {
+    setCheckedTerms((prev) => ({ ...prev, [key]: !prev[key] }));
   }, []);
 
-  // Are any filters active (i.e. something is unchecked)?
+  const setAll = useCallback(
+    (
+      setter: React.Dispatch<React.SetStateAction<Record<string, boolean>>>,
+      keys: string[],
+      value: boolean
+    ) => {
+      setter((prev) => {
+        const next = { ...prev };
+        for (const k of keys) next[k] = value;
+        return next;
+      });
+    },
+    []
+  );
+
+  // Commodity rows filtered by the search box
+  const visibleTermRows = useMemo(() => {
+    const rows = data?.allTermsByUnit ?? [];
+    const q = termSearch.trim().toLowerCase();
+    if (!q) return rows;
+    return rows.filter((t) =>
+      `${t.term} ${t.unit}`.toLowerCase().includes(q)
+    );
+  }, [data?.allTermsByUnit, termSearch]);
+
+  // Are any filters active (something unchecked, or a year range trimmed)?
   const hasActiveFilters = useMemo(() => {
     const anySourceOff = Object.values(checkedSources).some((v) => !v);
     const anyPurposeOff = Object.values(checkedPurposes).some((v) => !v);
     const anyTermOff = Object.values(checkedTerms).some((v) => !v);
-    return anySourceOff || anyPurposeOff || anyTermOff;
-  }, [checkedSources, checkedPurposes, checkedTerms]);
+    return anySourceOff || anyPurposeOff || anyTermOff || brush !== null;
+  }, [checkedSources, checkedPurposes, checkedTerms, brush]);
 
-  // Clear all filters (re-check everything)
+  // Clear all filters (re-check everything, reset the year trim)
   const clearFilters = useCallback(() => {
     setCheckedSources((prev) => {
       const next = { ...prev };
@@ -486,146 +915,33 @@ export default function CitesTradeSummary({
       for (const k of Object.keys(next)) next[k] = true;
       return next;
     });
+    setBrush(null);
+    setTermSearch("");
   }, []);
 
-  // Filter shipments and recompute all derived data
-  const filtered = useMemo(() => {
-    if (!data?.found || !data.shipments) {
-      return {
-        byYear: data?.byYear || [],
-        totalRecords: data?.totalRecords || 0,
-        totalQty: data?.byYear?.reduce((s, d) => s + d.quantity, 0) || 0,
-        topTerms: data?.topTerms || [],
-        topSources: data?.topSources || [],
-        topPurposes: data?.topPurposes || [],
-        topExporters: data?.topExporters || [],
-        topImporters: data?.topImporters || [],
-        topFlows: data?.topFlows || [],
-      };
-    }
-
-    const rows = data.shipments.filter((r) => {
-      if (!checkedSources[r.s] && r.s) return false;
-      if (!checkedPurposes[r.p] && r.p) return false;
-      if (!checkedTerms[r.t]) return false;
+  // Shipments passing the checkbox filters (all years) — drives the chart line.
+  const checkboxRows = useMemo(() => {
+    if (!data?.found || !data.shipments) return [];
+    return data.shipments.filter((r) => {
+      if (r.s && checkedSources[r.s] === false) return false;
+      if (r.p && checkedPurposes[r.p] === false) return false;
+      if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
       return true;
     });
-
-    // byYear
-    const yearMap = new Map<number, { quantity: number; records: number }>();
-    for (const r of rows) {
-      const entry = yearMap.get(r.y) || { quantity: 0, records: 0 };
-      entry.records++;
-      entry.quantity += r.q;
-      yearMap.set(r.y, entry);
-    }
-    // Ensure all years in range are present (even if 0)
-    if (data.yearRange) {
-      for (let y = data.yearRange[0]; y <= data.yearRange[1]; y++) {
-        if (!yearMap.has(y)) yearMap.set(y, { quantity: 0, records: 0 });
-      }
-    }
-    const byYear = Array.from(yearMap.entries())
-      .sort(([a], [b]) => a - b)
-      .map(([year, v]) => ({ year, ...v }));
-
-    // terms
-    const termMap = new Map<string, { quantity: number; records: number }>();
-    for (const r of rows) {
-      const entry = termMap.get(r.t) || { quantity: 0, records: 0 };
-      entry.records++;
-      entry.quantity += r.q;
-      termMap.set(r.t, entry);
-    }
-    const topTerms = Array.from(termMap.entries())
-      .sort(([, a], [, b]) => b.records - a.records)
-      .slice(0, 8)
-      .map(([term, v]) => ({ term, ...v }));
-
-    // sources
-    const sourceMap = new Map<string, number>();
-    for (const r of rows) {
-      if (r.s) sourceMap.set(r.s, (sourceMap.get(r.s) || 0) + 1);
-    }
-    const topSources = Array.from(sourceMap.entries())
-      .sort(([, a], [, b]) => b - a)
-      .map(([code, records]) => ({
-        code,
-        label: SOURCE_LABELS[code] || code,
-        records,
-      }));
-
-    // purposes
-    const purposeMap = new Map<string, number>();
-    for (const r of rows) {
-      if (r.p) purposeMap.set(r.p, (purposeMap.get(r.p) || 0) + 1);
-    }
-    const topPurposes = Array.from(purposeMap.entries())
-      .sort(([, a], [, b]) => b - a)
-      .map(([code, records]) => ({
-        code,
-        label: PURPOSE_LABELS[code] || code,
-        records,
-      }));
-
-    // exporters
-    const exporterMap = new Map<string, { records: number; quantity: number }>();
-    for (const r of rows) {
-      if (!r.e) continue;
-      const entry = exporterMap.get(r.e) || { records: 0, quantity: 0 };
-      entry.records++;
-      entry.quantity += r.q;
-      exporterMap.set(r.e, entry);
-    }
-    const topExporters = Array.from(exporterMap.entries())
-      .sort(([, a], [, b]) => b.records - a.records)
-      .slice(0, 8)
-      .map(([code, v]) => ({ code, ...v }));
-
-    // importers
-    const importerMap = new Map<string, { records: number; quantity: number }>();
-    for (const r of rows) {
-      if (!r.i) continue;
-      const entry = importerMap.get(r.i) || { records: 0, quantity: 0 };
-      entry.records++;
-      entry.quantity += r.q;
-      importerMap.set(r.i, entry);
-    }
-    const topImporters = Array.from(importerMap.entries())
-      .sort(([, a], [, b]) => b.records - a.records)
-      .slice(0, 8)
-      .map(([code, v]) => ({ code, ...v }));
-
-    // flows
-    const flowMap = new Map<string, { records: number; quantity: number }>();
-    for (const r of rows) {
-      if (!r.e || !r.i) continue;
-      const key = `${r.e}->${r.i}`;
-      const entry = flowMap.get(key) || { records: 0, quantity: 0 };
-      entry.records++;
-      entry.quantity += r.q;
-      flowMap.set(key, entry);
-    }
-    const topFlows = Array.from(flowMap.entries())
-      .sort(([, a], [, b]) => b.records - a.records)
-      .slice(0, 12)
-      .map(([key, v]) => {
-        const [from, to] = key.split("->");
-        return { from, to, ...v };
-      });
-
-    return {
-      byYear,
-      totalRecords: rows.length,
-      totalQty: rows.reduce((s, r) => s + r.q, 0),
-      topTerms,
-      topSources,
-      topPurposes,
-      topExporters,
-      topImporters,
-      topFlows,
-    };
   }, [data, checkedSources, checkedPurposes, checkedTerms]);
+
+  // Chart series (all years, checkbox-filtered)
+  const chartAgg = useMemo(() => aggregateShipments(checkboxRows), [checkboxRows]);
+
+  // Everything else also respects the year-range trim
+  const display = useMemo(() => {
+    const rows = brush
+      ? checkboxRows.filter((r) => r.y >= brush[0] && r.y <= brush[1])
+      : checkboxRows;
+    return aggregateShipments(rows);
+  }, [checkboxRows, brush]);
+
+  const hasShipments = !!data?.shipments && data.shipments.length > 0;
 
   /* ---------------------------------------------------------------- */
   /*  Render                                                           */
@@ -634,11 +950,7 @@ export default function CitesTradeSummary({
   if (loading) {
     return (
       <div className="flex items-center gap-2 text-xs text-zinc-400 dark:text-zinc-500 py-3">
-        <svg
-          className="animate-spin h-3.5 w-3.5"
-          viewBox="0 0 24 24"
-          fill="none"
-        >
+        <svg className="animate-spin h-3.5 w-3.5" viewBox="0 0 24 24" fill="none">
           <circle
             className="opacity-25"
             cx="12"
@@ -662,27 +974,44 @@ export default function CitesTradeSummary({
     return null;
   }
 
-  const hasShipments = !!data.shipments && data.shipments.length > 0;
+  const [minYear, maxYear] = data.yearRange;
+  const currentYear = new Date().getFullYear();
+  const provisionalFromYear = currentYear - PROVISIONAL_YEARS + 1;
+  const effectiveRange: [number, number] = brush ?? data.yearRange;
+
+  // Fall back to server-provided byYear when no shipments for client filtering
+  const chartByYear =
+    hasShipments && chartAgg.byYear.length > 0 ? chartAgg.byYear : data.byYear;
+  const displaySources =
+    hasShipments && display.topSources.length > 0 ? display.topSources : data.topSources;
+  const displayPurposes =
+    hasShipments && display.topPurposes.length > 0 ? display.topPurposes : data.topPurposes;
+  const displayExporters =
+    hasShipments && display.topExporters.length > 0 ? display.topExporters : data.topExporters;
+  const displayImporters =
+    hasShipments && display.topImporters.length > 0 ? display.topImporters : data.topImporters;
+  const displayFlows =
+    hasShipments && display.topFlows.length > 0 ? display.topFlows : data.topFlows ?? [];
 
   return (
     <div className="space-y-4">
-      {/* Headline + trend */}
+      {/* Headline */}
       <div className="flex items-baseline gap-3 flex-wrap">
         <span className="text-sm text-zinc-700 dark:text-zinc-200">
           <span className="font-semibold tabular-nums">
-            {filtered.totalRecords.toLocaleString()}
+            {display.totalRecords.toLocaleString()}
           </span>{" "}
           shipments
-          <span className="text-zinc-400 dark:text-zinc-500 mx-1">/</span>
-          <span className="font-semibold tabular-nums">
-            {fmtQty(filtered.totalQty)}
-          </span>{" "}
-          reported items
           <span className="text-zinc-400 dark:text-zinc-500 ml-1">
-            {data.yearRange[0]}–{data.yearRange[1]}
+            {effectiveRange[0]}–{effectiveRange[1]}
           </span>
+          {brush && (
+            <span className="text-zinc-400 dark:text-zinc-500 ml-1">
+              (of {minYear}–{maxYear})
+            </span>
+          )}
         </span>
-        <TrendSummary data={filtered.byYear} metric={metric} />
+        <TrendSummary data={display.byYear} metric={metric} />
         {hasActiveFilters && (
           <button
             className="text-[11px] text-blue-600 dark:text-blue-400 hover:underline ml-auto"
@@ -694,35 +1023,44 @@ export default function CitesTradeSummary({
       </div>
 
       {/* Trade flow map */}
-      {filtered.topFlows && filtered.topFlows.length > 0 && (
-        <div>
-          <div className="border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden bg-zinc-50 dark:bg-zinc-800/30">
-            <TradeFlowMap
-              flows={filtered.topFlows}
-              suspensionCountries={suspensionCountries}
-              countryAnnotations={countryAnnotations}
-            />
-          </div>
+      {displayFlows.length > 0 && (
+        <div className="border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden bg-zinc-50 dark:bg-zinc-800/30">
+          <TradeFlowMap
+            flows={displayFlows}
+            reExportFlows={display.reExportFlows}
+            suspensionCountries={suspensionCountries}
+            countryAnnotations={countryAnnotations}
+          />
         </div>
       )}
 
       {/* Exporters & Importers */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <CountryTable data={filtered.topExporters} label="Top exporters" />
-        <CountryTable data={filtered.topImporters} label="Top importers" />
+        <CountryTable data={displayExporters} label="Top exporters" />
+        <CountryTable data={displayImporters} label="Top importers" />
       </div>
 
       {/* Filters + Chart side by side */}
-      <div className={`grid grid-cols-1 gap-4 ${hasShipments ? "md:grid-cols-[220px_1fr]" : ""}`}>
+      <div
+        className={`grid grid-cols-1 gap-4 ${
+          hasShipments ? "md:grid-cols-[230px_1fr]" : ""
+        }`}
+      >
         {/* Filter panel */}
         {hasShipments && (
-          <div className="space-y-3 border border-zinc-200 dark:border-zinc-700 rounded-lg p-3 bg-zinc-50/50 dark:bg-zinc-800/20 max-h-[500px] overflow-y-auto">
+          <div className="space-y-3 border border-zinc-200 dark:border-zinc-700 rounded-lg p-3 bg-zinc-50/50 dark:bg-zinc-800/20 max-h-[520px] overflow-y-auto">
             {/* Source filters */}
             {data.allSources && data.allSources.length > 0 && (
               <div>
-                <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
-                  Source
-                </h5>
+                <FilterSectionHeader
+                  title="Source"
+                  onAll={() =>
+                    setAll(setCheckedSources, data.allSources!.map((s) => s.code), true)
+                  }
+                  onNone={() =>
+                    setAll(setCheckedSources, data.allSources!.map((s) => s.code), false)
+                  }
+                />
                 <div className="space-y-1">
                   {data.allSources.map((s) => (
                     <FilterCheckbox
@@ -742,9 +1080,15 @@ export default function CitesTradeSummary({
             {/* Purpose filters */}
             {data.allPurposes && data.allPurposes.length > 0 && (
               <div>
-                <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
-                  Purpose
-                </h5>
+                <FilterSectionHeader
+                  title="Purpose"
+                  onAll={() =>
+                    setAll(setCheckedPurposes, data.allPurposes!.map((p) => p.code), true)
+                  }
+                  onNone={() =>
+                    setAll(setCheckedPurposes, data.allPurposes!.map((p) => p.code), false)
+                  }
+                />
                 <div className="space-y-1">
                   {data.allPurposes.map((p) => (
                     <FilterCheckbox
@@ -761,26 +1105,53 @@ export default function CitesTradeSummary({
               </div>
             )}
 
-            {/* Term/commodity filters */}
-            {data.allTerms && data.allTerms.length > 0 && (
+            {/* Commodity (term + unit) filters — searchable, no truncation */}
+            {data.allTermsByUnit && data.allTermsByUnit.length > 0 && (
               <div>
-                <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
-                  Commodity
-                </h5>
+                <FilterSectionHeader
+                  title="Commodity"
+                  onAll={() =>
+                    setAll(
+                      setCheckedTerms,
+                      visibleTermRows.map((t) => termUnitKey(t.term, t.unit)),
+                      true
+                    )
+                  }
+                  onNone={() =>
+                    setAll(
+                      setCheckedTerms,
+                      visibleTermRows.map((t) => termUnitKey(t.term, t.unit)),
+                      false
+                    )
+                  }
+                />
+                {data.allTermsByUnit.length > 6 && (
+                  <input
+                    type="text"
+                    value={termSearch}
+                    onChange={(e) => setTermSearch(e.target.value)}
+                    placeholder="Search commodities…"
+                    className="w-full mb-1.5 px-2 py-1 text-xs rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300 placeholder:text-zinc-400"
+                  />
+                )}
                 <div className="space-y-1">
-                  {data.allTerms.slice(0, 10).map((t) => (
-                    <FilterCheckbox
-                      key={t.term}
-                      label={t.term}
-                      count={t.records}
-                      checked={checkedTerms[t.term] ?? true}
-                      onChange={() => toggleTerm(t.term)}
-                      color="#8b5cf6"
-                    />
-                  ))}
-                  {data.allTerms.length > 10 && (
-                    <span className="text-[10px] text-zinc-400 dark:text-zinc-500">
-                      +{data.allTerms.length - 10} more
+                  {visibleTermRows.map((t) => {
+                    const key = termUnitKey(t.term, t.unit);
+                    return (
+                      <FilterCheckbox
+                        key={key}
+                        label={t.term}
+                        sublabel={unitLabel(t.unit)}
+                        count={t.records}
+                        checked={checkedTerms[key] ?? true}
+                        onChange={() => toggleTerm(key)}
+                        color="#8b5cf6"
+                      />
+                    );
+                  })}
+                  {visibleTermRows.length === 0 && (
+                    <span className="text-[11px] text-zinc-400 dark:text-zinc-500">
+                      No commodities match “{termSearch}”.
                     </span>
                   )}
                 </div>
@@ -791,12 +1162,17 @@ export default function CitesTradeSummary({
 
         {/* Chart + details */}
         <div className="space-y-4 min-w-0">
-          {/* Metric toggle + line chart */}
+          {/* Metric toggle + line chart with trim handles */}
           <div>
             <div className="flex items-center gap-2 mb-2">
               <span className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
                 Trade over time
               </span>
+              {brush && (
+                <span className="text-[11px] text-blue-600 dark:text-blue-400 tabular-nums">
+                  {brush[0]}–{brush[1]}
+                </span>
+              )}
               <div className="flex items-center gap-1 ml-auto bg-zinc-100 dark:bg-zinc-800 rounded-md p-0.5">
                 <button
                   className={`px-2 py-0.5 text-[11px] rounded ${
@@ -820,21 +1196,41 @@ export default function CitesTradeSummary({
                 </button>
               </div>
             </div>
-            <TrendLineChart data={filtered.byYear} metric={metric} />
+            <TrendLineChart
+              data={chartByYear}
+              metric={metric}
+              minYear={minYear}
+              maxYear={maxYear}
+              brush={brush}
+              onBrushChange={setBrush}
+              provisionalFromYear={provisionalFromYear}
+            />
+            <p className="text-[10px] text-zinc-400 dark:text-zinc-500 mt-1 leading-snug">
+              Drag the handles to trim the year range.
+              {maxYear >= provisionalFromYear && (
+                <>
+                  {" "}
+                  Recent years (dashed, {provisionalFromYear}+) are{" "}
+                  <span className="text-amber-500 dark:text-amber-400">provisional</span> —
+                  CITES reporting lags by a few years, so they are usually incomplete
+                  rather than showing a real drop.
+                </>
+              )}
+            </p>
           </div>
 
           {/* Source breakdown — most important for assessors */}
-          {filtered.topSources.length > 0 && (
+          {displaySources.length > 0 && (
             <div>
               <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
                 Wild vs. Captive
               </h5>
-              <SourceBreakdown sources={filtered.topSources} />
+              <SourceBreakdown sources={displaySources} />
             </div>
           )}
 
-          {/* Commodities — table with quantities */}
-          {filtered.topTerms.length > 0 && (
+          {/* Commodities — grouped by term + unit (never aggregated across units) */}
+          {display.termsByUnit.length > 0 && (
             <div>
               <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
                 Commodities
@@ -843,20 +1239,22 @@ export default function CitesTradeSummary({
                 <thead>
                   <tr className="text-left text-zinc-400 dark:text-zinc-500">
                     <th className="font-medium pb-1 pr-2">Term</th>
-                    <th className="font-medium pb-1 pr-2 text-right">
-                      Records
-                    </th>
+                    <th className="font-medium pb-1 pr-2">Unit</th>
+                    <th className="font-medium pb-1 pr-2 text-right">Records</th>
                     <th className="font-medium pb-1 text-right">Quantity</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {filtered.topTerms.slice(0, 6).map((t) => (
+                  {display.termsByUnit.slice(0, 8).map((t) => (
                     <tr
-                      key={t.term}
+                      key={termUnitKey(t.term, t.unit)}
                       className="border-t border-zinc-100 dark:border-zinc-800/50"
                     >
                       <td className="py-1 pr-2 text-zinc-700 dark:text-zinc-300 capitalize">
                         {t.term}
+                      </td>
+                      <td className="py-1 pr-2 text-zinc-500 dark:text-zinc-400">
+                        {t.unit || "—"}
                       </td>
                       <td className="py-1 pr-2 text-right text-zinc-500 dark:text-zinc-400 tabular-nums">
                         {t.records.toLocaleString()}
@@ -872,13 +1270,13 @@ export default function CitesTradeSummary({
           )}
 
           {/* Purpose */}
-          {filtered.topPurposes.length > 0 && (
+          {displayPurposes.length > 0 && (
             <div>
               <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
                 Purpose
               </h5>
               <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-600 dark:text-zinc-300">
-                {filtered.topPurposes.map((p) => (
+                {displayPurposes.map((p) => (
                   <span key={p.code} className="tabular-nums">
                     {p.label}{" "}
                     <span className="text-zinc-400 dark:text-zinc-500">
@@ -891,7 +1289,6 @@ export default function CitesTradeSummary({
           )}
         </div>
       </div>
-
     </div>
   );
 }

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -788,8 +788,11 @@ export default function CitesTradeSummary({
   );
   const [error, setError] = useState<string | null>(null);
 
-  // Metric toggle: show records (shipments) or quantity (items)
-  const [metric, setMetric] = useState<"records" | "quantity">("records");
+  // Trend is always measured in shipment records. Quantities are NEVER plotted
+  // as a single line because the CITES guide warns they cannot be aggregated
+  // across incompatible units (kg, m, pieces, unit-less) — per-unit quantities
+  // live in the Commodities table instead.
+  const metric = "records" as const;
 
   // Filter state — all checked by default
   const [checkedSources, setCheckedSources] = useState<Record<string, boolean>>({});
@@ -1168,33 +1171,14 @@ export default function CitesTradeSummary({
               <span className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
                 Trade over time
               </span>
+              <span className="text-[11px] text-zinc-400 dark:text-zinc-500 normal-case">
+                (shipments)
+              </span>
               {brush && (
-                <span className="text-[11px] text-blue-600 dark:text-blue-400 tabular-nums">
+                <span className="text-[11px] text-blue-600 dark:text-blue-400 tabular-nums ml-auto">
                   {brush[0]}–{brush[1]}
                 </span>
               )}
-              <div className="flex items-center gap-1 ml-auto bg-zinc-100 dark:bg-zinc-800 rounded-md p-0.5">
-                <button
-                  className={`px-2 py-0.5 text-[11px] rounded ${
-                    metric === "records"
-                      ? "bg-white dark:bg-zinc-700 text-zinc-800 dark:text-zinc-200 shadow-sm font-medium"
-                      : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"
-                  }`}
-                  onClick={() => setMetric("records")}
-                >
-                  Shipments
-                </button>
-                <button
-                  className={`px-2 py-0.5 text-[11px] rounded ${
-                    metric === "quantity"
-                      ? "bg-white dark:bg-zinc-700 text-zinc-800 dark:text-zinc-200 shadow-sm font-medium"
-                      : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"
-                  }`}
-                  onClick={() => setMetric("quantity")}
-                >
-                  Volume
-                </button>
-              </div>
             </div>
             <TrendLineChart
               data={chartByYear}

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -178,7 +178,7 @@ function TradeFlowMap({
   const [hoveredReExport, setHoveredReExport] = useState<number | null>(null);
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
   const [selectedCountry, setSelectedCountry] = useState<string | null>(null);
-  const [showReExports, setShowReExports] = useState(false);
+  const [showReExports, setShowReExports] = useState(true);
 
   // Only render flows where we have centroids for both endpoints
   const renderableFlows = useMemo(
@@ -231,16 +231,14 @@ function TradeFlowMap({
 
   return (
     <div className="relative">
-      {/* Hover tooltip */}
+      {/* Direct-flow tooltip — labelled with CITES roles (Exporter → Importer) */}
       {hoveredFlowData && (
         <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 bg-zinc-800 dark:bg-zinc-700 text-white text-[11px] px-3 py-1.5 rounded-lg shadow-lg pointer-events-none whitespace-nowrap">
-          <span className="font-medium">
-            {countryName(hoveredFlowData.from)}
-          </span>
+          <span className="text-zinc-400">Exporter </span>
+          <span className="font-medium">{countryName(hoveredFlowData.from)}</span>
           <span className="text-zinc-300 mx-1.5">&rarr;</span>
-          <span className="font-medium">
-            {countryName(hoveredFlowData.to)}
-          </span>
+          <span className="text-zinc-400">Importer </span>
+          <span className="font-medium">{countryName(hoveredFlowData.to)}</span>
           <span className="text-zinc-400 ml-2">
             {hoveredFlowData.records.toLocaleString()} records
           </span>
@@ -252,12 +250,13 @@ function TradeFlowMap({
         </div>
       )}
 
-      {/* Re-export pathway tooltip (plain language) */}
+      {/* Re-export pathway tooltip — CITES terms: Origin → Exporter (re-exporter) */}
       {hoveredReExportData && !hoveredFlowData && (
-        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 bg-zinc-800 dark:bg-zinc-700 text-white text-[11px] px-3 py-1.5 rounded-lg shadow-lg pointer-events-none max-w-[300px] text-center">
-          Originated in{" "}
-          <span className="font-medium">{countryName(hoveredReExportData.from)}</span>,
-          re-exported via{" "}
+        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 bg-zinc-800 dark:bg-zinc-700 text-white text-[11px] px-3 py-1.5 rounded-lg shadow-lg pointer-events-none max-w-[320px] text-center">
+          <span className="text-amber-300">Origin </span>
+          <span className="font-medium">{countryName(hoveredReExportData.from)}</span>
+          <span className="text-zinc-300 mx-1.5">&rarr;</span>
+          <span className="text-zinc-400">re-exported by </span>
           <span className="font-medium">{countryName(hoveredReExportData.to)}</span>
           <span className="text-zinc-400 ml-1.5">
             {hoveredReExportData.records.toLocaleString()} records
@@ -504,7 +503,7 @@ function TradeFlowMap({
         </g>
       </ComposableMap>
 
-      {/* Legend */}
+      {/* Legend — labelled with CITES roles */}
       <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 mt-1 text-[10px] text-zinc-500 dark:text-zinc-400">
         <span className="flex items-center gap-1">
           <span className="inline-block w-2 h-2 rounded-full bg-red-500" />
@@ -512,14 +511,14 @@ function TradeFlowMap({
         </span>
         <span className="flex items-center gap-1">
           <span className="inline-block w-2 h-2 rounded-full bg-blue-500" />
-          Importer
+          Importer (destination)
         </span>
         <span className="flex items-center gap-1">
           <svg width="16" height="8" className="inline-block">
             <line x1="0" y1="4" x2="12" y2="4" stroke="#ef4444" strokeWidth="2" strokeOpacity="0.5" />
             <polygon points="12,1.5 16,4 12,6.5" fill="#ef4444" fillOpacity="0.7" />
           </svg>
-          Flow direction
+          Exporter &rarr; Importer
         </span>
         {suspensionCountries && suspensionCountries.size > 0 && (
           <span className="flex items-center gap-1">
@@ -528,20 +527,28 @@ function TradeFlowMap({
           </span>
         )}
         {renderableReExports.length > 0 && (
-          <label className="flex items-center gap-1 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              checked={showReExports}
-              onChange={() => setShowReExports((v) => !v)}
-              className="w-3 h-3 rounded"
-              style={{ accentColor: "#d97706" }}
-            />
-            <svg width="16" height="8" className="inline-block">
-              <line x1="0" y1="4" x2="12" y2="4" stroke="#d97706" strokeWidth="1.5" strokeDasharray="3,2" />
-              <polygon points="12,1.5 16,4 12,6.5" fill="#d97706" />
-            </svg>
-            Show where specimens came from (re-exports)
-          </label>
+          <>
+            <span className="flex items-center gap-1">
+              <svg width="12" height="12" className="inline-block">
+                <rect x="2.5" y="2.5" width="7" height="7" transform="rotate(45 6 6)" fill="none" stroke="#d97706" strokeWidth="1.2" />
+              </svg>
+              Country of origin
+            </span>
+            <label className="flex items-center gap-1 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={showReExports}
+                onChange={() => setShowReExports((v) => !v)}
+                className="w-3 h-3 rounded"
+                style={{ accentColor: "#d97706" }}
+              />
+              <svg width="16" height="8" className="inline-block">
+                <line x1="0" y1="4" x2="12" y2="4" stroke="#d97706" strokeWidth="1.5" strokeDasharray="3,2" />
+                <polygon points="12,1.5 16,4 12,6.5" fill="#d97706" />
+              </svg>
+              Re-exports (Origin &rarr; Exporter)
+            </label>
+          </>
         )}
         <span className="text-zinc-400 dark:text-zinc-500 italic">click dot to filter</span>
       </div>

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -142,7 +142,7 @@ function endAngle(from: [number, number], to: [number, number], curvature = 0.25
   return (Math.atan2(tdy, tdx) * 180) / Math.PI;
 }
 
-interface TradeFlow {
+export interface TradeFlow {
   from: string;
   to: string;
   records: number;
@@ -156,22 +156,43 @@ export interface CountryAnnotation {
 
 interface TradeFlowMapProps {
   flows: TradeFlow[];
+  /**
+   * Re-export legs: where specimens originally came from before the exporter
+   * (origin → re-exporter). Shown as an opt-in dashed overlay.
+   */
+  reExportFlows?: TradeFlow[];
   /** ISO alpha-2 codes of countries with active trade suspensions */
   suspensionCountries?: Set<string>;
   /** Per-country suspension/quota annotations for hover tooltip */
   countryAnnotations?: Record<string, CountryAnnotation>;
 }
 
-function TradeFlowMap({ flows, suspensionCountries, countryAnnotations }: TradeFlowMapProps) {
+function TradeFlowMap({
+  flows,
+  reExportFlows,
+  suspensionCountries,
+  countryAnnotations,
+}: TradeFlowMapProps) {
   const { resolvedTheme } = useTheme();
   const [hoveredFlow, setHoveredFlow] = useState<number | null>(null);
+  const [hoveredReExport, setHoveredReExport] = useState<number | null>(null);
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
   const [selectedCountry, setSelectedCountry] = useState<string | null>(null);
+  const [showReExports, setShowReExports] = useState(false);
 
   // Only render flows where we have centroids for both endpoints
   const renderableFlows = useMemo(
     () => flows.filter((f) => COUNTRY_CENTROIDS[f.from] && COUNTRY_CENTROIDS[f.to]),
     [flows]
+  );
+
+  // Re-export legs (origin → re-exporter) with known centroids
+  const renderableReExports = useMemo(
+    () =>
+      (reExportFlows ?? []).filter(
+        (f) => COUNTRY_CENTROIDS[f.from] && COUNTRY_CENTROIDS[f.to]
+      ),
+    [reExportFlows]
   );
 
   if (renderableFlows.length === 0) return null;
@@ -183,6 +204,16 @@ function TradeFlowMap({ flows, suspensionCountries, countryAnnotations }: TradeF
     ? renderableFlows.filter((f) => f.from === selectedCountry || f.to === selectedCountry)
     : renderableFlows;
 
+  // Re-export legs to show: only when toggled on, respecting any country filter
+  const visibleReExports =
+    showReExports && renderableReExports.length > 0
+      ? selectedCountry
+        ? renderableReExports.filter(
+            (f) => f.from === selectedCountry || f.to === selectedCountry
+          )
+        : renderableReExports
+      : [];
+
   // Collect unique exporter/importer codes from visible flows
   const exporterCodes = new Set(visibleFlows.map((f) => f.from));
   const importerCodes = new Set(visibleFlows.map((f) => f.to));
@@ -191,10 +222,12 @@ function TradeFlowMap({ flows, suspensionCountries, countryAnnotations }: TradeF
 
   // Theme-aware colors for SVG fills (can't use Tailwind classes in SVG)
   const colors = dark
-    ? { base: "#18181b", exporter: "#7f1d1d", importer: "#1e3a5f", both: "#312e81", stroke: "#27272a", suspension: "#991b1b", arcDefault: "#f87171", arcHover: "#fbbf24" }
-    : { base: "#f4f4f5", exporter: "#fee2e2", importer: "#dbeafe", both: "#e0e7ff", stroke: "#d4d4d8", suspension: "#fecaca", arcDefault: "#ef4444", arcHover: "#f59e0b" };
+    ? { base: "#18181b", exporter: "#7f1d1d", importer: "#1e3a5f", both: "#312e81", stroke: "#27272a", suspension: "#991b1b", arcDefault: "#f87171", arcHover: "#fbbf24", reExport: "#d97706" }
+    : { base: "#f4f4f5", exporter: "#fee2e2", importer: "#dbeafe", both: "#e0e7ff", stroke: "#d4d4d8", suspension: "#fecaca", arcDefault: "#ef4444", arcHover: "#f59e0b", reExport: "#d97706" };
 
   const hoveredFlowData = hoveredFlow !== null ? visibleFlows[hoveredFlow] : null;
+  const hoveredReExportData =
+    hoveredReExport !== null ? visibleReExports[hoveredReExport] : null;
 
   return (
     <div className="relative">
@@ -219,8 +252,21 @@ function TradeFlowMap({ flows, suspensionCountries, countryAnnotations }: TradeF
         </div>
       )}
 
+      {/* Re-export pathway tooltip (plain language) */}
+      {hoveredReExportData && !hoveredFlowData && (
+        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 bg-zinc-800 dark:bg-zinc-700 text-white text-[11px] px-3 py-1.5 rounded-lg shadow-lg pointer-events-none max-w-[300px] text-center">
+          Originated in{" "}
+          <span className="font-medium">{countryName(hoveredReExportData.from)}</span>,
+          re-exported via{" "}
+          <span className="font-medium">{countryName(hoveredReExportData.to)}</span>
+          <span className="text-zinc-400 ml-1.5">
+            {hoveredReExportData.records.toLocaleString()} records
+          </span>
+        </div>
+      )}
+
       {/* Country annotation tooltip (suspensions/quotas) */}
-      {hoveredCountry && !hoveredFlowData && countryAnnotations?.[hoveredCountry] && (
+      {hoveredCountry && !hoveredFlowData && !hoveredReExportData && countryAnnotations?.[hoveredCountry] && (
         <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 bg-zinc-800 dark:bg-zinc-700 text-white text-[11px] px-3 py-2 rounded-lg shadow-lg pointer-events-none max-w-[280px]">
           <div className="font-medium mb-1">{countryName(hoveredCountry)}</div>
           {countryAnnotations[hoveredCountry].suspensions && countryAnnotations[hoveredCountry].suspensions!.length > 0 && (
@@ -304,6 +350,70 @@ function TradeFlowMap({ flows, suspensionCountries, countryAnnotations }: TradeF
             }
           </Geographies>
         </g>
+
+        {/* Re-export legs (origin → re-exporter), drawn underneath the direct
+            flows as dashed amber arcs so they read as the upstream part of the
+            pathway rather than a competing flow. */}
+        {visibleReExports.map((flow, i) => {
+          const from = COUNTRY_CENTROIDS[flow.from];
+          const to = COUNTRY_CENTROIDS[flow.to];
+          const path = arcPath(from, to);
+          if (!path) return null;
+          const isHovered = hoveredReExport === i;
+          const dest = project(to);
+          const angle = endAngle(from, to);
+          return (
+            <g key={`reexport-${flow.from}-${flow.to}`}>
+              <path
+                d={path}
+                fill="none"
+                stroke={colors.reExport}
+                strokeWidth={isHovered ? 2.5 : 1.5}
+                strokeLinecap="round"
+                strokeDasharray="4,3"
+                strokeOpacity={isHovered ? 0.95 : 0.6}
+                onMouseEnter={() => setHoveredReExport(i)}
+                onMouseLeave={() => setHoveredReExport(null)}
+                style={{ cursor: "pointer" }}
+              />
+              {dest && (
+                <polygon
+                  points="-4,-2.5 0,0 -4,2.5"
+                  fill={colors.reExport}
+                  fillOpacity={isHovered ? 0.95 : 0.6}
+                  transform={`translate(${dest[0]},${dest[1]}) rotate(${angle})`}
+                />
+              )}
+            </g>
+          );
+        })}
+
+        {/* Origin markers for re-export legs (hollow amber diamonds) */}
+        {visibleReExports.length > 0 &&
+          (() => {
+            const seen = new Set<string>();
+            const markers: React.ReactNode[] = [];
+            for (const flow of visibleReExports) {
+              if (seen.has(flow.from)) continue;
+              seen.add(flow.from);
+              const p = project(COUNTRY_CENTROIDS[flow.from]);
+              if (!p) continue;
+              markers.push(
+                <rect
+                  key={`origin-${flow.from}`}
+                  x={p[0] - 3}
+                  y={p[1] - 3}
+                  width={6}
+                  height={6}
+                  transform={`rotate(45 ${p[0]} ${p[1]})`}
+                  fill="none"
+                  stroke={colors.reExport}
+                  strokeWidth={1.2}
+                />
+              );
+            }
+            return markers;
+          })()}
 
         {/* Curved flow arcs with arrowheads — rendered outside the offset <g> since we project manually */}
         {visibleFlows.map((flow, i) => {
@@ -416,6 +526,22 @@ function TradeFlowMap({ flows, suspensionCountries, countryAnnotations }: TradeF
             <span className="inline-block w-3 h-2 rounded-sm border border-dashed border-red-500 bg-red-100 dark:bg-red-900/30" />
             Suspension
           </span>
+        )}
+        {renderableReExports.length > 0 && (
+          <label className="flex items-center gap-1 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={showReExports}
+              onChange={() => setShowReExports((v) => !v)}
+              className="w-3 h-3 rounded"
+              style={{ accentColor: "#d97706" }}
+            />
+            <svg width="16" height="8" className="inline-block">
+              <line x1="0" y1="4" x2="12" y2="4" stroke="#d97706" strokeWidth="1.5" strokeDasharray="3,2" />
+              <polygon points="12,1.5 16,4 12,6.5" fill="#d97706" />
+            </svg>
+            Show where specimens came from (re-exports)
+          </label>
         )}
         <span className="text-zinc-400 dark:text-zinc-500 italic">click dot to filter</span>
       </div>


### PR DESCRIPTION
Implements the CITES improvements discussed in #300 (consolidated into one branch).

## Trade data (`api/cites/trade/route.ts`)
- **Full history**: fetches from 1975 (CITES inception) instead of a rolling 10-year window — early records (e.g. *Panthera leo* from 1977) are no longer cut off.
- **Exporter-preferred quantity** per the CITES Trade Database Guide (falls back to the importer figure only when the exporter did not report); importer/exporter figures are never summed.
- Adds `unit` + `origin` to the compact shipment records and a new `allTermsByUnit` grouping (term + unit, never cross-aggregated).

## Trade summary (`CitesTradeSummary.tsx`)
- **Searchable commodity filter** with **All / None** bulk-select per section (Source, Purpose, Commodity) — removes the inaccessible "+x more" dead end.
- **Unit-aware commodities**: grouped by term + unit, with a Unit column; each term+unit is its own filter row, so kg / m / pieces / unit-less never get summed together (e.g. Savanna Elephant tusks-kg vs unit-less stay separate).
- **Year-range trimming** via draggable handles on the trade-over-time chart; the chart itself is unchanged and the area **outside** the selection is dimmed. Updates the map, tables, headline and breakdowns live.
- **Reporting-lag handling**: the most recent years render **dashed** and are captioned as *provisional*, since CITES annual reports lag by a few years — this explains the apparent "drop to zero" rather than presenting it as a real collapse.
- The trend is **shipment-count only**; the old cross-unit "Volume" line was removed because aggregating quantities across incompatible units violates the guide.

## Trade map (`TradeFlowMap.tsx`)
- **Re-exports shown by default** (still toggleable), drawn as connected dashed amber **Origin → Exporter** legs.
- Labelled with **CITES terminology** — **Origin** (country of origin), **Exporter** (the re-exporter when an origin is present), **Importer** (destination). Tooltips and legend use these roles. ("Source" is deliberately reserved for the CITES specimen-source code shown in the Wild vs. Captive panel, not a country.)

## Layout (`CitesSummary.tsx`)
- Moved the formal CITES listing detail (Current Listings, Reservations) to **below** the International Trade / Suspensions / Quotas sections.

## CITES guideline compliance
- ✅ Comparative tabulation format (avoids importer/exporter double-counting)
- ✅ Exporter-preferred quantity
- ✅ Quantities never aggregated across units
- ✅ Direct vs. indirect (re-export) trade distinguished via the Origin column

## Verification
`tsc --noEmit`, ESLint, and the full Vitest suite (402 tests) all pass. Trade-route tests updated for exporter-preferred quantity, the new unit/origin fields and the `allTermsByUnit` grouping.

Not included (out of scope): split-view comparison of two commodities / year ranges.

Closes #300

https://claude.ai/code/session_01MTGCk1uUQWLcmB7PqLY6pS

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTGCk1uUQWLcmB7PqLY6pS)_