### PR TITLE
CITES trade: cross-filter bar charts, country drill-down, and layout rework

### DIFF
--- a/app/src/app/api/cites/route.ts
+++ b/app/src/app/api/cites/route.ts
@@ -62,7 +62,9 @@ interface CitesLegislation {
     notes: string | null;
     url: string | null;
     is_current: boolean;
-    unit: string | null;
+    // Species+ returns this as an object ({ code, name }), occasionally a
+    // string or null.
+    unit: { code?: string; name?: string } | string | null;
     geo_entity: { iso_code2: string; name: string; type: string };
   }[];
   cites_suspensions: {
@@ -259,7 +261,10 @@ export async function GET(request: NextRequest) {
         country: q.geo_entity.name,
         countryCode: q.geo_entity.iso_code2,
         quota: q.quota,
-        unit: q.unit,
+        unit:
+          q.unit && typeof q.unit === "object"
+            ? q.unit.name ?? q.unit.code ?? null
+            : q.unit,
         notes: q.notes,
         publicationDate: q.publication_date,
       })),

--- a/app/src/components/CitesSummary.tsx
+++ b/app/src/components/CitesSummary.tsx
@@ -82,6 +82,29 @@ function AppendixBadge({ appendix }: { appendix: string }) {
   );
 }
 
+const fmtCitesDate = (d: string) =>
+  new Date(d).toLocaleDateString("en-GB", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+/** Compact section header with an optional count. */
+function SectionHeader({ title, count }: { title: string; count?: number }) {
+  return (
+    <div className="flex items-baseline gap-2 mb-1.5">
+      <h4 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+        {title}
+      </h4>
+      {count != null && (
+        <span className="text-[11px] text-zinc-400 dark:text-zinc-500 tabular-nums">
+          {count}
+        </span>
+      )}
+    </div>
+  );
+}
+
 export default function CitesSummary({
   scientificName,
 }: {
@@ -217,7 +240,7 @@ export default function CitesSummary({
     : (data.quotas || []).slice(0, 5);
 
   return (
-    <div className="p-4 md:p-6 space-y-5">
+    <div className="p-4 md:p-6 space-y-4">
       {/* Listing summary + external links */}
       <div className="flex flex-wrap items-center gap-3">
         {data.citesListing ? (
@@ -262,116 +285,86 @@ export default function CitesSummary({
         </div>
       )}
 
-      {/* Current listings detail — below trade overview, above suspensions/quotas */}
-      {data.currentListings && data.currentListings.length > 0 && (
-        <div>
-          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-            Current Listings
-          </h4>
-          <div className="space-y-2">
-            {data.currentListings.map((listing, i) => (
-              <div
-                key={i}
-                className="flex flex-wrap items-start gap-2 text-sm"
-              >
-                <AppendixBadge appendix={listing.appendix} />
-                <span className="text-zinc-500 dark:text-zinc-400 text-xs mt-0.5">
-                  since{" "}
-                  {new Date(listing.effectiveAt).toLocaleDateString("en-GB", {
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                  })}
-                </span>
-                {listing.annotation && (
-                  <p className="w-full text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 pl-0.5">
-                    {listing.annotation}
-                  </p>
-                )}
+      {/* Listings & reservations — compact, side by side on wider screens */}
+      {((data.currentListings && data.currentListings.length > 0) ||
+        (data.reservations && data.reservations.length > 0)) && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-6 gap-y-4">
+          {data.currentListings && data.currentListings.length > 0 && (
+            <div>
+              <SectionHeader title="Current Listings" />
+              <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
+                {data.currentListings.map((listing, i) => (
+                  <div key={i} className="px-3 py-2">
+                    <div className="flex items-center gap-2 text-xs">
+                      <AppendixBadge appendix={listing.appendix} />
+                      <span className="text-zinc-400 dark:text-zinc-500 ml-auto whitespace-nowrap">
+                        since {fmtCitesDate(listing.effectiveAt)}
+                      </span>
+                    </div>
+                    {listing.annotation && (
+                      <p className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug">
+                        {listing.annotation}
+                      </p>
+                    )}
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-        </div>
-      )}
+            </div>
+          )}
 
-      {/* Reservations — country-specific opt-outs from a listing */}
-      {data.reservations && data.reservations.length > 0 && (
-        <div>
-          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-            Reservations ({data.reservations.length})
-          </h4>
-          <div className="space-y-2">
-            {data.reservations.map((r, i) => (
-              <div
-                key={i}
-                className="flex flex-wrap items-start gap-2 text-sm"
-              >
-                <AppendixBadge appendix={r.appendix} />
-                <span className="text-zinc-700 dark:text-zinc-300">
-                  {r.country || r.countryCode || "Unknown party"}
-                </span>
-                <span className="text-zinc-500 dark:text-zinc-400 text-xs mt-0.5">
-                  since{" "}
-                  {new Date(r.effectiveAt).toLocaleDateString("en-GB", {
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                  })}
-                </span>
-                {r.annotation && (
-                  <p className="w-full text-xs text-zinc-500 dark:text-zinc-400 mt-0.5 pl-0.5">
-                    {r.annotation}
-                  </p>
-                )}
+          {data.reservations && data.reservations.length > 0 && (
+            <div>
+              <SectionHeader title="Reservations" count={data.reservations.length} />
+              <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
+                {data.reservations.map((r, i) => (
+                  <div key={i} className="px-3 py-2">
+                    <div className="flex items-center gap-2 text-xs">
+                      <AppendixBadge appendix={r.appendix} />
+                      <span className="text-zinc-700 dark:text-zinc-300 font-medium truncate">
+                        {r.country || r.countryCode || "Unknown party"}
+                      </span>
+                      <span className="text-zinc-400 dark:text-zinc-500 ml-auto whitespace-nowrap">
+                        since {fmtCitesDate(r.effectiveAt)}
+                      </span>
+                    </div>
+                    {r.annotation && (
+                      <p className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug">
+                        {r.annotation}
+                      </p>
+                    )}
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
+            </div>
+          )}
         </div>
       )}
 
       {/* Trade suspensions */}
       {data.suspensions && data.suspensions.length > 0 && (
         <div>
-          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-            Trade Suspensions ({data.suspensions.length})
-          </h4>
-          <div className="border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="bg-zinc-50 dark:bg-zinc-800/50">
-                  <th className="text-left px-3 py-1.5 font-medium text-zinc-500 dark:text-zinc-400">
-                    Country
-                  </th>
-                  <th className="text-left px-3 py-1.5 font-medium text-zinc-500 dark:text-zinc-400">
-                    Type
-                  </th>
-                  <th className="text-left px-3 py-1.5 font-medium text-zinc-500 dark:text-zinc-400">
-                    Since
-                  </th>
-                  <th className="text-left px-3 py-1.5 font-medium text-zinc-500 dark:text-zinc-400 hidden md:table-cell">
-                    Notification
-                  </th>
-                </tr>
-              </thead>
+          <SectionHeader title="Trade Suspensions" count={data.suspensions.length} />
+          <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+            <table className="w-full text-[11px]">
               <tbody>
                 {suspensionsToShow.map((s, i) => (
                   <tr
                     key={i}
-                    className="border-t border-zinc-100 dark:border-zinc-800"
+                    className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
                   >
-                    <td className="px-3 py-1.5 text-zinc-700 dark:text-zinc-300">
+                    <td className="px-3 py-1 text-zinc-700 dark:text-zinc-300">
                       {s.country}
                     </td>
-                    <td className="px-3 py-1.5 text-zinc-500 dark:text-zinc-400 capitalize">
+                    <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 capitalize whitespace-nowrap">
                       {s.appliesTo}
                     </td>
-                    <td className="px-3 py-1.5 text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
+                    <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 whitespace-nowrap tabular-nums">
                       {new Date(s.startDate).toLocaleDateString("en-GB", {
                         year: "numeric",
                         month: "short",
                       })}
                     </td>
-                    <td className="px-3 py-1.5 text-zinc-400 hidden md:table-cell">
+                    <td className="px-3 py-1 text-right hidden md:table-cell">
                       {s.notification?.url ? (
                         <a
                           href={s.notification.url}
@@ -382,7 +375,7 @@ export default function CitesSummary({
                           {s.notification.name}
                         </a>
                       ) : (
-                        s.notification?.name || "—"
+                        <span className="text-zinc-400">{s.notification?.name || "—"}</span>
                       )}
                     </td>
                   </tr>
@@ -391,12 +384,12 @@ export default function CitesSummary({
             </table>
             {data.suspensions.length > 5 && (
               <button
-                className="w-full px-3 py-1.5 text-xs text-blue-600 dark:text-blue-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 border-t border-zinc-100 dark:border-zinc-800"
+                className="w-full px-3 py-1 text-[11px] text-blue-600 dark:text-blue-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 border-t border-zinc-100 dark:border-zinc-800"
                 onClick={() => setShowAllSuspensions(!showAllSuspensions)}
               >
                 {showAllSuspensions
                   ? "Show fewer"
-                  : `Show all ${data.suspensions.length} suspensions`}
+                  : `Show all ${data.suspensions.length}`}
               </button>
             )}
           </div>
@@ -406,38 +399,23 @@ export default function CitesSummary({
       {/* Trade quotas */}
       {data.quotas && data.quotas.length > 0 && (
         <div>
-          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-            Trade Quotas ({data.quotas.length})
-          </h4>
-          <div className="border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="bg-zinc-50 dark:bg-zinc-800/50">
-                  <th className="text-left px-3 py-1.5 font-medium text-zinc-500 dark:text-zinc-400">
-                    Country
-                  </th>
-                  <th className="text-right px-3 py-1.5 font-medium text-zinc-500 dark:text-zinc-400">
-                    Quota
-                  </th>
-                  <th className="text-left px-3 py-1.5 font-medium text-zinc-500 dark:text-zinc-400 hidden md:table-cell">
-                    Notes
-                  </th>
-                </tr>
-              </thead>
+          <SectionHeader title="Trade Quotas" count={data.quotas.length} />
+          <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+            <table className="w-full text-[11px]">
               <tbody>
                 {quotasToShow.map((q, i) => (
                   <tr
                     key={i}
-                    className="border-t border-zinc-100 dark:border-zinc-800"
+                    className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
                   >
-                    <td className="px-3 py-1.5 text-zinc-700 dark:text-zinc-300">
+                    <td className="px-3 py-1 text-zinc-700 dark:text-zinc-300 whitespace-nowrap">
                       {q.country}
                     </td>
-                    <td className="px-3 py-1.5 text-right text-zinc-700 dark:text-zinc-300 tabular-nums">
+                    <td className="px-3 py-1 text-right text-zinc-700 dark:text-zinc-300 tabular-nums whitespace-nowrap">
                       {q.quota != null ? q.quota.toLocaleString() : "—"}
                       {q.unit ? ` ${q.unit}` : ""}
                     </td>
-                    <td className="px-3 py-1.5 text-zinc-400 max-w-[250px] truncate hidden md:table-cell">
+                    <td className="px-3 py-1 text-zinc-400 max-w-[280px] truncate hidden md:table-cell">
                       {q.notes || "—"}
                     </td>
                   </tr>
@@ -446,12 +424,12 @@ export default function CitesSummary({
             </table>
             {data.quotas.length > 5 && (
               <button
-                className="w-full px-3 py-1.5 text-xs text-blue-600 dark:text-blue-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 border-t border-zinc-100 dark:border-zinc-800"
+                className="w-full px-3 py-1 text-[11px] text-blue-600 dark:text-blue-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 border-t border-zinc-100 dark:border-zinc-800"
                 onClick={() => setShowAllQuotas(!showAllQuotas)}
               >
                 {showAllQuotas
                   ? "Show fewer"
-                  : `Show all ${data.quotas.length} quotas`}
+                  : `Show all ${data.quotas.length}`}
               </button>
             )}
           </div>

--- a/app/src/components/CitesSummary.tsx
+++ b/app/src/components/CitesSummary.tsx
@@ -218,17 +218,7 @@ export default function CitesSummary({
 
   return (
     <div className="p-4 md:p-6 space-y-5">
-      {/* Trade overview from CITES Trade Database */}
-      {data.citesId && (
-        <div>
-          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-            International Trade
-          </h4>
-          <CitesTradeSummary citesId={data.citesId} prefetchedData={tradeData} prefetchedLoading={tradeLoading} suspensionCountries={suspensionCountryCodes} countryAnnotations={countryAnnotations} />
-        </div>
-      )}
-
-      {/* Listing summary + external links — below the trade info */}
+      {/* Listing summary + external links */}
       <div className="flex flex-wrap items-center gap-3">
         {data.citesListing ? (
           <div className="flex items-center gap-2">
@@ -261,6 +251,16 @@ export default function CitesSummary({
           </a>
         </div>
       </div>
+
+      {/* Trade overview from CITES Trade Database */}
+      {data.citesId && (
+        <div>
+          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
+            International Trade
+          </h4>
+          <CitesTradeSummary citesId={data.citesId} prefetchedData={tradeData} prefetchedLoading={tradeLoading} suspensionCountries={suspensionCountryCodes} countryAnnotations={countryAnnotations} />
+        </div>
+      )}
 
       {/* Current listings detail — below trade overview, above suspensions/quotas */}
       {data.currentListings && data.currentListings.length > 0 && (

--- a/app/src/components/CitesSummary.tsx
+++ b/app/src/components/CitesSummary.tsx
@@ -124,8 +124,8 @@ function PagedList<T>({
   const slice = items.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE);
 
   return (
-    <div className="flex flex-col flex-1 min-h-0">
-      <div className="flex-1">{children(slice)}</div>
+    <>
+      {children(slice)}
       {totalPages > 1 && (
         <div className="flex items-center justify-between mt-1 text-[10px] text-zinc-400 dark:text-zinc-500">
           <button
@@ -147,7 +147,7 @@ function PagedList<T>({
           </button>
         </div>
       )}
-    </div>
+    </>
   );
 }
 
@@ -352,173 +352,163 @@ export default function CitesSummary({
         </div>
       )}
 
-      {/* Current Listings | Reservations */}
-      {((data.currentListings && data.currentListings.length > 0) ||
-        reservationGroups.length > 0) && (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-6 gap-y-4 items-stretch">
-          {data.currentListings && data.currentListings.length > 0 && (
-            <div className="flex flex-col">
-              <SectionHeader title="Current Listings" count={data.currentListings.length} />
-              <PagedList items={data.currentListings}>
-                {(slice) => (
-                  <div className="h-full rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
-                    {slice.map((listing, i) => (
-                      <div key={i} className="px-3 py-2">
-                        <div className="flex items-center gap-2 text-xs">
-                          <AppendixBadge appendix={listing.appendix} />
-                          <span className="text-zinc-400 dark:text-zinc-500 ml-auto whitespace-nowrap">
-                            since {fmtCitesDate(listing.effectiveAt)}
-                          </span>
-                        </div>
-                        {listing.annotation && (
-                          <p
-                            title={listing.annotation}
-                            className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug line-clamp-3"
-                          >
-                            {listing.annotation}
-                          </p>
-                        )}
-                      </div>
-                    ))}
+      {/* Current Listings */}
+      {data.currentListings && data.currentListings.length > 0 && (
+        <div>
+          <SectionHeader title="Current Listings" count={data.currentListings.length} />
+          <PagedList items={data.currentListings}>
+            {(slice) => (
+              <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
+                {slice.map((listing, i) => (
+                  <div key={i} className="px-3 py-2">
+                    <div className="flex items-center gap-2 text-xs">
+                      <AppendixBadge appendix={listing.appendix} />
+                      <span className="text-zinc-400 dark:text-zinc-500 ml-auto whitespace-nowrap">
+                        since {fmtCitesDate(listing.effectiveAt)}
+                      </span>
+                    </div>
+                    {listing.annotation && (
+                      <p
+                        title={listing.annotation}
+                        className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug line-clamp-3"
+                      >
+                        {listing.annotation}
+                      </p>
+                    )}
                   </div>
-                )}
-              </PagedList>
-            </div>
-          )}
-
-          {reservationGroups.length > 0 && (
-            <div className="flex flex-col">
-              <SectionHeader title="Reservations" count={data.reservations?.length} />
-              <PagedList items={reservationGroups}>
-                {(slice) => (
-                  <div className="h-full rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
-                    {slice.map((group, i) => (
-                      <div key={i} className="px-3 py-2">
-                        <AppendixBadge appendix={group.appendix} />
-                        <div className="mt-1.5 space-y-0.5">
-                          {group.parties.map((p, j) => (
-                            <div key={j} className="flex items-baseline gap-2 text-xs">
-                              <span className="text-zinc-700 dark:text-zinc-300">
-                                {p.name}
-                              </span>
-                              <span className="text-zinc-400 dark:text-zinc-500 ml-auto shrink-0 whitespace-nowrap">
-                                since {fmtCitesDate(p.effectiveAt)}
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                        {group.annotation && (
-                          <p
-                            title={group.annotation}
-                            className="mt-1.5 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug line-clamp-3"
-                          >
-                            {group.annotation}
-                          </p>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </PagedList>
-            </div>
-          )}
+                ))}
+              </div>
+            )}
+          </PagedList>
         </div>
       )}
 
-      {/* Trade Quotas | Trade Suspensions */}
-      {(sortedQuotas.length > 0 || sortedSuspensions.length > 0) && (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-6 gap-y-4 items-stretch">
-          {sortedQuotas.length > 0 && (
-            <div className="flex flex-col">
-              <SectionHeader title="Trade Quotas" count={sortedQuotas.length} />
-              <PagedList items={sortedQuotas}>
-                {(slice) => (
-                  <div className="h-full border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
-                    <table className="w-full text-[11px] table-fixed">
-                      <tbody>
-                        {slice.map((q, i) => (
-                          <tr
-                            key={i}
-                            className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
-                          >
-                            <td
-                              title={q.country}
-                              className="px-3 py-1 text-zinc-700 dark:text-zinc-300 truncate w-[35%]"
-                            >
-                              {q.country}
-                            </td>
-                            <td className="px-3 py-1 text-right text-zinc-700 dark:text-zinc-300 tabular-nums whitespace-nowrap w-[22%]">
-                              {q.quota != null ? q.quota.toLocaleString() : "—"}
-                              {q.unit ? ` ${q.unit}` : ""}
-                            </td>
-                            <td
-                              title={q.notes || undefined}
-                              className="px-3 py-1 text-zinc-400 truncate"
-                            >
-                              {q.notes || "—"}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
+      {/* Reservations */}
+      {reservationGroups.length > 0 && (
+        <div>
+          <SectionHeader title="Reservations" count={data.reservations?.length} />
+          <PagedList items={reservationGroups}>
+            {(slice) => (
+              <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
+                {slice.map((group, i) => (
+                  <div key={i} className="px-3 py-2">
+                    <AppendixBadge appendix={group.appendix} />
+                    <div className="mt-1.5 space-y-0.5">
+                      {group.parties.map((p, j) => (
+                        <div key={j} className="flex items-baseline gap-2 text-xs">
+                          <span className="text-zinc-700 dark:text-zinc-300">
+                            {p.name}
+                          </span>
+                          <span className="text-zinc-400 dark:text-zinc-500 ml-auto shrink-0 whitespace-nowrap">
+                            since {fmtCitesDate(p.effectiveAt)}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                    {group.annotation && (
+                      <p
+                        title={group.annotation}
+                        className="mt-1.5 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug line-clamp-3"
+                      >
+                        {group.annotation}
+                      </p>
+                    )}
                   </div>
-                )}
-              </PagedList>
-            </div>
-          )}
+                ))}
+              </div>
+            )}
+          </PagedList>
+        </div>
+      )}
 
-          {sortedSuspensions.length > 0 && (
-            <div className="flex flex-col">
-              <SectionHeader title="Trade Suspensions" count={sortedSuspensions.length} />
-              <PagedList items={sortedSuspensions}>
-                {(slice) => (
-                  <div className="h-full border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
-                    <table className="w-full text-[11px] table-fixed">
-                      <tbody>
-                        {slice.map((s, i) => (
-                          <tr
-                            key={i}
-                            className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
-                          >
-                            <td
-                              title={s.country}
-                              className="px-3 py-1 text-zinc-700 dark:text-zinc-300 truncate"
+      {/* Trade Quotas */}
+      {sortedQuotas.length > 0 && (
+        <div>
+          <SectionHeader title="Trade Quotas" count={sortedQuotas.length} />
+          <PagedList items={sortedQuotas}>
+            {(slice) => (
+              <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+                <table className="w-full text-[11px] table-fixed">
+                  <tbody>
+                    {slice.map((q, i) => (
+                      <tr
+                        key={i}
+                        className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
+                      >
+                        <td
+                          title={q.country}
+                          className="px-3 py-1 text-zinc-700 dark:text-zinc-300 truncate w-[28%]"
+                        >
+                          {q.country}
+                        </td>
+                        <td className="px-3 py-1 text-right text-zinc-700 dark:text-zinc-300 tabular-nums whitespace-nowrap w-[16%]">
+                          {q.quota != null ? q.quota.toLocaleString() : "—"}
+                          {q.unit ? ` ${q.unit}` : ""}
+                        </td>
+                        <td
+                          title={q.notes || undefined}
+                          className="px-3 py-1 text-zinc-400 truncate"
+                        >
+                          {q.notes || "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </PagedList>
+        </div>
+      )}
+
+      {/* Trade Suspensions */}
+      {sortedSuspensions.length > 0 && (
+        <div>
+          <SectionHeader title="Trade Suspensions" count={sortedSuspensions.length} />
+          <PagedList items={sortedSuspensions}>
+            {(slice) => (
+              <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+                <table className="w-full text-[11px]">
+                  <tbody>
+                    {slice.map((s, i) => (
+                      <tr
+                        key={i}
+                        className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
+                      >
+                        <td className="px-3 py-1 text-zinc-700 dark:text-zinc-300">
+                          {s.country}
+                        </td>
+                        <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 capitalize whitespace-nowrap">
+                          {s.appliesTo}
+                        </td>
+                        <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 whitespace-nowrap tabular-nums">
+                          {new Date(s.startDate).toLocaleDateString("en-GB", {
+                            year: "numeric",
+                            month: "short",
+                          })}
+                        </td>
+                        <td className="px-3 py-1 text-right hidden md:table-cell">
+                          {s.notification?.url ? (
+                            <a
+                              href={s.notification.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              title={s.notification.name}
+                              className="text-blue-600 dark:text-blue-400 hover:underline"
                             >
-                              {s.country}
-                            </td>
-                            <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 capitalize whitespace-nowrap w-[18%]">
-                              {s.appliesTo}
-                            </td>
-                            <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 whitespace-nowrap tabular-nums w-[22%]">
-                              {new Date(s.startDate).toLocaleDateString("en-GB", {
-                                year: "numeric",
-                                month: "short",
-                              })}
-                            </td>
-                            <td className="px-3 py-1 text-right whitespace-nowrap w-[28%] hidden md:table-cell">
-                              {s.notification?.url ? (
-                                <a
-                                  href={s.notification.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  title={s.notification.name}
-                                  className="text-blue-600 dark:text-blue-400 hover:underline"
-                                >
-                                  {s.notification.name}
-                                </a>
-                              ) : (
-                                <span className="text-zinc-400">{s.notification?.name || "—"}</span>
-                              )}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
-              </PagedList>
-            </div>
-          )}
+                              {s.notification.name}
+                            </a>
+                          ) : (
+                            <span className="text-zinc-400">{s.notification?.name || "—"}</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </PagedList>
         </div>
       )}
 

--- a/app/src/components/CitesSummary.tsx
+++ b/app/src/components/CitesSummary.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, type ReactNode } from "react";
 import CitesTradeSummary from "./CitesTradeSummary";
 import type { CountryAnnotation } from "./TradeFlowMap";
 
@@ -105,6 +105,52 @@ function SectionHeader({ title, count }: { title: string; count?: number }) {
   );
 }
 
+const PAGE_SIZE = 5;
+
+/**
+ * Renders a fixed-size page (5) of a list with Prev/Next controls instead of an
+ * expand-all toggle. `children` receives the current page's slice.
+ */
+function PagedList<T>({
+  items,
+  children,
+}: {
+  items: T[];
+  children: (slice: T[]) => ReactNode;
+}) {
+  const [page, setPage] = useState(0);
+  const totalPages = Math.max(1, Math.ceil(items.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages - 1);
+  const slice = items.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE);
+
+  return (
+    <>
+      {children(slice)}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-1 text-[10px] text-zinc-400 dark:text-zinc-500">
+          <button
+            onClick={() => setPage(Math.max(0, safePage - 1))}
+            disabled={safePage === 0}
+            className="px-1.5 py-0.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800 disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            Prev
+          </button>
+          <span className="tabular-nums">
+            {safePage * PAGE_SIZE + 1}–{Math.min((safePage + 1) * PAGE_SIZE, items.length)} of {items.length}
+          </span>
+          <button
+            onClick={() => setPage(Math.min(totalPages - 1, safePage + 1))}
+            disabled={safePage >= totalPages - 1}
+            className="px-1.5 py-0.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800 disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
 export default function CitesSummary({
   scientificName,
 }: {
@@ -115,8 +161,6 @@ export default function CitesSummary({
   const [tradeLoading, setTradeLoading] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [showAllSuspensions, setShowAllSuspensions] = useState(false);
-  const [showAllQuotas, setShowAllQuotas] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -232,12 +276,13 @@ export default function CitesSummary({
     );
   }
 
-  const suspensionsToShow = showAllSuspensions
-    ? data.suspensions || []
-    : (data.suspensions || []).slice(0, 5);
-  const quotasToShow = showAllQuotas
-    ? data.quotas || []
-    : (data.quotas || []).slice(0, 5);
+  // Suspensions newest-first; quotas largest-first.
+  const sortedSuspensions = [...(data.suspensions || [])].sort(
+    (a, b) => new Date(b.startDate).getTime() - new Date(a.startDate).getTime()
+  );
+  const sortedQuotas = [...(data.quotas || [])].sort(
+    (a, b) => (b.quota ?? -Infinity) - (a.quota ?? -Infinity)
+  );
 
   return (
     <div className="p-4 md:p-6 space-y-4">
@@ -285,152 +330,173 @@ export default function CitesSummary({
         </div>
       )}
 
-      {/* Listings & reservations — compact, side by side on wider screens */}
+      {/* Listings & reservations (left) · quotas & suspensions (right) */}
       {((data.currentListings && data.currentListings.length > 0) ||
-        (data.reservations && data.reservations.length > 0)) && (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-6 gap-y-4">
-          {data.currentListings && data.currentListings.length > 0 && (
-            <div>
-              <SectionHeader title="Current Listings" />
-              <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
-                {data.currentListings.map((listing, i) => (
-                  <div key={i} className="px-3 py-2">
-                    <div className="flex items-center gap-2 text-xs">
-                      <AppendixBadge appendix={listing.appendix} />
-                      <span className="text-zinc-400 dark:text-zinc-500 ml-auto whitespace-nowrap">
-                        since {fmtCitesDate(listing.effectiveAt)}
-                      </span>
+        (data.reservations && data.reservations.length > 0) ||
+        sortedSuspensions.length > 0 ||
+        sortedQuotas.length > 0) && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-6 gap-y-4 items-start">
+          {/* Left column */}
+          <div className="space-y-4">
+            {data.currentListings && data.currentListings.length > 0 && (
+              <div>
+                <SectionHeader title="Current Listings" count={data.currentListings.length} />
+                <PagedList items={data.currentListings}>
+                  {(slice) => (
+                    <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
+                      {slice.map((listing, i) => (
+                        <div key={i} className="px-3 py-2">
+                          <div className="flex items-center gap-2 text-xs">
+                            <AppendixBadge appendix={listing.appendix} />
+                            <span className="text-zinc-400 dark:text-zinc-500 ml-auto whitespace-nowrap">
+                              since {fmtCitesDate(listing.effectiveAt)}
+                            </span>
+                          </div>
+                          {listing.annotation && (
+                            <p
+                              title={listing.annotation}
+                              className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug line-clamp-3"
+                            >
+                              {listing.annotation}
+                            </p>
+                          )}
+                        </div>
+                      ))}
                     </div>
-                    {listing.annotation && (
-                      <p className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug">
-                        {listing.annotation}
-                      </p>
-                    )}
-                  </div>
-                ))}
+                  )}
+                </PagedList>
               </div>
-            </div>
-          )}
+            )}
 
-          {data.reservations && data.reservations.length > 0 && (
-            <div>
-              <SectionHeader title="Reservations" count={data.reservations.length} />
-              <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
-                {data.reservations.map((r, i) => (
-                  <div key={i} className="px-3 py-2">
-                    <div className="flex items-center gap-2 text-xs">
-                      <AppendixBadge appendix={r.appendix} />
-                      <span className="text-zinc-700 dark:text-zinc-300 font-medium truncate">
-                        {r.country || r.countryCode || "Unknown party"}
-                      </span>
-                      <span className="text-zinc-400 dark:text-zinc-500 ml-auto whitespace-nowrap">
-                        since {fmtCitesDate(r.effectiveAt)}
-                      </span>
+            {data.reservations && data.reservations.length > 0 && (
+              <div>
+                <SectionHeader title="Reservations" count={data.reservations.length} />
+                <PagedList items={data.reservations}>
+                  {(slice) => (
+                    <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
+                      {slice.map((r, i) => (
+                        <div key={i} className="px-3 py-2">
+                          <div className="flex items-center gap-2 text-xs">
+                            <AppendixBadge appendix={r.appendix} />
+                            <span
+                              title={r.country || r.countryCode || "Unknown party"}
+                              className="text-zinc-700 dark:text-zinc-300 font-medium truncate"
+                            >
+                              {r.country || r.countryCode || "Unknown party"}
+                            </span>
+                            <span className="text-zinc-400 dark:text-zinc-500 ml-auto whitespace-nowrap">
+                              since {fmtCitesDate(r.effectiveAt)}
+                            </span>
+                          </div>
+                          {r.annotation && (
+                            <p
+                              title={r.annotation}
+                              className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug line-clamp-3"
+                            >
+                              {r.annotation}
+                            </p>
+                          )}
+                        </div>
+                      ))}
                     </div>
-                    {r.annotation && (
-                      <p className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug">
-                        {r.annotation}
-                      </p>
-                    )}
-                  </div>
-                ))}
+                  )}
+                </PagedList>
               </div>
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Trade suspensions */}
-      {data.suspensions && data.suspensions.length > 0 && (
-        <div>
-          <SectionHeader title="Trade Suspensions" count={data.suspensions.length} />
-          <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
-            <table className="w-full text-[11px]">
-              <tbody>
-                {suspensionsToShow.map((s, i) => (
-                  <tr
-                    key={i}
-                    className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
-                  >
-                    <td className="px-3 py-1 text-zinc-700 dark:text-zinc-300">
-                      {s.country}
-                    </td>
-                    <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 capitalize whitespace-nowrap">
-                      {s.appliesTo}
-                    </td>
-                    <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 whitespace-nowrap tabular-nums">
-                      {new Date(s.startDate).toLocaleDateString("en-GB", {
-                        year: "numeric",
-                        month: "short",
-                      })}
-                    </td>
-                    <td className="px-3 py-1 text-right hidden md:table-cell">
-                      {s.notification?.url ? (
-                        <a
-                          href={s.notification.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-blue-600 dark:text-blue-400 hover:underline"
-                        >
-                          {s.notification.name}
-                        </a>
-                      ) : (
-                        <span className="text-zinc-400">{s.notification?.name || "—"}</span>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            {data.suspensions.length > 5 && (
-              <button
-                className="w-full px-3 py-1 text-[11px] text-blue-600 dark:text-blue-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 border-t border-zinc-100 dark:border-zinc-800"
-                onClick={() => setShowAllSuspensions(!showAllSuspensions)}
-              >
-                {showAllSuspensions
-                  ? "Show fewer"
-                  : `Show all ${data.suspensions.length}`}
-              </button>
             )}
           </div>
-        </div>
-      )}
 
-      {/* Trade quotas */}
-      {data.quotas && data.quotas.length > 0 && (
-        <div>
-          <SectionHeader title="Trade Quotas" count={data.quotas.length} />
-          <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
-            <table className="w-full text-[11px]">
-              <tbody>
-                {quotasToShow.map((q, i) => (
-                  <tr
-                    key={i}
-                    className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
-                  >
-                    <td className="px-3 py-1 text-zinc-700 dark:text-zinc-300 whitespace-nowrap">
-                      {q.country}
-                    </td>
-                    <td className="px-3 py-1 text-right text-zinc-700 dark:text-zinc-300 tabular-nums whitespace-nowrap">
-                      {q.quota != null ? q.quota.toLocaleString() : "—"}
-                      {q.unit ? ` ${q.unit}` : ""}
-                    </td>
-                    <td className="px-3 py-1 text-zinc-400 max-w-[280px] truncate hidden md:table-cell">
-                      {q.notes || "—"}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            {data.quotas.length > 5 && (
-              <button
-                className="w-full px-3 py-1 text-[11px] text-blue-600 dark:text-blue-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 border-t border-zinc-100 dark:border-zinc-800"
-                onClick={() => setShowAllQuotas(!showAllQuotas)}
-              >
-                {showAllQuotas
-                  ? "Show fewer"
-                  : `Show all ${data.quotas.length}`}
-              </button>
+          {/* Right column */}
+          <div className="space-y-4">
+            {sortedQuotas.length > 0 && (
+              <div>
+                <SectionHeader title="Trade Quotas" count={sortedQuotas.length} />
+                <PagedList items={sortedQuotas}>
+                  {(slice) => (
+                    <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+                      <table className="w-full text-[11px] table-fixed">
+                        <tbody>
+                          {slice.map((q, i) => (
+                            <tr
+                              key={i}
+                              className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
+                            >
+                              <td
+                                title={q.country}
+                                className="px-3 py-1 text-zinc-700 dark:text-zinc-300 truncate w-[35%]"
+                              >
+                                {q.country}
+                              </td>
+                              <td className="px-3 py-1 text-right text-zinc-700 dark:text-zinc-300 tabular-nums whitespace-nowrap w-[22%]">
+                                {q.quota != null ? q.quota.toLocaleString() : "—"}
+                                {q.unit ? ` ${q.unit}` : ""}
+                              </td>
+                              <td
+                                title={q.notes || undefined}
+                                className="px-3 py-1 text-zinc-400 truncate"
+                              >
+                                {q.notes || "—"}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </PagedList>
+              </div>
+            )}
+
+            {sortedSuspensions.length > 0 && (
+              <div>
+                <SectionHeader title="Trade Suspensions" count={sortedSuspensions.length} />
+                <PagedList items={sortedSuspensions}>
+                  {(slice) => (
+                    <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+                      <table className="w-full text-[11px] table-fixed">
+                        <tbody>
+                          {slice.map((s, i) => (
+                            <tr
+                              key={i}
+                              className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
+                            >
+                              <td
+                                title={s.country}
+                                className="px-3 py-1 text-zinc-700 dark:text-zinc-300 truncate"
+                              >
+                                {s.country}
+                              </td>
+                              <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 capitalize whitespace-nowrap w-[18%]">
+                                {s.appliesTo}
+                              </td>
+                              <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 whitespace-nowrap tabular-nums w-[22%]">
+                                {new Date(s.startDate).toLocaleDateString("en-GB", {
+                                  year: "numeric",
+                                  month: "short",
+                                })}
+                              </td>
+                              <td className="px-3 py-1 text-right whitespace-nowrap w-[28%] hidden md:table-cell">
+                                {s.notification?.url ? (
+                                  <a
+                                    href={s.notification.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    title={s.notification.name}
+                                    className="text-blue-600 dark:text-blue-400 hover:underline"
+                                  >
+                                    {s.notification.name}
+                                  </a>
+                                ) : (
+                                  <span className="text-zinc-400">{s.notification?.name || "—"}</span>
+                                )}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </PagedList>
+              </div>
             )}
           </div>
         </div>

--- a/app/src/components/CitesSummary.tsx
+++ b/app/src/components/CitesSummary.tsx
@@ -75,7 +75,7 @@ const APPENDIX_COLORS: Record<string, string> = {
 function AppendixBadge({ appendix }: { appendix: string }) {
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold ${APPENDIX_COLORS[appendix] || "bg-zinc-100 text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200"}`}
+      className={`inline-flex items-center shrink-0 whitespace-nowrap px-2 py-0.5 rounded text-xs font-semibold ${APPENDIX_COLORS[appendix] || "bg-zinc-100 text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200"}`}
     >
       Appendix {appendix}
     </span>
@@ -124,8 +124,8 @@ function PagedList<T>({
   const slice = items.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE);
 
   return (
-    <>
-      {children(slice)}
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="flex-1">{children(slice)}</div>
       {totalPages > 1 && (
         <div className="flex items-center justify-between mt-1 text-[10px] text-zinc-400 dark:text-zinc-500">
           <button
@@ -147,7 +147,7 @@ function PagedList<T>({
           </button>
         </div>
       )}
-    </>
+    </div>
   );
 }
 
@@ -284,6 +284,28 @@ export default function CitesSummary({
     (a, b) => (b.quota ?? -Infinity) - (a.quota ?? -Infinity)
   );
 
+  // Group reservations that share an appendix + annotation, so the (often
+  // identical) annotation text isn't repeated per country.
+  const reservationGroups: {
+    appendix: string;
+    annotation: string | null;
+    parties: { name: string; effectiveAt: string }[];
+  }[] = [];
+  for (const r of data.reservations || []) {
+    const key = `${r.appendix}|${r.annotation ?? ""}`;
+    let group = reservationGroups.find(
+      (g) => `${g.appendix}|${g.annotation ?? ""}` === key
+    );
+    if (!group) {
+      group = { appendix: r.appendix, annotation: r.annotation, parties: [] };
+      reservationGroups.push(group);
+    }
+    group.parties.push({
+      name: r.country || r.countryCode || "Unknown party",
+      effectiveAt: r.effectiveAt,
+    });
+  }
+
   return (
     <div className="p-4 md:p-6 space-y-4">
       {/* Listing summary + external links */}
@@ -330,175 +352,173 @@ export default function CitesSummary({
         </div>
       )}
 
-      {/* Listings & reservations (left) · quotas & suspensions (right) */}
+      {/* Current Listings | Reservations */}
       {((data.currentListings && data.currentListings.length > 0) ||
-        (data.reservations && data.reservations.length > 0) ||
-        sortedSuspensions.length > 0 ||
-        sortedQuotas.length > 0) && (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-6 gap-y-4 items-start">
-          {/* Left column */}
-          <div className="space-y-4">
-            {data.currentListings && data.currentListings.length > 0 && (
-              <div>
-                <SectionHeader title="Current Listings" count={data.currentListings.length} />
-                <PagedList items={data.currentListings}>
-                  {(slice) => (
-                    <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
-                      {slice.map((listing, i) => (
-                        <div key={i} className="px-3 py-2">
-                          <div className="flex items-center gap-2 text-xs">
-                            <AppendixBadge appendix={listing.appendix} />
-                            <span className="text-zinc-400 dark:text-zinc-500 ml-auto whitespace-nowrap">
-                              since {fmtCitesDate(listing.effectiveAt)}
-                            </span>
-                          </div>
-                          {listing.annotation && (
-                            <p
-                              title={listing.annotation}
-                              className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug line-clamp-3"
-                            >
-                              {listing.annotation}
-                            </p>
-                          )}
+        reservationGroups.length > 0) && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-6 gap-y-4 items-stretch">
+          {data.currentListings && data.currentListings.length > 0 && (
+            <div className="flex flex-col">
+              <SectionHeader title="Current Listings" count={data.currentListings.length} />
+              <PagedList items={data.currentListings}>
+                {(slice) => (
+                  <div className="h-full rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
+                    {slice.map((listing, i) => (
+                      <div key={i} className="px-3 py-2">
+                        <div className="flex items-center gap-2 text-xs">
+                          <AppendixBadge appendix={listing.appendix} />
+                          <span className="text-zinc-400 dark:text-zinc-500 ml-auto whitespace-nowrap">
+                            since {fmtCitesDate(listing.effectiveAt)}
+                          </span>
                         </div>
-                      ))}
-                    </div>
-                  )}
-                </PagedList>
-              </div>
-            )}
+                        {listing.annotation && (
+                          <p
+                            title={listing.annotation}
+                            className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug line-clamp-3"
+                          >
+                            {listing.annotation}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </PagedList>
+            </div>
+          )}
 
-            {data.reservations && data.reservations.length > 0 && (
-              <div>
-                <SectionHeader title="Reservations" count={data.reservations.length} />
-                <PagedList items={data.reservations}>
-                  {(slice) => (
-                    <div className="rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
-                      {slice.map((r, i) => (
-                        <div key={i} className="px-3 py-2">
-                          <div className="flex items-center gap-2 text-xs">
-                            <AppendixBadge appendix={r.appendix} />
-                            <span
-                              title={r.country || r.countryCode || "Unknown party"}
-                              className="text-zinc-700 dark:text-zinc-300 font-medium truncate"
-                            >
-                              {r.country || r.countryCode || "Unknown party"}
-                            </span>
-                            <span className="text-zinc-400 dark:text-zinc-500 ml-auto whitespace-nowrap">
-                              since {fmtCitesDate(r.effectiveAt)}
-                            </span>
-                          </div>
-                          {r.annotation && (
-                            <p
-                              title={r.annotation}
-                              className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug line-clamp-3"
-                            >
-                              {r.annotation}
-                            </p>
-                          )}
+          {reservationGroups.length > 0 && (
+            <div className="flex flex-col">
+              <SectionHeader title="Reservations" count={data.reservations?.length} />
+              <PagedList items={reservationGroups}>
+                {(slice) => (
+                  <div className="h-full rounded-lg border border-zinc-200 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
+                    {slice.map((group, i) => (
+                      <div key={i} className="px-3 py-2">
+                        <AppendixBadge appendix={group.appendix} />
+                        <div className="mt-1.5 space-y-0.5">
+                          {group.parties.map((p, j) => (
+                            <div key={j} className="flex items-baseline gap-2 text-xs">
+                              <span className="text-zinc-700 dark:text-zinc-300">
+                                {p.name}
+                              </span>
+                              <span className="text-zinc-400 dark:text-zinc-500 ml-auto shrink-0 whitespace-nowrap">
+                                since {fmtCitesDate(p.effectiveAt)}
+                              </span>
+                            </div>
+                          ))}
                         </div>
-                      ))}
-                    </div>
-                  )}
-                </PagedList>
-              </div>
-            )}
-          </div>
+                        {group.annotation && (
+                          <p
+                            title={group.annotation}
+                            className="mt-1.5 text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug line-clamp-3"
+                          >
+                            {group.annotation}
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </PagedList>
+            </div>
+          )}
+        </div>
+      )}
 
-          {/* Right column */}
-          <div className="space-y-4">
-            {sortedQuotas.length > 0 && (
-              <div>
-                <SectionHeader title="Trade Quotas" count={sortedQuotas.length} />
-                <PagedList items={sortedQuotas}>
-                  {(slice) => (
-                    <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
-                      <table className="w-full text-[11px] table-fixed">
-                        <tbody>
-                          {slice.map((q, i) => (
-                            <tr
-                              key={i}
-                              className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
+      {/* Trade Quotas | Trade Suspensions */}
+      {(sortedQuotas.length > 0 || sortedSuspensions.length > 0) && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-6 gap-y-4 items-stretch">
+          {sortedQuotas.length > 0 && (
+            <div className="flex flex-col">
+              <SectionHeader title="Trade Quotas" count={sortedQuotas.length} />
+              <PagedList items={sortedQuotas}>
+                {(slice) => (
+                  <div className="h-full border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+                    <table className="w-full text-[11px] table-fixed">
+                      <tbody>
+                        {slice.map((q, i) => (
+                          <tr
+                            key={i}
+                            className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
+                          >
+                            <td
+                              title={q.country}
+                              className="px-3 py-1 text-zinc-700 dark:text-zinc-300 truncate w-[35%]"
                             >
-                              <td
-                                title={q.country}
-                                className="px-3 py-1 text-zinc-700 dark:text-zinc-300 truncate w-[35%]"
-                              >
-                                {q.country}
-                              </td>
-                              <td className="px-3 py-1 text-right text-zinc-700 dark:text-zinc-300 tabular-nums whitespace-nowrap w-[22%]">
-                                {q.quota != null ? q.quota.toLocaleString() : "—"}
-                                {q.unit ? ` ${q.unit}` : ""}
-                              </td>
-                              <td
-                                title={q.notes || undefined}
-                                className="px-3 py-1 text-zinc-400 truncate"
-                              >
-                                {q.notes || "—"}
-                              </td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    </div>
-                  )}
-                </PagedList>
-              </div>
-            )}
+                              {q.country}
+                            </td>
+                            <td className="px-3 py-1 text-right text-zinc-700 dark:text-zinc-300 tabular-nums whitespace-nowrap w-[22%]">
+                              {q.quota != null ? q.quota.toLocaleString() : "—"}
+                              {q.unit ? ` ${q.unit}` : ""}
+                            </td>
+                            <td
+                              title={q.notes || undefined}
+                              className="px-3 py-1 text-zinc-400 truncate"
+                            >
+                              {q.notes || "—"}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </PagedList>
+            </div>
+          )}
 
-            {sortedSuspensions.length > 0 && (
-              <div>
-                <SectionHeader title="Trade Suspensions" count={sortedSuspensions.length} />
-                <PagedList items={sortedSuspensions}>
-                  {(slice) => (
-                    <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
-                      <table className="w-full text-[11px] table-fixed">
-                        <tbody>
-                          {slice.map((s, i) => (
-                            <tr
-                              key={i}
-                              className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
+          {sortedSuspensions.length > 0 && (
+            <div className="flex flex-col">
+              <SectionHeader title="Trade Suspensions" count={sortedSuspensions.length} />
+              <PagedList items={sortedSuspensions}>
+                {(slice) => (
+                  <div className="h-full border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+                    <table className="w-full text-[11px] table-fixed">
+                      <tbody>
+                        {slice.map((s, i) => (
+                          <tr
+                            key={i}
+                            className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
+                          >
+                            <td
+                              title={s.country}
+                              className="px-3 py-1 text-zinc-700 dark:text-zinc-300 truncate"
                             >
-                              <td
-                                title={s.country}
-                                className="px-3 py-1 text-zinc-700 dark:text-zinc-300 truncate"
-                              >
-                                {s.country}
-                              </td>
-                              <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 capitalize whitespace-nowrap w-[18%]">
-                                {s.appliesTo}
-                              </td>
-                              <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 whitespace-nowrap tabular-nums w-[22%]">
-                                {new Date(s.startDate).toLocaleDateString("en-GB", {
-                                  year: "numeric",
-                                  month: "short",
-                                })}
-                              </td>
-                              <td className="px-3 py-1 text-right whitespace-nowrap w-[28%] hidden md:table-cell">
-                                {s.notification?.url ? (
-                                  <a
-                                    href={s.notification.url}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    title={s.notification.name}
-                                    className="text-blue-600 dark:text-blue-400 hover:underline"
-                                  >
-                                    {s.notification.name}
-                                  </a>
-                                ) : (
-                                  <span className="text-zinc-400">{s.notification?.name || "—"}</span>
-                                )}
-                              </td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    </div>
-                  )}
-                </PagedList>
-              </div>
-            )}
-          </div>
+                              {s.country}
+                            </td>
+                            <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 capitalize whitespace-nowrap w-[18%]">
+                              {s.appliesTo}
+                            </td>
+                            <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 whitespace-nowrap tabular-nums w-[22%]">
+                              {new Date(s.startDate).toLocaleDateString("en-GB", {
+                                year: "numeric",
+                                month: "short",
+                              })}
+                            </td>
+                            <td className="px-3 py-1 text-right whitespace-nowrap w-[28%] hidden md:table-cell">
+                              {s.notification?.url ? (
+                                <a
+                                  href={s.notification.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  title={s.notification.name}
+                                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                                >
+                                  {s.notification.name}
+                                </a>
+                              ) : (
+                                <span className="text-zinc-400">{s.notification?.name || "—"}</span>
+                              )}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </PagedList>
+            </div>
+          )}
         </div>
       )}
 

--- a/app/src/components/CitesSummary.tsx
+++ b/app/src/components/CitesSummary.tsx
@@ -218,7 +218,17 @@ export default function CitesSummary({
 
   return (
     <div className="p-4 md:p-6 space-y-5">
-      {/* Header: Listing summary */}
+      {/* Trade overview from CITES Trade Database */}
+      {data.citesId && (
+        <div>
+          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
+            International Trade
+          </h4>
+          <CitesTradeSummary citesId={data.citesId} prefetchedData={tradeData} prefetchedLoading={tradeLoading} suspensionCountries={suspensionCountryCodes} countryAnnotations={countryAnnotations} />
+        </div>
+      )}
+
+      {/* Listing summary + external links — below the trade info */}
       <div className="flex flex-wrap items-center gap-3">
         {data.citesListing ? (
           <div className="flex items-center gap-2">
@@ -251,16 +261,6 @@ export default function CitesSummary({
           </a>
         </div>
       </div>
-
-      {/* Trade overview from CITES Trade Database */}
-      {data.citesId && (
-        <div>
-          <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-            International Trade
-          </h4>
-          <CitesTradeSummary citesId={data.citesId} prefetchedData={tradeData} prefetchedLoading={tradeLoading} suspensionCountries={suspensionCountryCodes} countryAnnotations={countryAnnotations} />
-        </div>
-      )}
 
       {/* Current listings detail — below trade overview, above suspensions/quotas */}
       {data.currentListings && data.currentListings.length > 0 && (

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -131,10 +131,6 @@ function termUnitKey(term: string, unit: string): string {
   return `${term}|${unit}`;
 }
 
-function unitLabel(unit: string): string {
-  return unit || "no unit";
-}
-
 /* ------------------------------------------------------------------ */
 /*  Aggregation                                                        */
 /* ------------------------------------------------------------------ */
@@ -267,83 +263,102 @@ function aggregateShipments(rows: CompactRecord[]): Aggregated {
 }
 
 /* ------------------------------------------------------------------ */
-/*  Filter checkbox row                                                */
+/*  Interactive filter bar chart                                        */
 /* ------------------------------------------------------------------ */
 
-function FilterCheckbox({
-  label,
-  sublabel,
-  count,
-  checked,
-  onChange,
-  color,
-}: {
+interface FilterBar {
+  /** Stable key passed back to onToggle (source/purpose code or term key). */
+  key: string;
   label: string;
   sublabel?: string;
-  count: number;
-  checked: boolean;
-  onChange: () => void;
-  color?: string;
-}) {
-  return (
-    <div
-      className={`flex items-center gap-2 transition-opacity cursor-pointer select-none ${
-        checked ? "" : "opacity-40"
-      }`}
-      onClick={onChange}
-    >
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={onChange}
-        onClick={(e) => e.stopPropagation()}
-        className="w-3.5 h-3.5 rounded shrink-0"
-        style={color ? { accentColor: color } : undefined}
-      />
-      <span className="flex-1 text-xs text-zinc-700 dark:text-zinc-300 truncate capitalize">
-        {label}
-        {sublabel && (
-          <span className="text-zinc-400 dark:text-zinc-500 ml-1 normal-case">
-            ({sublabel})
-          </span>
-        )}
-      </span>
-      <span className="text-xs text-zinc-400 dark:text-zinc-500 tabular-nums shrink-0">
-        {count.toLocaleString()}
-      </span>
-    </div>
-  );
+  records: number;
+  /** Whether this category is currently included by the filter. */
+  active: boolean;
+  /** Tailwind classes for the bar fill. */
+  barClass: string;
+  /** Optional tooltip override (defaults to "label (sublabel) — N records"). */
+  title?: string;
 }
 
-/** Section header with All / None bulk-select buttons. */
-function FilterSectionHeader({
+/**
+ * A scrollable horizontal bar chart that doubles as a cross-filter: clicking a
+ * bar calls onToggle(key) to add/remove that category, and de-selected bars are
+ * dimmed but stay visible so they can be toggled back on. An optional search box
+ * (used by the Commodity chart) filters the rows shown.
+ */
+function FilterBarChart({
   title,
-  onAll,
-  onNone,
+  bars,
+  onToggle,
+  search,
+  onSearchChange,
+  searchPlaceholder,
+  emptyHint,
 }: {
   title: string;
-  onAll: () => void;
-  onNone: () => void;
+  bars: FilterBar[];
+  onToggle?: (key: string) => void;
+  search?: string;
+  onSearchChange?: (value: string) => void;
+  searchPlaceholder?: string;
+  emptyHint?: string;
 }) {
+  const max = bars.reduce((m, b) => Math.max(m, b.records), 0);
+
   return (
-    <div className="flex items-center justify-between mb-1.5">
-      <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+    <div className="min-w-0">
+      <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
         {title}
       </h5>
-      <div className="flex items-center gap-1 text-[10px]">
-        <button
-          className="text-blue-600 dark:text-blue-400 hover:underline"
-          onClick={onAll}
-        >
-          All
-        </button>
-        <span className="text-zinc-300 dark:text-zinc-600">/</span>
-        <button
-          className="text-blue-600 dark:text-blue-400 hover:underline"
-          onClick={onNone}
-        >
-          None
-        </button>
+      {onSearchChange && (
+        <input
+          type="text"
+          value={search ?? ""}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder={searchPlaceholder}
+          className="w-full mb-1.5 px-2 py-1 text-xs rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300 placeholder:text-zinc-400"
+        />
+      )}
+      <div className="space-y-1 max-h-[240px] overflow-y-auto pr-1">
+        {bars.map((b) => {
+          const pct = max > 0 ? (b.records / max) * 100 : 0;
+          return (
+            <div
+              key={b.key}
+              onClick={onToggle ? () => onToggle(b.key) : undefined}
+              title={
+                b.title ??
+                `${b.label}${b.sublabel ? ` (${b.sublabel})` : ""} — ${b.records.toLocaleString()} records`
+              }
+              className={`flex items-center gap-2 text-xs select-none transition-opacity ${
+                onToggle ? "cursor-pointer" : ""
+              } ${b.active ? "" : "opacity-40"}`}
+            >
+              <span className="w-24 shrink-0 truncate capitalize text-zinc-700 dark:text-zinc-300">
+                {b.label}
+                {b.sublabel && (
+                  <span className="text-zinc-400 dark:text-zinc-500 ml-1 normal-case">
+                    {b.sublabel}
+                  </span>
+                )}
+              </span>
+              <div className="flex-1 h-3.5 bg-zinc-100 dark:bg-zinc-800 rounded overflow-hidden">
+                <div
+                  className={`h-full rounded ${b.barClass}`}
+                  style={{ width: `${Math.max(pct, 1)}%` }}
+                />
+              </div>
+              <span className="w-12 text-right text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">
+                {b.records.toLocaleString()}
+              </span>
+            </div>
+          );
+        })}
+        {bars.length === 0 && emptyHint && (
+          <span className="text-[11px] text-zinc-400 dark:text-zinc-500">
+            {emptyHint}
+          </span>
+        )}
       </div>
     </div>
   );
@@ -678,81 +693,6 @@ function TrendSummary({
 }
 
 /* ------------------------------------------------------------------ */
-/*  Source breakdown (wild vs captive bar)                              */
-/* ------------------------------------------------------------------ */
-
-function SourceBreakdown({
-  sources,
-  wildActive = true,
-  captiveActive = true,
-  onToggleWild,
-  onToggleCaptive,
-}: {
-  sources: CodedData[];
-  wildActive?: boolean;
-  captiveActive?: boolean;
-  onToggleWild?: () => void;
-  onToggleCaptive?: () => void;
-}) {
-  const total = sources.reduce((s, d) => s + d.records, 0);
-  if (total === 0) return null;
-
-  const wildRecords = sources
-    .filter((s) => WILD_SOURCE_CODES.has(s.code))
-    .reduce((sum, s) => sum + s.records, 0);
-  const captiveRecords = total - wildRecords;
-  const wildPct = Math.round((wildRecords / total) * 100);
-  const captivePct = 100 - wildPct;
-
-  const rows = [
-    {
-      label: "Wild",
-      active: wildActive,
-      onToggle: onToggleWild,
-      bar: "bg-amber-400 dark:bg-amber-500",
-      pct: wildPct,
-      records: wildRecords,
-    },
-    {
-      label: "Captive",
-      active: captiveActive,
-      onToggle: onToggleCaptive,
-      bar: "bg-emerald-300 dark:bg-emerald-600",
-      pct: captivePct,
-      records: captiveRecords,
-    },
-  ];
-
-  return (
-    <div className="space-y-1.5">
-      {rows.map((r) => (
-        <div
-          key={r.label}
-          onClick={r.onToggle}
-          title={r.onToggle ? `Filter by ${r.label.toLowerCase()} source` : undefined}
-          className={`flex items-center gap-2 text-xs select-none transition-opacity ${
-            r.onToggle ? "cursor-pointer" : ""
-          } ${r.active ? "" : "opacity-40"}`}
-        >
-          <span className="w-16 text-zinc-600 dark:text-zinc-300 shrink-0">
-            {r.label}
-          </span>
-          <div className="flex-1 h-4 bg-zinc-100 dark:bg-zinc-800 rounded overflow-hidden">
-            <div
-              className={`h-full rounded ${r.bar}`}
-              style={{ width: `${Math.max(r.pct, 1)}%` }}
-            />
-          </div>
-          <span className="w-20 text-right text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">
-            {r.pct}% ({r.records.toLocaleString()})
-          </span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-/* ------------------------------------------------------------------ */
 /*  Country table                                                      */
 /* ------------------------------------------------------------------ */
 
@@ -898,50 +838,6 @@ export default function CitesTradeSummary({
     setCheckedTerms((prev) => ({ ...prev, [key]: !prev[key] }));
   }, []);
 
-  // Toggle every source code in the wild (or captive) bucket at once. If any
-  // code in the bucket is currently on, the click turns the whole bucket off;
-  // otherwise it turns it back on.
-  const toggleSourceBucket = useCallback(
-    (wild: boolean) => {
-      const codes = (data?.allSources ?? [])
-        .filter((s) => WILD_SOURCE_CODES.has(s.code) === wild)
-        .map((s) => s.code);
-      if (codes.length === 0) return;
-      setCheckedSources((prev) => {
-        const anyOn = codes.some((c) => prev[c] !== false);
-        const next = { ...prev };
-        for (const c of codes) next[c] = !anyOn;
-        return next;
-      });
-    },
-    [data]
-  );
-
-  const setAll = useCallback(
-    (
-      setter: React.Dispatch<React.SetStateAction<Record<string, boolean>>>,
-      keys: string[],
-      value: boolean
-    ) => {
-      setter((prev) => {
-        const next = { ...prev };
-        for (const k of keys) next[k] = value;
-        return next;
-      });
-    },
-    []
-  );
-
-  // Commodity rows filtered by the search box
-  const visibleTermRows = useMemo(() => {
-    const rows = data?.allTermsByUnit ?? [];
-    const q = termSearch.trim().toLowerCase();
-    if (!q) return rows;
-    return rows.filter((t) =>
-      `${t.term} ${t.unit}`.toLowerCase().includes(q)
-    );
-  }, [data?.allTermsByUnit, termSearch]);
-
   // Are any filters active (something unchecked, or a year range trimmed)?
   const hasActiveFilters = useMemo(() => {
     const anySourceOff = Object.values(checkedSources).some((v) => !v);
@@ -1018,6 +914,17 @@ export default function CitesTradeSummary({
     return aggregateShipments(rows).topSources;
   }, [data, checkedPurposes, checkedTerms, brush]);
 
+  const purposeChart = useMemo(() => {
+    if (!data?.found || !data.shipments) return [];
+    const rows = data.shipments.filter((r) => {
+      if (r.s && checkedSources[r.s] === false) return false;
+      if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
+      if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
+      return true;
+    });
+    return aggregateShipments(rows).topPurposes;
+  }, [data, checkedSources, checkedTerms, brush]);
+
   const hasShipments = !!data?.shipments && data.shipments.length > 0;
 
   /* ---------------------------------------------------------------- */
@@ -1059,8 +966,6 @@ export default function CitesTradeSummary({
   // Fall back to server-provided byYear when no shipments for client filtering
   const chartByYear =
     hasShipments && chartAgg.byYear.length > 0 ? chartAgg.byYear : data.byYear;
-  const displaySources =
-    hasShipments && sourceChart.length > 0 ? sourceChart : data.topSources;
   const displayExporters =
     hasShipments && display.topExporters.length > 0 ? display.topExporters : data.topExporters;
   const displayImporters =
@@ -1068,18 +973,50 @@ export default function CitesTradeSummary({
   const displayFlows =
     hasShipments && display.topFlows.length > 0 ? display.topFlows : data.topFlows ?? [];
 
-  // Cross-filter affordances (only interactive when we have client-side rows).
-  const maxCommodityRecords = commodityChart.reduce(
-    (m, t) => Math.max(m, t.records),
-    0
-  );
-  const allSources = data.allSources ?? [];
-  const wildActive = allSources.some(
-    (s) => WILD_SOURCE_CODES.has(s.code) && checkedSources[s.code] !== false
-  );
-  const captiveActive = allSources.some(
-    (s) => !WILD_SOURCE_CODES.has(s.code) && checkedSources[s.code] !== false
-  );
+  // Build the three interactive filter charts. Source bars keep the
+  // wild (amber) vs captive (emerald) distinction by colour.
+  const sourceBars: FilterBar[] = sourceChart.map((s) => ({
+    key: s.code,
+    label: s.label,
+    sublabel: s.code,
+    records: s.records,
+    active: checkedSources[s.code] !== false,
+    barClass: WILD_SOURCE_CODES.has(s.code)
+      ? "bg-amber-400 dark:bg-amber-500"
+      : "bg-emerald-300 dark:bg-emerald-600",
+  }));
+
+  const purposeBars: FilterBar[] = purposeChart.map((p) => ({
+    key: p.code,
+    label: p.label,
+    sublabel: p.code,
+    records: p.records,
+    active: checkedPurposes[p.code] !== false,
+    barClass: "bg-blue-400 dark:bg-blue-500",
+  }));
+
+  const commoditySearch = termSearch.trim().toLowerCase();
+  const commodityBars: FilterBar[] = commodityChart
+    .filter((t) =>
+      commoditySearch
+        ? `${t.term} ${t.unit}`.toLowerCase().includes(commoditySearch)
+        : true
+    )
+    .map((t) => {
+      const key = termUnitKey(t.term, t.unit);
+      return {
+        key,
+        label: t.term,
+        sublabel: t.unit || undefined,
+        records: t.records,
+        active: checkedTerms[key] !== false,
+        barClass: "bg-violet-400 dark:bg-violet-500",
+        title: `${t.term}${t.unit ? ` (${t.unit})` : ""} — ${t.records.toLocaleString()} records / ${fmtQty(t.quantity)} items`,
+      };
+    });
+
+  const hasFilterCharts =
+    sourceBars.length > 0 || purposeBars.length > 0 || commodityChart.length > 0;
 
   return (
     <div className="space-y-4">
@@ -1110,255 +1047,98 @@ export default function CitesTradeSummary({
         )}
       </div>
 
-      {/* Trade flow map */}
-      {displayFlows.length > 0 && (
-        <div className="border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden bg-zinc-50 dark:bg-zinc-800/30">
-          <TradeFlowMap
-            flows={displayFlows}
-            reExportFlows={display.reExportFlows}
-            exporters={displayExporters}
-            importers={displayImporters}
-            suspensionCountries={suspensionCountries}
-            countryAnnotations={countryAnnotations}
-          />
+      {/* Trade flow map with Top exporters / importers alongside it */}
+      {displayFlows.length > 0 ? (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          <div className="lg:col-span-2 border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden bg-zinc-50 dark:bg-zinc-800/30">
+            <TradeFlowMap
+              flows={displayFlows}
+              reExportFlows={display.reExportFlows}
+              exporters={displayExporters}
+              importers={displayImporters}
+              suspensionCountries={suspensionCountries}
+              countryAnnotations={countryAnnotations}
+            />
+          </div>
+          <div className="space-y-4">
+            <CountryTable data={displayExporters} label="Top exporters" />
+            <CountryTable data={displayImporters} label="Top importers" />
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <CountryTable data={displayExporters} label="Top exporters" />
+          <CountryTable data={displayImporters} label="Top importers" />
         </div>
       )}
 
-      {/* Exporters & Importers */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <CountryTable data={displayExporters} label="Top exporters" />
-        <CountryTable data={displayImporters} label="Top importers" />
-      </div>
-
-      {/* Filters + Chart side by side */}
-      <div
-        className={`grid grid-cols-1 gap-4 ${
-          hasShipments ? "md:grid-cols-[230px_1fr]" : ""
-        }`}
-      >
-        {/* Filter panel */}
-        {hasShipments && (
-          <div className="space-y-3 border border-zinc-200 dark:border-zinc-700 rounded-lg p-3 bg-zinc-50/50 dark:bg-zinc-800/20 max-h-[520px] overflow-y-auto">
-            {/* Source filters */}
-            {data.allSources && data.allSources.length > 0 && (
-              <div>
-                <FilterSectionHeader
-                  title="Source"
-                  onAll={() =>
-                    setAll(setCheckedSources, data.allSources!.map((s) => s.code), true)
-                  }
-                  onNone={() =>
-                    setAll(setCheckedSources, data.allSources!.map((s) => s.code), false)
-                  }
-                />
-                <div className="space-y-1">
-                  {data.allSources.map((s) => (
-                    <FilterCheckbox
-                      key={s.code}
-                      label={s.label}
-                      sublabel={s.code}
-                      count={s.records}
-                      checked={checkedSources[s.code] ?? true}
-                      onChange={() => toggleSource(s.code)}
-                      color={WILD_SOURCE_CODES.has(s.code) ? "#f59e0b" : "#34d399"}
-                    />
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Purpose filters */}
-            {data.allPurposes && data.allPurposes.length > 0 && (
-              <div>
-                <FilterSectionHeader
-                  title="Purpose"
-                  onAll={() =>
-                    setAll(setCheckedPurposes, data.allPurposes!.map((p) => p.code), true)
-                  }
-                  onNone={() =>
-                    setAll(setCheckedPurposes, data.allPurposes!.map((p) => p.code), false)
-                  }
-                />
-                <div className="space-y-1">
-                  {data.allPurposes.map((p) => (
-                    <FilterCheckbox
-                      key={p.code}
-                      label={p.label}
-                      sublabel={p.code}
-                      count={p.records}
-                      checked={checkedPurposes[p.code] ?? true}
-                      onChange={() => togglePurpose(p.code)}
-                      color="#3b82f6"
-                    />
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Commodity (term + unit) filters — searchable, no truncation */}
-            {data.allTermsByUnit && data.allTermsByUnit.length > 0 && (
-              <div>
-                <FilterSectionHeader
-                  title="Commodity"
-                  onAll={() =>
-                    setAll(
-                      setCheckedTerms,
-                      visibleTermRows.map((t) => termUnitKey(t.term, t.unit)),
-                      true
-                    )
-                  }
-                  onNone={() =>
-                    setAll(
-                      setCheckedTerms,
-                      visibleTermRows.map((t) => termUnitKey(t.term, t.unit)),
-                      false
-                    )
-                  }
-                />
-                {data.allTermsByUnit.length > 6 && (
-                  <input
-                    type="text"
-                    value={termSearch}
-                    onChange={(e) => setTermSearch(e.target.value)}
-                    placeholder="Search commodities…"
-                    className="w-full mb-1.5 px-2 py-1 text-xs rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300 placeholder:text-zinc-400"
-                  />
-                )}
-                <div className="space-y-1">
-                  {visibleTermRows.map((t) => {
-                    const key = termUnitKey(t.term, t.unit);
-                    return (
-                      <FilterCheckbox
-                        key={key}
-                        label={t.term}
-                        sublabel={unitLabel(t.unit)}
-                        count={t.records}
-                        checked={checkedTerms[key] ?? true}
-                        onChange={() => toggleTerm(key)}
-                        color="#8b5cf6"
-                      />
-                    );
-                  })}
-                  {visibleTermRows.length === 0 && (
-                    <span className="text-[11px] text-zinc-400 dark:text-zinc-500">
-                      No commodities match “{termSearch}”.
-                    </span>
-                  )}
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Chart + details */}
-        <div className="space-y-4 min-w-0">
-          {/* Metric toggle + line chart with trim handles */}
-          <div>
-            <div className="flex items-center gap-2 mb-2">
-              <span className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
-                Trade over time
-              </span>
-              <span className="text-[11px] text-zinc-400 dark:text-zinc-500 normal-case">
-                (shipments)
-              </span>
-              {brush && (
-                <span className="text-[11px] text-blue-600 dark:text-blue-400 tabular-nums ml-auto">
-                  {brush[0]}–{brush[1]}
-                </span>
-              )}
-            </div>
-            <TrendLineChart
-              data={chartByYear}
-              metric={metric}
-              minYear={minYear}
-              maxYear={maxYear}
-              brush={brush}
-              onBrushChange={setBrush}
-              provisionalFromYear={provisionalFromYear}
-            />
-            <p className="text-[10px] text-zinc-400 dark:text-zinc-500 mt-1 leading-snug">
-              Drag the handles to trim the year range.
-              {maxYear >= provisionalFromYear && (
-                <>
-                  {" "}
-                  Recent years (dashed, {provisionalFromYear}+) are{" "}
-                  <span className="text-amber-500 dark:text-amber-400">provisional</span> —
-                  CITES reporting lags by a few years, so they are usually incomplete
-                  rather than showing a real drop.
-                </>
-              )}
-            </p>
-          </div>
-
-          {/* Source breakdown — most important for assessors. Click a bar to
-              filter the whole summary to that source group. */}
-          {displaySources.length > 0 && (
-            <div>
-              <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-                Wild vs. Captive
-              </h5>
-              <SourceBreakdown
-                sources={displaySources}
-                wildActive={wildActive}
-                captiveActive={captiveActive}
-                onToggleWild={hasShipments ? () => toggleSourceBucket(true) : undefined}
-                onToggleCaptive={
-                  hasShipments ? () => toggleSourceBucket(false) : undefined
-                }
-              />
-            </div>
-          )}
-
-          {/* Commodities — grouped by term + unit (never aggregated across
-              units). Scrollable bar chart; click a bar to filter the summary
-              to that commodity. */}
-          {commodityChart.length > 0 && (
-            <div>
-              <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
-                Commodities
-              </h5>
-              <div className="space-y-1 max-h-[200px] overflow-y-auto pr-1">
-                {commodityChart.map((t) => {
-                  const key = termUnitKey(t.term, t.unit);
-                  const active = checkedTerms[key] !== false;
-                  const pct =
-                    maxCommodityRecords > 0
-                      ? (t.records / maxCommodityRecords) * 100
-                      : 0;
-                  return (
-                    <div
-                      key={key}
-                      onClick={hasShipments ? () => toggleTerm(key) : undefined}
-                      title={`${t.term}${t.unit ? ` (${t.unit})` : ""} — ${t.records.toLocaleString()} records / ${fmtQty(t.quantity)} items`}
-                      className={`flex items-center gap-2 text-xs select-none transition-opacity ${
-                        hasShipments ? "cursor-pointer" : ""
-                      } ${active ? "" : "opacity-40"}`}
-                    >
-                      <span className="w-28 shrink-0 truncate capitalize text-zinc-700 dark:text-zinc-300">
-                        {t.term}
-                        {t.unit && (
-                          <span className="text-zinc-400 dark:text-zinc-500 ml-1 normal-case">
-                            {t.unit}
-                          </span>
-                        )}
-                      </span>
-                      <div className="flex-1 h-3.5 bg-zinc-100 dark:bg-zinc-800 rounded overflow-hidden">
-                        <div
-                          className="h-full bg-violet-400 dark:bg-violet-500 rounded"
-                          style={{ width: `${Math.max(pct, 1)}%` }}
-                        />
-                      </div>
-                      <span className="w-12 text-right text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">
-                        {t.records.toLocaleString()}
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
+      {/* Trade over time */}
+      <div>
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+            Trade over time
+          </span>
+          <span className="text-[11px] text-zinc-400 dark:text-zinc-500 normal-case">
+            (shipments)
+          </span>
+          {brush && (
+            <span className="text-[11px] text-blue-600 dark:text-blue-400 tabular-nums ml-auto">
+              {brush[0]}–{brush[1]}
+            </span>
           )}
         </div>
+        <TrendLineChart
+          data={chartByYear}
+          metric={metric}
+          minYear={minYear}
+          maxYear={maxYear}
+          brush={brush}
+          onBrushChange={setBrush}
+          provisionalFromYear={provisionalFromYear}
+        />
+        <p className="text-[10px] text-zinc-400 dark:text-zinc-500 mt-1 leading-snug">
+          Drag the handles to trim the year range.
+          {maxYear >= provisionalFromYear && (
+            <>
+              {" "}
+              Recent years (dashed, {provisionalFromYear}+) are{" "}
+              <span className="text-amber-500 dark:text-amber-400">provisional</span> —
+              CITES reporting lags by a few years, so they are usually incomplete
+              rather than showing a real drop.
+            </>
+          )}
+        </p>
       </div>
+
+      {/* Filter charts — click a bar to cross-filter the whole summary.
+          Source bars are coloured wild (amber) vs captive (emerald). */}
+      {hasFilterCharts && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <FilterBarChart
+            title="Source"
+            bars={sourceBars}
+            onToggle={hasShipments ? toggleSource : undefined}
+          />
+          <FilterBarChart
+            title="Commodity"
+            bars={commodityBars}
+            onToggle={hasShipments ? toggleTerm : undefined}
+            search={termSearch}
+            onSearchChange={setTermSearch}
+            searchPlaceholder="Search commodities…"
+            emptyHint={
+              commoditySearch
+                ? `No commodities match “${termSearch}”.`
+                : undefined
+            }
+          />
+          <FilterBarChart
+            title="Purpose"
+            bars={purposeBars}
+            onToggle={hasShipments ? togglePurpose : undefined}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -182,8 +182,9 @@ function aggregateShipments(rows: CompactRecord[]): Aggregated {
     yEntry.quantity += r.q;
     yearMap.set(r.y, yEntry);
 
-    if (r.s) sourceMap.set(r.s, (sourceMap.get(r.s) || 0) + 1);
-    if (r.p) purposeMap.set(r.p, (purposeMap.get(r.p) || 0) + 1);
+    // Count blanks too, under code "" → "Unspecified", so they're filterable.
+    sourceMap.set(r.s, (sourceMap.get(r.s) || 0) + 1);
+    purposeMap.set(r.p, (purposeMap.get(r.p) || 0) + 1);
 
     if (r.e) {
       const e = exporterMap.get(r.e) || { records: 0, quantity: 0 };
@@ -231,11 +232,19 @@ function aggregateShipments(rows: CompactRecord[]): Aggregated {
 
   const topSources = Array.from(sourceMap.entries())
     .sort(([, a], [, b]) => b - a)
-    .map(([code, records]) => ({ code, label: SOURCE_LABELS[code] || code, records }));
+    .map(([code, records]) => ({
+      code,
+      label: code === "" ? "Unspecified" : SOURCE_LABELS[code] || code,
+      records,
+    }));
 
   const topPurposes = Array.from(purposeMap.entries())
     .sort(([, a], [, b]) => b - a)
-    .map(([code, records]) => ({ code, label: PURPOSE_LABELS[code] || code, records }));
+    .map(([code, records]) => ({
+      code,
+      label: code === "" ? "Unspecified" : PURPOSE_LABELS[code] || code,
+      records,
+    }));
 
   // Full sorted lists (not capped): the map colours every country that traded,
   // and the lists slice for display. Capping here previously hid genuine
@@ -849,18 +858,31 @@ export default function CitesTradeSummary({
     };
   }, [citesId, prefetchedData, prefetchedLoading]);
 
+  // Source / purpose category universes derived from the records, INCLUDING the
+  // blank "" ("Unspecified") category, so it gets initialised and is isolatable.
+  const allSourceCodes = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of data?.shipments ?? []) set.add(r.s);
+    return Array.from(set);
+  }, [data]);
+  const allPurposeCodes = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of data?.shipments ?? []) set.add(r.p);
+    return Array.from(set);
+  }, [data]);
+
   // Initialize filter checkboxes when data arrives
   useEffect(() => {
     if (!data || !data.found || filtersInitialized) return;
 
-    if (data.allSources) {
+    if (allSourceCodes.length > 0) {
       const init: Record<string, boolean> = {};
-      for (const s of data.allSources) init[s.code] = true;
+      for (const c of allSourceCodes) init[c] = true;
       setCheckedSources(init);
     }
-    if (data.allPurposes) {
+    if (allPurposeCodes.length > 0) {
       const init: Record<string, boolean> = {};
-      for (const p of data.allPurposes) init[p.code] = true;
+      for (const c of allPurposeCodes) init[c] = true;
       setCheckedPurposes(init);
     }
     if (data.allTermsByUnit) {
@@ -869,23 +891,21 @@ export default function CitesTradeSummary({
       setCheckedTerms(init);
     }
     setFiltersInitialized(true);
-  }, [data, filtersInitialized]);
+  }, [data, filtersInitialized, allSourceCodes, allPurposeCodes]);
 
   // Clicking a bar isolates that category (selects only it); clicking the
   // already-isolated one resets the dimension to all.
   const isolateSource = useCallback(
     (code: string) => {
-      const keys = (data?.allSources ?? []).map((s) => s.code);
-      setCheckedSources((prev) => isolateState(prev, keys, code));
+      setCheckedSources((prev) => isolateState(prev, allSourceCodes, code));
     },
-    [data]
+    [allSourceCodes]
   );
   const isolatePurpose = useCallback(
     (code: string) => {
-      const keys = (data?.allPurposes ?? []).map((p) => p.code);
-      setCheckedPurposes((prev) => isolateState(prev, keys, code));
+      setCheckedPurposes((prev) => isolateState(prev, allPurposeCodes, code));
     },
-    [data]
+    [allPurposeCodes]
   );
   const isolateTerm = useCallback(
     (key: string) => {
@@ -950,14 +970,14 @@ export default function CitesTradeSummary({
   const checkboxRows = useMemo(() => {
     if (!data?.found || !data.shipments) return [];
     return data.shipments.filter((r) => {
-      if (anySourceOff && (!r.s || checkedSources[r.s] === false)) return false;
-      if (anyPurposeOff && (!r.p || checkedPurposes[r.p] === false)) return false;
+      if (checkedSources[r.s] === false) return false;
+      if (checkedPurposes[r.p] === false) return false;
       if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
       if (selectedCountry && r.e !== selectedCountry && r.i !== selectedCountry)
         return false;
       return true;
     });
-  }, [data, checkedSources, checkedPurposes, checkedTerms, selectedCountry, anySourceOff, anyPurposeOff]);
+  }, [data, checkedSources, checkedPurposes, checkedTerms, selectedCountry]);
 
   // Chart series (all years, checkbox-filtered)
   const chartAgg = useMemo(() => aggregateShipments(checkboxRows), [checkboxRows]);
@@ -976,20 +996,20 @@ export default function CitesTradeSummary({
   const commodityChart = useMemo(() => {
     if (!data?.found || !data.shipments) return [];
     const rows = data.shipments.filter((r) => {
-      if (anySourceOff && (!r.s || checkedSources[r.s] === false)) return false;
-      if (anyPurposeOff && (!r.p || checkedPurposes[r.p] === false)) return false;
+      if (checkedSources[r.s] === false) return false;
+      if (checkedPurposes[r.p] === false) return false;
       if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
       if (selectedCountry && r.e !== selectedCountry && r.i !== selectedCountry)
         return false;
       return true;
     });
     return aggregateShipments(rows).termsByUnit;
-  }, [data, checkedSources, checkedPurposes, brush, selectedCountry, anySourceOff, anyPurposeOff]);
+  }, [data, checkedSources, checkedPurposes, brush, selectedCountry]);
 
   const sourceChart = useMemo(() => {
     if (!data?.found || !data.shipments) return [];
     const rows = data.shipments.filter((r) => {
-      if (anyPurposeOff && (!r.p || checkedPurposes[r.p] === false)) return false;
+      if (checkedPurposes[r.p] === false) return false;
       if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
       if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
       if (selectedCountry && r.e !== selectedCountry && r.i !== selectedCountry)
@@ -997,12 +1017,12 @@ export default function CitesTradeSummary({
       return true;
     });
     return aggregateShipments(rows).topSources;
-  }, [data, checkedPurposes, checkedTerms, brush, selectedCountry, anyPurposeOff]);
+  }, [data, checkedPurposes, checkedTerms, brush, selectedCountry]);
 
   const purposeChart = useMemo(() => {
     if (!data?.found || !data.shipments) return [];
     const rows = data.shipments.filter((r) => {
-      if (anySourceOff && (!r.s || checkedSources[r.s] === false)) return false;
+      if (checkedSources[r.s] === false) return false;
       if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
       if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
       if (selectedCountry && r.e !== selectedCountry && r.i !== selectedCountry)
@@ -1010,7 +1030,7 @@ export default function CitesTradeSummary({
       return true;
     });
     return aggregateShipments(rows).topPurposes;
-  }, [data, checkedSources, checkedTerms, brush, selectedCountry, anySourceOff]);
+  }, [data, checkedSources, checkedTerms, brush, selectedCountry]);
 
   // Exporter / importer aggregates that DON'T apply the country cross-filter, so
   // the Top exporters / importers lists stay populated and let you switch
@@ -1018,14 +1038,14 @@ export default function CitesTradeSummary({
   const countryAgg = useMemo(() => {
     if (!data?.found || !data.shipments) return null;
     const rows = data.shipments.filter((r) => {
-      if (anySourceOff && (!r.s || checkedSources[r.s] === false)) return false;
-      if (anyPurposeOff && (!r.p || checkedPurposes[r.p] === false)) return false;
+      if (checkedSources[r.s] === false) return false;
+      if (checkedPurposes[r.p] === false) return false;
       if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
       if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
       return true;
     });
     return aggregateShipments(rows);
-  }, [data, checkedSources, checkedPurposes, checkedTerms, brush, anySourceOff, anyPurposeOff]);
+  }, [data, checkedSources, checkedPurposes, checkedTerms, brush]);
 
   const hasShipments = !!data?.shipments && data.shipments.length > 0;
 
@@ -1092,9 +1112,12 @@ export default function CitesTradeSummary({
     sublabel: s.code,
     records: s.records,
     active: checkedSources[s.code] !== false,
-    barClass: WILD_SOURCE_CODES.has(s.code)
-      ? "bg-amber-400 dark:bg-amber-500"
-      : "bg-emerald-300 dark:bg-emerald-600",
+    barClass:
+      s.code === ""
+        ? "bg-zinc-400 dark:bg-zinc-500"
+        : WILD_SOURCE_CODES.has(s.code)
+          ? "bg-amber-400 dark:bg-amber-500"
+          : "bg-emerald-300 dark:bg-emerald-600",
   }));
 
   const purposeBars: FilterBar[] = purposeChart.map((p) => ({
@@ -1103,7 +1126,7 @@ export default function CitesTradeSummary({
     sublabel: p.code,
     records: p.records,
     active: checkedPurposes[p.code] !== false,
-    barClass: "bg-blue-400 dark:bg-blue-500",
+    barClass: p.code === "" ? "bg-zinc-400 dark:bg-zinc-500" : "bg-blue-400 dark:bg-blue-500",
   }));
 
   const commoditySearch = termSearch.trim().toLowerCase();

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -131,6 +131,24 @@ function termUnitKey(term: string, unit: string): string {
   return `${term}|${unit}`;
 }
 
+/**
+ * "Isolate" a category within a filter dimension: clicking a bar selects only
+ * that one. Clicking the already-isolated category resets the dimension to all
+ * (so a second click un-filters). Returns the next checked-state map.
+ */
+function isolateState(
+  prev: Record<string, boolean>,
+  allKeys: string[],
+  key: string
+): Record<string, boolean> {
+  const onlyThis = allKeys.every((k) =>
+    k === key ? prev[k] !== false : prev[k] === false
+  );
+  const next: Record<string, boolean> = {};
+  for (const k of allKeys) next[k] = onlyThis ? true : k === key;
+  return next;
+}
+
 /* ------------------------------------------------------------------ */
 /*  Aggregation                                                        */
 /* ------------------------------------------------------------------ */
@@ -852,16 +870,31 @@ export default function CitesTradeSummary({
     setFiltersInitialized(true);
   }, [data, filtersInitialized]);
 
-  // Toggle helpers
-  const toggleSource = useCallback((code: string) => {
-    setCheckedSources((prev) => ({ ...prev, [code]: !prev[code] }));
-  }, []);
-  const togglePurpose = useCallback((code: string) => {
-    setCheckedPurposes((prev) => ({ ...prev, [code]: !prev[code] }));
-  }, []);
-  const toggleTerm = useCallback((key: string) => {
-    setCheckedTerms((prev) => ({ ...prev, [key]: !prev[key] }));
-  }, []);
+  // Clicking a bar isolates that category (selects only it); clicking the
+  // already-isolated one resets the dimension to all.
+  const isolateSource = useCallback(
+    (code: string) => {
+      const keys = (data?.allSources ?? []).map((s) => s.code);
+      setCheckedSources((prev) => isolateState(prev, keys, code));
+    },
+    [data]
+  );
+  const isolatePurpose = useCallback(
+    (code: string) => {
+      const keys = (data?.allPurposes ?? []).map((p) => p.code);
+      setCheckedPurposes((prev) => isolateState(prev, keys, code));
+    },
+    [data]
+  );
+  const isolateTerm = useCallback(
+    (key: string) => {
+      const keys = (data?.allTermsByUnit ?? []).map((t) =>
+        termUnitKey(t.term, t.unit)
+      );
+      setCheckedTerms((prev) => isolateState(prev, keys, key));
+    },
+    [data]
+  );
 
   // Are any filters active (something unchecked, or a year range trimmed)?
   const hasActiveFilters = useMemo(() => {
@@ -1221,7 +1254,7 @@ export default function CitesTradeSummary({
           <FilterBarChart
             title="Commodity"
             bars={commodityBars}
-            onToggle={hasShipments ? toggleTerm : undefined}
+            onToggle={hasShipments ? isolateTerm : undefined}
             search={termSearch}
             onSearchChange={setTermSearch}
             searchPlaceholder="Search…"
@@ -1234,12 +1267,12 @@ export default function CitesTradeSummary({
           <FilterBarChart
             title="Purpose"
             bars={purposeBars}
-            onToggle={hasShipments ? togglePurpose : undefined}
+            onToggle={hasShipments ? isolatePurpose : undefined}
           />
           <FilterBarChart
             title="Source"
             bars={sourceBars}
-            onToggle={hasShipments ? toggleSource : undefined}
+            onToggle={hasShipments ? isolateSource : undefined}
           />
         </div>
       )}

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -681,43 +681,73 @@ function TrendSummary({
 /*  Source breakdown (wild vs captive bar)                              */
 /* ------------------------------------------------------------------ */
 
-function SourceBreakdown({ sources }: { sources: CodedData[] }) {
+function SourceBreakdown({
+  sources,
+  wildActive = true,
+  captiveActive = true,
+  onToggleWild,
+  onToggleCaptive,
+}: {
+  sources: CodedData[];
+  wildActive?: boolean;
+  captiveActive?: boolean;
+  onToggleWild?: () => void;
+  onToggleCaptive?: () => void;
+}) {
   const total = sources.reduce((s, d) => s + d.records, 0);
   if (total === 0) return null;
 
-  const wildSources = sources.filter((s) => WILD_SOURCE_CODES.has(s.code));
-  const captiveSources = sources.filter((s) => !WILD_SOURCE_CODES.has(s.code));
-  const wildRecords = wildSources.reduce((sum, s) => sum + s.records, 0);
-  const captiveRecords = captiveSources.reduce((sum, s) => sum + s.records, 0);
+  const wildRecords = sources
+    .filter((s) => WILD_SOURCE_CODES.has(s.code))
+    .reduce((sum, s) => sum + s.records, 0);
+  const captiveRecords = total - wildRecords;
   const wildPct = Math.round((wildRecords / total) * 100);
   const captivePct = 100 - wildPct;
 
+  const rows = [
+    {
+      label: "Wild",
+      active: wildActive,
+      onToggle: onToggleWild,
+      bar: "bg-amber-400 dark:bg-amber-500",
+      pct: wildPct,
+      records: wildRecords,
+    },
+    {
+      label: "Captive",
+      active: captiveActive,
+      onToggle: onToggleCaptive,
+      bar: "bg-emerald-300 dark:bg-emerald-600",
+      pct: captivePct,
+      records: captiveRecords,
+    },
+  ];
+
   return (
     <div className="space-y-1.5">
-      <div className="flex items-center gap-2 text-xs">
-        <span className="w-16 text-zinc-600 dark:text-zinc-300 shrink-0">Wild</span>
-        <div className="flex-1 h-4 bg-zinc-100 dark:bg-zinc-800 rounded overflow-hidden">
-          <div
-            className="h-full bg-amber-400 dark:bg-amber-500 rounded"
-            style={{ width: `${Math.max(wildPct, 1)}%` }}
-          />
+      {rows.map((r) => (
+        <div
+          key={r.label}
+          onClick={r.onToggle}
+          title={r.onToggle ? `Filter by ${r.label.toLowerCase()} source` : undefined}
+          className={`flex items-center gap-2 text-xs select-none transition-opacity ${
+            r.onToggle ? "cursor-pointer" : ""
+          } ${r.active ? "" : "opacity-40"}`}
+        >
+          <span className="w-16 text-zinc-600 dark:text-zinc-300 shrink-0">
+            {r.label}
+          </span>
+          <div className="flex-1 h-4 bg-zinc-100 dark:bg-zinc-800 rounded overflow-hidden">
+            <div
+              className={`h-full rounded ${r.bar}`}
+              style={{ width: `${Math.max(r.pct, 1)}%` }}
+            />
+          </div>
+          <span className="w-20 text-right text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">
+            {r.pct}% ({r.records.toLocaleString()})
+          </span>
         </div>
-        <span className="w-20 text-right text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">
-          {wildPct}% ({wildRecords.toLocaleString()})
-        </span>
-      </div>
-      <div className="flex items-center gap-2 text-xs">
-        <span className="w-16 text-zinc-600 dark:text-zinc-300 shrink-0">Captive</span>
-        <div className="flex-1 h-4 bg-zinc-100 dark:bg-zinc-800 rounded overflow-hidden">
-          <div
-            className="h-full bg-emerald-300 dark:bg-emerald-600 rounded"
-            style={{ width: `${Math.max(captivePct, 1)}%` }}
-          />
-        </div>
-        <span className="w-20 text-right text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">
-          {captivePct}% ({captiveRecords.toLocaleString()})
-        </span>
-      </div>
+      ))}
     </div>
   );
 }
@@ -868,6 +898,25 @@ export default function CitesTradeSummary({
     setCheckedTerms((prev) => ({ ...prev, [key]: !prev[key] }));
   }, []);
 
+  // Toggle every source code in the wild (or captive) bucket at once. If any
+  // code in the bucket is currently on, the click turns the whole bucket off;
+  // otherwise it turns it back on.
+  const toggleSourceBucket = useCallback(
+    (wild: boolean) => {
+      const codes = (data?.allSources ?? [])
+        .filter((s) => WILD_SOURCE_CODES.has(s.code) === wild)
+        .map((s) => s.code);
+      if (codes.length === 0) return;
+      setCheckedSources((prev) => {
+        const anyOn = codes.some((c) => prev[c] !== false);
+        const next = { ...prev };
+        for (const c of codes) next[c] = !anyOn;
+        return next;
+      });
+    },
+    [data]
+  );
+
   const setAll = useCallback(
     (
       setter: React.Dispatch<React.SetStateAction<Record<string, boolean>>>,
@@ -944,6 +993,31 @@ export default function CitesTradeSummary({
     return aggregateShipments(rows);
   }, [checkboxRows, brush]);
 
+  // Cross-filter views: each interactive chart aggregates rows passing every
+  // active filter EXCEPT its own dimension, so its categories stay visible and
+  // a click can toggle them back on (rather than vanishing once de-selected).
+  const commodityChart = useMemo(() => {
+    if (!data?.found || !data.shipments) return [];
+    const rows = data.shipments.filter((r) => {
+      if (r.s && checkedSources[r.s] === false) return false;
+      if (r.p && checkedPurposes[r.p] === false) return false;
+      if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
+      return true;
+    });
+    return aggregateShipments(rows).termsByUnit;
+  }, [data, checkedSources, checkedPurposes, brush]);
+
+  const sourceChart = useMemo(() => {
+    if (!data?.found || !data.shipments) return [];
+    const rows = data.shipments.filter((r) => {
+      if (r.p && checkedPurposes[r.p] === false) return false;
+      if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
+      if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
+      return true;
+    });
+    return aggregateShipments(rows).topSources;
+  }, [data, checkedPurposes, checkedTerms, brush]);
+
   const hasShipments = !!data?.shipments && data.shipments.length > 0;
 
   /* ---------------------------------------------------------------- */
@@ -986,15 +1060,26 @@ export default function CitesTradeSummary({
   const chartByYear =
     hasShipments && chartAgg.byYear.length > 0 ? chartAgg.byYear : data.byYear;
   const displaySources =
-    hasShipments && display.topSources.length > 0 ? display.topSources : data.topSources;
-  const displayPurposes =
-    hasShipments && display.topPurposes.length > 0 ? display.topPurposes : data.topPurposes;
+    hasShipments && sourceChart.length > 0 ? sourceChart : data.topSources;
   const displayExporters =
     hasShipments && display.topExporters.length > 0 ? display.topExporters : data.topExporters;
   const displayImporters =
     hasShipments && display.topImporters.length > 0 ? display.topImporters : data.topImporters;
   const displayFlows =
     hasShipments && display.topFlows.length > 0 ? display.topFlows : data.topFlows ?? [];
+
+  // Cross-filter affordances (only interactive when we have client-side rows).
+  const maxCommodityRecords = commodityChart.reduce(
+    (m, t) => Math.max(m, t.records),
+    0
+  );
+  const allSources = data.allSources ?? [];
+  const wildActive = allSources.some(
+    (s) => WILD_SOURCE_CODES.has(s.code) && checkedSources[s.code] !== false
+  );
+  const captiveActive = allSources.some(
+    (s) => !WILD_SOURCE_CODES.has(s.code) && checkedSources[s.code] !== false
+  );
 
   return (
     <div className="space-y-4">
@@ -1205,71 +1290,70 @@ export default function CitesTradeSummary({
             </p>
           </div>
 
-          {/* Source breakdown — most important for assessors */}
+          {/* Source breakdown — most important for assessors. Click a bar to
+              filter the whole summary to that source group. */}
           {displaySources.length > 0 && (
             <div>
               <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
                 Wild vs. Captive
               </h5>
-              <SourceBreakdown sources={displaySources} />
+              <SourceBreakdown
+                sources={displaySources}
+                wildActive={wildActive}
+                captiveActive={captiveActive}
+                onToggleWild={hasShipments ? () => toggleSourceBucket(true) : undefined}
+                onToggleCaptive={
+                  hasShipments ? () => toggleSourceBucket(false) : undefined
+                }
+              />
             </div>
           )}
 
-          {/* Commodities — grouped by term + unit (never aggregated across units) */}
-          {display.termsByUnit.length > 0 && (
+          {/* Commodities — grouped by term + unit (never aggregated across
+              units). Scrollable bar chart; click a bar to filter the summary
+              to that commodity. */}
+          {commodityChart.length > 0 && (
             <div>
               <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
                 Commodities
               </h5>
-              <table className="w-full text-xs">
-                <thead>
-                  <tr className="text-left text-zinc-400 dark:text-zinc-500">
-                    <th className="font-medium pb-1 pr-2">Term</th>
-                    <th className="font-medium pb-1 pr-2">Unit</th>
-                    <th className="font-medium pb-1 pr-2 text-right">Records</th>
-                    <th className="font-medium pb-1 text-right">Quantity</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {display.termsByUnit.slice(0, 8).map((t) => (
-                    <tr
-                      key={termUnitKey(t.term, t.unit)}
-                      className="border-t border-zinc-100 dark:border-zinc-800/50"
+              <div className="space-y-1 max-h-[200px] overflow-y-auto pr-1">
+                {commodityChart.map((t) => {
+                  const key = termUnitKey(t.term, t.unit);
+                  const active = checkedTerms[key] !== false;
+                  const pct =
+                    maxCommodityRecords > 0
+                      ? (t.records / maxCommodityRecords) * 100
+                      : 0;
+                  return (
+                    <div
+                      key={key}
+                      onClick={hasShipments ? () => toggleTerm(key) : undefined}
+                      title={`${t.term}${t.unit ? ` (${t.unit})` : ""} — ${t.records.toLocaleString()} records / ${fmtQty(t.quantity)} items`}
+                      className={`flex items-center gap-2 text-xs select-none transition-opacity ${
+                        hasShipments ? "cursor-pointer" : ""
+                      } ${active ? "" : "opacity-40"}`}
                     >
-                      <td className="py-1 pr-2 text-zinc-700 dark:text-zinc-300 capitalize">
+                      <span className="w-28 shrink-0 truncate capitalize text-zinc-700 dark:text-zinc-300">
                         {t.term}
-                      </td>
-                      <td className="py-1 pr-2 text-zinc-500 dark:text-zinc-400">
-                        {t.unit || "—"}
-                      </td>
-                      <td className="py-1 pr-2 text-right text-zinc-500 dark:text-zinc-400 tabular-nums">
+                        {t.unit && (
+                          <span className="text-zinc-400 dark:text-zinc-500 ml-1 normal-case">
+                            {t.unit}
+                          </span>
+                        )}
+                      </span>
+                      <div className="flex-1 h-3.5 bg-zinc-100 dark:bg-zinc-800 rounded overflow-hidden">
+                        <div
+                          className="h-full bg-violet-400 dark:bg-violet-500 rounded"
+                          style={{ width: `${Math.max(pct, 1)}%` }}
+                        />
+                      </div>
+                      <span className="w-12 text-right text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">
                         {t.records.toLocaleString()}
-                      </td>
-                      <td className="py-1 text-right text-zinc-500 dark:text-zinc-400 tabular-nums">
-                        {fmtQty(t.quantity)}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-
-          {/* Purpose */}
-          {displayPurposes.length > 0 && (
-            <div>
-              <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-                Purpose
-              </h5>
-              <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-600 dark:text-zinc-300">
-                {displayPurposes.map((p) => (
-                  <span key={p.code} className="tabular-nums">
-                    {p.label}{" "}
-                    <span className="text-zinc-400 dark:text-zinc-500">
-                      ({p.records})
-                    </span>
-                  </span>
-                ))}
+                      </span>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -237,14 +237,15 @@ function aggregateShipments(rows: CompactRecord[]): Aggregated {
     .sort(([, a], [, b]) => b - a)
     .map(([code, records]) => ({ code, label: PURPOSE_LABELS[code] || code, records }));
 
+  // Full sorted lists (not capped): the map colours every country that traded,
+  // and the lists slice for display. Capping here previously hid genuine
+  // traders (e.g. Cameroon, rank 16) from the map until a filter promoted them.
   const topExporters = Array.from(exporterMap.entries())
     .sort(([, a], [, b]) => b.records - a.records)
-    .slice(0, 15)
     .map(([code, v]) => ({ code, ...v }));
 
   const topImporters = Array.from(importerMap.entries())
     .sort(([, a], [, b]) => b.records - a.records)
-    .slice(0, 15)
     .map(([code, v]) => ({ code, ...v }));
 
   const topFlows = Array.from(flowMap.entries())
@@ -1056,8 +1057,9 @@ export default function CitesTradeSummary({
   // Fall back to server-provided byYear when no shipments for client filtering
   const chartByYear =
     hasShipments && chartAgg.byYear.length > 0 ? chartAgg.byYear : data.byYear;
-  // Country lists (and the map's colour-by-role) use the country-excluded
-  // aggregate so they stay global while a country is selected.
+  // Full country lists (and the map's colour-by-role) use the country-excluded
+  // aggregate so they stay global while a country is selected. The map colours
+  // every trading country; the Top exporters/importers lists show the leaders.
   const displayExporters =
     hasShipments && countryAgg && countryAgg.topExporters.length > 0
       ? countryAgg.topExporters
@@ -1066,6 +1068,8 @@ export default function CitesTradeSummary({
     hasShipments && countryAgg && countryAgg.topImporters.length > 0
       ? countryAgg.topImporters
       : data.topImporters;
+  const tableExporters = displayExporters.slice(0, 15);
+  const tableImporters = displayImporters.slice(0, 15);
   const displayFlows =
     hasShipments && display.topFlows.length > 0 ? display.topFlows : data.topFlows ?? [];
 
@@ -1107,7 +1111,7 @@ export default function CitesTradeSummary({
         records: t.records,
         active: checkedTerms[key] !== false,
         barClass: "bg-violet-400 dark:bg-violet-500",
-        title: `${t.term}${t.unit ? ` (${t.unit})` : ""} — ${t.records.toLocaleString()} records / ${fmtQty(t.quantity)} items`,
+        title: `${t.term}${t.unit ? ` (${t.unit})` : ""} — ${t.records.toLocaleString()} records / ${fmtQty(t.quantity)} ${t.unit || "items"}`,
       };
     });
 
@@ -1211,13 +1215,13 @@ export default function CitesTradeSummary({
           <div className="flex flex-col gap-3">
             <div className="grid grid-cols-2 gap-3">
               <CountryTable
-                data={displayExporters}
+                data={tableExporters}
                 label="Top exporters"
                 selected={selectedCountry}
                 onSelect={setSelectedCountry}
               />
               <CountryTable
-                data={displayImporters}
+                data={tableImporters}
                 label="Top importers"
                 selected={selectedCountry}
                 onSelect={setSelectedCountry}
@@ -1231,13 +1235,13 @@ export default function CitesTradeSummary({
           {headline}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <CountryTable
-              data={displayExporters}
+              data={tableExporters}
               label="Top exporters"
               selected={selectedCountry}
               onSelect={setSelectedCountry}
             />
             <CountryTable
-              data={displayImporters}
+              data={tableImporters}
               label="Top importers"
               selected={selectedCountry}
               onSelect={setSelectedCountry}

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -280,11 +280,49 @@ interface FilterBar {
   title?: string;
 }
 
+/** Rows shown per page in the paginated bar charts and country lists. */
+const PAGE_SIZE = 5;
+
+/** Prev / "x–y of N" / Next pager, shown only when there is more than one page. */
+function Pager({
+  page,
+  total,
+  onPage,
+}: {
+  page: number;
+  total: number;
+  onPage: (p: number) => void;
+}) {
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+  if (totalPages <= 1) return null;
+  return (
+    <div className="flex items-center justify-between mt-1 text-[10px] text-zinc-400 dark:text-zinc-500">
+      <button
+        onClick={() => onPage(Math.max(0, page - 1))}
+        disabled={page === 0}
+        className="px-1.5 py-0.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800 disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        Prev
+      </button>
+      <span className="tabular-nums">
+        {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, total)} of {total}
+      </span>
+      <button
+        onClick={() => onPage(Math.min(totalPages - 1, page + 1))}
+        disabled={page >= totalPages - 1}
+        className="px-1.5 py-0.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800 disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        Next
+      </button>
+    </div>
+  );
+}
+
 /**
- * A scrollable horizontal bar chart that doubles as a cross-filter: clicking a
+ * A paginated horizontal bar chart that doubles as a cross-filter: clicking a
  * bar calls onToggle(key) to add/remove that category, and de-selected bars are
- * dimmed but stay visible so they can be toggled back on. An optional search box
- * (used by the Commodity chart) filters the rows shown.
+ * dimmed but stay visible so they can be toggled back on. Shows PAGE_SIZE rows
+ * at a time with Prev/Next, and an optional search box (used by Commodity).
  */
 function FilterBarChart({
   title,
@@ -303,7 +341,20 @@ function FilterBarChart({
   searchPlaceholder?: string;
   emptyHint?: string;
 }) {
+  const [page, setPage] = useState(0);
+  // Reset to the first page whenever the search term changes the result set
+  // (adjusting state during render, per the React docs, rather than in an effect).
+  const [prevSearch, setPrevSearch] = useState(search);
+  if (search !== prevSearch) {
+    setPrevSearch(search);
+    setPage(0);
+  }
+
+  // Scale bars against the global max so widths stay comparable across pages.
   const max = bars.reduce((m, b) => Math.max(m, b.records), 0);
+  const totalPages = Math.max(1, Math.ceil(bars.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages - 1);
+  const pageBars = bars.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE);
 
   return (
     <div className="min-w-0">
@@ -323,8 +374,8 @@ function FilterBarChart({
           />
         )}
       </div>
-      <div className="space-y-1 max-h-[240px] overflow-y-auto pr-1">
-        {bars.map((b) => {
+      <div className="space-y-1">
+        {pageBars.map((b) => {
           const pct = max > 0 ? (b.records / max) * 100 : 0;
           return (
             <div
@@ -364,6 +415,7 @@ function FilterBarChart({
           </span>
         )}
       </div>
+      <Pager page={safePage} total={bars.length} onPage={setPage} />
     </div>
   );
 }
@@ -400,7 +452,7 @@ function ChartTooltip({
       <div className="text-zinc-400">{label}</div>
       <div className="text-white tabular-nums">
         {(point.value ?? 0).toLocaleString()}{" "}
-        {metric === "records" ? "shipments" : "items"}
+        {metric === "records" ? "records" : "items"}
       </div>
       {isProvisional && (
         <div className="text-amber-400 text-[10px] mt-0.5">
@@ -662,16 +714,20 @@ function CountryTable({
   selected?: string | null;
   onSelect?: (code: string | null) => void;
 }) {
+  const [page, setPage] = useState(0);
   if (data.length === 0) return null;
-  const top = [...data].sort((a, b) => b.records - a.records);
+  const sorted = [...data].sort((a, b) => b.records - a.records);
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages - 1);
+  const pageRows = sorted.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE);
 
   return (
     <div className="min-w-0">
       <h5 className="text-[10px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-0.5">
         {label}
       </h5>
-      <div className="max-h-[116px] overflow-y-auto pr-1">
-        {top.map((c) => {
+      <div>
+        {pageRows.map((c) => {
           const isSel = selected === c.code;
           return (
             <div
@@ -695,6 +751,7 @@ function CountryTable({
           );
         })}
       </div>
+      <Pager page={safePage} total={sorted.length} onPage={setPage} />
     </div>
   );
 }
@@ -842,16 +899,20 @@ export default function CitesTradeSummary({
     setSelectedCountry(null);
   }, []);
 
-  // Shipments passing the checkbox filters (all years) — drives the chart line.
+  // Records passing the active filters (all years) — drives the chart line.
+  // A selected country acts as an extra cross-filter: keep only its trade
+  // (as exporter or importer).
   const checkboxRows = useMemo(() => {
     if (!data?.found || !data.shipments) return [];
     return data.shipments.filter((r) => {
       if (r.s && checkedSources[r.s] === false) return false;
       if (r.p && checkedPurposes[r.p] === false) return false;
       if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
+      if (selectedCountry && r.e !== selectedCountry && r.i !== selectedCountry)
+        return false;
       return true;
     });
-  }, [data, checkedSources, checkedPurposes, checkedTerms]);
+  }, [data, checkedSources, checkedPurposes, checkedTerms, selectedCountry]);
 
   // Chart series (all years, checkbox-filtered)
   const chartAgg = useMemo(() => aggregateShipments(checkboxRows), [checkboxRows]);
@@ -873,10 +934,12 @@ export default function CitesTradeSummary({
       if (r.s && checkedSources[r.s] === false) return false;
       if (r.p && checkedPurposes[r.p] === false) return false;
       if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
+      if (selectedCountry && r.e !== selectedCountry && r.i !== selectedCountry)
+        return false;
       return true;
     });
     return aggregateShipments(rows).termsByUnit;
-  }, [data, checkedSources, checkedPurposes, brush]);
+  }, [data, checkedSources, checkedPurposes, brush, selectedCountry]);
 
   const sourceChart = useMemo(() => {
     if (!data?.found || !data.shipments) return [];
@@ -884,10 +947,12 @@ export default function CitesTradeSummary({
       if (r.p && checkedPurposes[r.p] === false) return false;
       if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
       if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
+      if (selectedCountry && r.e !== selectedCountry && r.i !== selectedCountry)
+        return false;
       return true;
     });
     return aggregateShipments(rows).topSources;
-  }, [data, checkedPurposes, checkedTerms, brush]);
+  }, [data, checkedPurposes, checkedTerms, brush, selectedCountry]);
 
   const purposeChart = useMemo(() => {
     if (!data?.found || !data.shipments) return [];
@@ -895,10 +960,27 @@ export default function CitesTradeSummary({
       if (r.s && checkedSources[r.s] === false) return false;
       if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
       if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
+      if (selectedCountry && r.e !== selectedCountry && r.i !== selectedCountry)
+        return false;
       return true;
     });
     return aggregateShipments(rows).topPurposes;
-  }, [data, checkedSources, checkedTerms, brush]);
+  }, [data, checkedSources, checkedTerms, brush, selectedCountry]);
+
+  // Exporter / importer aggregates that DON'T apply the country cross-filter, so
+  // the Top exporters / importers lists stay populated and let you switch
+  // country (the same "exclude your own dimension" rule the bar charts use).
+  const countryAgg = useMemo(() => {
+    if (!data?.found || !data.shipments) return null;
+    const rows = data.shipments.filter((r) => {
+      if (r.s && checkedSources[r.s] === false) return false;
+      if (r.p && checkedPurposes[r.p] === false) return false;
+      if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
+      if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
+      return true;
+    });
+    return aggregateShipments(rows);
+  }, [data, checkedSources, checkedPurposes, checkedTerms, brush]);
 
   const hasShipments = !!data?.shipments && data.shipments.length > 0;
 
@@ -941,10 +1023,16 @@ export default function CitesTradeSummary({
   // Fall back to server-provided byYear when no shipments for client filtering
   const chartByYear =
     hasShipments && chartAgg.byYear.length > 0 ? chartAgg.byYear : data.byYear;
+  // Country lists (and the map's colour-by-role) use the country-excluded
+  // aggregate so they stay global while a country is selected.
   const displayExporters =
-    hasShipments && display.topExporters.length > 0 ? display.topExporters : data.topExporters;
+    hasShipments && countryAgg && countryAgg.topExporters.length > 0
+      ? countryAgg.topExporters
+      : data.topExporters;
   const displayImporters =
-    hasShipments && display.topImporters.length > 0 ? display.topImporters : data.topImporters;
+    hasShipments && countryAgg && countryAgg.topImporters.length > 0
+      ? countryAgg.topImporters
+      : data.topImporters;
   const displayFlows =
     hasShipments && display.topFlows.length > 0 ? display.topFlows : data.topFlows ?? [];
 
@@ -1001,19 +1089,21 @@ export default function CitesTradeSummary({
       ? ` Recent years (dashed, ${provisionalFromYear}+) are provisional — CITES reporting lags by a few years, so they are usually incomplete rather than showing a real drop.`
       : "");
   const tradeOverTimeChart = (
-    <div>
+    <div className="flex flex-col">
       <div className="flex items-center gap-1.5 mb-2">
         <span className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
           Trade over time
         </span>
         <span className="text-[11px] text-zinc-400 dark:text-zinc-500 normal-case">
-          (shipments)
+          (records)
         </span>
-        <span
-          title={trendInfo}
-          className="flex items-center justify-center w-3.5 h-3.5 rounded-full border border-zinc-400 dark:border-zinc-500 text-[9px] font-semibold text-zinc-400 dark:text-zinc-500 cursor-help"
-        >
-          i
+        <span className="relative group inline-flex">
+          <span className="flex items-center justify-center w-3.5 h-3.5 rounded-full border border-zinc-400 dark:border-zinc-500 text-[9px] font-semibold text-zinc-400 dark:text-zinc-500 cursor-help">
+            i
+          </span>
+          <span className="pointer-events-none absolute left-1/2 top-full mt-1 -translate-x-1/2 hidden group-hover:block z-20 w-56 bg-zinc-800 dark:bg-zinc-700 text-white text-[10px] leading-snug rounded-md p-2 shadow-lg normal-case font-normal tracking-normal">
+            {trendInfo}
+          </span>
         </span>
         {brush && (
           <span className="text-[11px] text-blue-600 dark:text-blue-400 tabular-nums ml-auto">
@@ -1033,39 +1123,45 @@ export default function CitesTradeSummary({
     </div>
   );
 
+  // Record count + year range + clear button. Overlaid on the map (or shown as
+  // a row when there is no map) so it doesn't take a whole dead row of its own.
+  const headline = (
+    <div className="flex items-baseline gap-2">
+      <span className="text-sm text-zinc-700 dark:text-zinc-200">
+        <span className="font-semibold tabular-nums">
+          {display.totalRecords.toLocaleString()}
+        </span>{" "}
+        records
+        <span className="text-zinc-400 dark:text-zinc-500 ml-1 tabular-nums">
+          {effectiveRange[0]}–{effectiveRange[1]}
+        </span>
+        {brush && (
+          <span className="text-zinc-400 dark:text-zinc-500 ml-1 tabular-nums">
+            (of {minYear}–{maxYear})
+          </span>
+        )}
+      </span>
+      {hasActiveFilters && (
+        <button
+          className="text-[11px] text-blue-600 dark:text-blue-400 hover:underline"
+          onClick={clearFilters}
+        >
+          Clear filters
+        </button>
+      )}
+    </div>
+  );
+
   return (
     <div className="space-y-4">
-      {/* Headline */}
-      <div className="flex items-baseline gap-3 flex-wrap">
-        <span className="text-sm text-zinc-700 dark:text-zinc-200">
-          <span className="font-semibold tabular-nums">
-            {display.totalRecords.toLocaleString()}
-          </span>{" "}
-          shipments
-          <span className="text-zinc-400 dark:text-zinc-500 ml-1">
-            {effectiveRange[0]}–{effectiveRange[1]}
-          </span>
-          {brush && (
-            <span className="text-zinc-400 dark:text-zinc-500 ml-1">
-              (of {minYear}–{maxYear})
-            </span>
-          )}
-        </span>
-        {hasActiveFilters && (
-          <button
-            className="text-[11px] text-blue-600 dark:text-blue-400 hover:underline ml-auto"
-            onClick={clearFilters}
-          >
-            Clear filters
-          </button>
-        )}
-      </div>
-
-      {/* Trade flow map, with Top exporters / importers and the trade-over-time
-          chart stacked in the side column. */}
+      {/* Trade flow map (with the record count overlaid), and Top exporters /
+          importers + the trade-over-time chart in the side column. */}
       {displayFlows.length > 0 ? (
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 items-start">
-          <div className="lg:col-span-2 border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden bg-zinc-50 dark:bg-zinc-800/30">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          <div className="lg:col-span-2 relative border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden bg-zinc-50 dark:bg-zinc-800/30">
+            <div className="absolute top-2 left-3 z-10 bg-zinc-50/70 dark:bg-zinc-900/40 backdrop-blur-sm rounded-md px-2 py-1">
+              {headline}
+            </div>
             <TradeFlowMap
               flows={displayFlows}
               reExportFlows={display.reExportFlows}
@@ -1077,7 +1173,9 @@ export default function CitesTradeSummary({
               onSelectCountry={setSelectedCountry}
             />
           </div>
-          <div className="space-y-3">
+          {/* Side column stretches to the map's height; the trade-over-time
+              chart is pushed to the bottom so it lines up with the map base. */}
+          <div className="flex flex-col gap-3">
             <div className="grid grid-cols-2 gap-3">
               <CountryTable
                 data={displayExporters}
@@ -1092,11 +1190,12 @@ export default function CitesTradeSummary({
                 onSelect={setSelectedCountry}
               />
             </div>
-            {tradeOverTimeChart}
+            <div className="mt-auto">{tradeOverTimeChart}</div>
           </div>
         </div>
       ) : (
         <div className="space-y-4">
+          {headline}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <CountryTable
               data={displayExporters}

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -475,7 +475,7 @@ function ChartTooltip({
       </div>
       {isProvisional && (
         <div className="text-amber-400 text-[10px] mt-0.5">
-          provisional — incomplete reporting
+          provisional
         </div>
       )}
     </div>
@@ -897,11 +897,22 @@ export default function CitesTradeSummary({
     [data]
   );
 
+  // Whether a dimension is actively filtered (some category de-selected). When
+  // it is, rows with a *blank* value for that dimension are excluded too —
+  // otherwise isolating e.g. "Hunting trophy" would also keep the ~10.9k
+  // blank-purpose elephant records (source/purpose can be blank; term can't).
+  const anySourceOff = useMemo(
+    () => Object.values(checkedSources).some((v) => v === false),
+    [checkedSources]
+  );
+  const anyPurposeOff = useMemo(
+    () => Object.values(checkedPurposes).some((v) => v === false),
+    [checkedPurposes]
+  );
+
   // Are any filters active (something unchecked, or a year range trimmed)?
   const hasActiveFilters = useMemo(() => {
-    const anySourceOff = Object.values(checkedSources).some((v) => !v);
-    const anyPurposeOff = Object.values(checkedPurposes).some((v) => !v);
-    const anyTermOff = Object.values(checkedTerms).some((v) => !v);
+    const anyTermOff = Object.values(checkedTerms).some((v) => v === false);
     return (
       anySourceOff ||
       anyPurposeOff ||
@@ -909,7 +920,7 @@ export default function CitesTradeSummary({
       brush !== null ||
       selectedCountry !== null
     );
-  }, [checkedSources, checkedPurposes, checkedTerms, brush, selectedCountry]);
+  }, [anySourceOff, anyPurposeOff, checkedTerms, brush, selectedCountry]);
 
   // Clear all filters (re-check everything, reset the year trim)
   const clearFilters = useCallback(() => {
@@ -939,14 +950,14 @@ export default function CitesTradeSummary({
   const checkboxRows = useMemo(() => {
     if (!data?.found || !data.shipments) return [];
     return data.shipments.filter((r) => {
-      if (r.s && checkedSources[r.s] === false) return false;
-      if (r.p && checkedPurposes[r.p] === false) return false;
+      if (anySourceOff && (!r.s || checkedSources[r.s] === false)) return false;
+      if (anyPurposeOff && (!r.p || checkedPurposes[r.p] === false)) return false;
       if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
       if (selectedCountry && r.e !== selectedCountry && r.i !== selectedCountry)
         return false;
       return true;
     });
-  }, [data, checkedSources, checkedPurposes, checkedTerms, selectedCountry]);
+  }, [data, checkedSources, checkedPurposes, checkedTerms, selectedCountry, anySourceOff, anyPurposeOff]);
 
   // Chart series (all years, checkbox-filtered)
   const chartAgg = useMemo(() => aggregateShipments(checkboxRows), [checkboxRows]);
@@ -965,20 +976,20 @@ export default function CitesTradeSummary({
   const commodityChart = useMemo(() => {
     if (!data?.found || !data.shipments) return [];
     const rows = data.shipments.filter((r) => {
-      if (r.s && checkedSources[r.s] === false) return false;
-      if (r.p && checkedPurposes[r.p] === false) return false;
+      if (anySourceOff && (!r.s || checkedSources[r.s] === false)) return false;
+      if (anyPurposeOff && (!r.p || checkedPurposes[r.p] === false)) return false;
       if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
       if (selectedCountry && r.e !== selectedCountry && r.i !== selectedCountry)
         return false;
       return true;
     });
     return aggregateShipments(rows).termsByUnit;
-  }, [data, checkedSources, checkedPurposes, brush, selectedCountry]);
+  }, [data, checkedSources, checkedPurposes, brush, selectedCountry, anySourceOff, anyPurposeOff]);
 
   const sourceChart = useMemo(() => {
     if (!data?.found || !data.shipments) return [];
     const rows = data.shipments.filter((r) => {
-      if (r.p && checkedPurposes[r.p] === false) return false;
+      if (anyPurposeOff && (!r.p || checkedPurposes[r.p] === false)) return false;
       if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
       if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
       if (selectedCountry && r.e !== selectedCountry && r.i !== selectedCountry)
@@ -986,12 +997,12 @@ export default function CitesTradeSummary({
       return true;
     });
     return aggregateShipments(rows).topSources;
-  }, [data, checkedPurposes, checkedTerms, brush, selectedCountry]);
+  }, [data, checkedPurposes, checkedTerms, brush, selectedCountry, anyPurposeOff]);
 
   const purposeChart = useMemo(() => {
     if (!data?.found || !data.shipments) return [];
     const rows = data.shipments.filter((r) => {
-      if (r.s && checkedSources[r.s] === false) return false;
+      if (anySourceOff && (!r.s || checkedSources[r.s] === false)) return false;
       if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
       if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
       if (selectedCountry && r.e !== selectedCountry && r.i !== selectedCountry)
@@ -999,7 +1010,7 @@ export default function CitesTradeSummary({
       return true;
     });
     return aggregateShipments(rows).topPurposes;
-  }, [data, checkedSources, checkedTerms, brush, selectedCountry]);
+  }, [data, checkedSources, checkedTerms, brush, selectedCountry, anySourceOff]);
 
   // Exporter / importer aggregates that DON'T apply the country cross-filter, so
   // the Top exporters / importers lists stay populated and let you switch
@@ -1007,14 +1018,14 @@ export default function CitesTradeSummary({
   const countryAgg = useMemo(() => {
     if (!data?.found || !data.shipments) return null;
     const rows = data.shipments.filter((r) => {
-      if (r.s && checkedSources[r.s] === false) return false;
-      if (r.p && checkedPurposes[r.p] === false) return false;
+      if (anySourceOff && (!r.s || checkedSources[r.s] === false)) return false;
+      if (anyPurposeOff && (!r.p || checkedPurposes[r.p] === false)) return false;
       if (checkedTerms[termUnitKey(r.t, r.u)] === false) return false;
       if (brush && (r.y < brush[0] || r.y > brush[1])) return false;
       return true;
     });
     return aggregateShipments(rows);
-  }, [data, checkedSources, checkedPurposes, checkedTerms, brush]);
+  }, [data, checkedSources, checkedPurposes, checkedTerms, brush, anySourceOff, anyPurposeOff]);
 
   const hasShipments = !!data?.shipments && data.shipments.length > 0;
 

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -307,18 +307,22 @@ function FilterBarChart({
 
   return (
     <div className="min-w-0">
-      <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
-        {title}
-      </h5>
-      {onSearchChange && (
-        <input
-          type="text"
-          value={search ?? ""}
-          onChange={(e) => onSearchChange(e.target.value)}
-          placeholder={searchPlaceholder}
-          className="w-full mb-1.5 px-2 py-1 text-xs rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300 placeholder:text-zinc-400"
-        />
-      )}
+      {/* Fixed-height header row so the bar lists in adjacent charts line up,
+          whether or not a chart has an inline search box. */}
+      <div className="flex items-center gap-2 mb-1.5 h-7">
+        <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider shrink-0">
+          {title}
+        </h5>
+        {onSearchChange && (
+          <input
+            type="text"
+            value={search ?? ""}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder={searchPlaceholder}
+            className="ml-auto w-32 px-2 py-0.5 text-xs rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300 placeholder:text-zinc-400"
+          />
+        )}
+      </div>
       <div className="space-y-1 max-h-[240px] overflow-y-auto pr-1">
         {bars.map((b) => {
           const pct = max > 0 ? (b.records / max) * 100 : 0;
@@ -644,55 +648,6 @@ function TrendLineChart({
 }
 
 /* ------------------------------------------------------------------ */
-/*  Trend summary text                                                 */
-/* ------------------------------------------------------------------ */
-
-function TrendSummary({
-  data,
-  metric,
-}: {
-  data: YearData[];
-  metric: "records" | "quantity";
-}) {
-  if (data.length < 4) return null;
-  const mid = Math.floor(data.length / 2);
-  const firstHalf = data.slice(0, mid);
-  const secondHalf = data.slice(mid);
-  const key = metric;
-  const avgFirst = firstHalf.reduce((s, d) => s + d[key], 0) / firstHalf.length;
-  const avgSecond =
-    secondHalf.reduce((s, d) => s + d[key], 0) / secondHalf.length;
-  if (avgFirst === 0 && avgSecond === 0) return null;
-  const pctChange = avgFirst === 0 ? 100 : ((avgSecond - avgFirst) / avgFirst) * 100;
-
-  if (Math.abs(pctChange) < 15) {
-    return (
-      <span className="text-zinc-400 dark:text-zinc-500 text-[11px]" title="Stable trend">
-        Trend: stable
-      </span>
-    );
-  }
-  if (pctChange > 0) {
-    return (
-      <span
-        className="text-red-500 dark:text-red-400 text-[11px] font-medium"
-        title={`Increased ~${Math.round(pctChange)}% (comparing first/second half of period)`}
-      >
-        &#9650; +{Math.round(pctChange)}%
-      </span>
-    );
-  }
-  return (
-    <span
-      className="text-emerald-500 dark:text-emerald-400 text-[11px] font-medium"
-      title={`Decreased ~${Math.round(Math.abs(pctChange))}% (comparing first/second half of period)`}
-    >
-      &#9660; {Math.round(pctChange)}%
-    </span>
-  );
-}
-
-/* ------------------------------------------------------------------ */
 /*  Country table                                                      */
 /* ------------------------------------------------------------------ */
 
@@ -702,35 +657,27 @@ function CountryTable({ data, label }: { data: CountryData[]; label: string }) {
 
   return (
     <div>
-      <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
+      <h5 className="text-[10px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-0.5">
         {label}
       </h5>
-      <table className="w-full text-xs">
-        <thead>
-          <tr className="text-left text-zinc-400 dark:text-zinc-500">
-            <th className="font-medium pb-1 pr-2">Country</th>
-            <th className="font-medium pb-1 text-right">Records</th>
-          </tr>
-        </thead>
-        <tbody>
-          {top.map((c) => (
-            <tr
-              key={c.code}
-              className="border-t border-zinc-100 dark:border-zinc-800/50"
-            >
-              <td className="py-1 pr-2 text-zinc-700 dark:text-zinc-300">
-                {countryName(c.code)}
-                <span className="text-zinc-400 dark:text-zinc-500 ml-1">
-                  ({c.code})
-                </span>
-              </td>
-              <td className="py-1 text-right text-zinc-500 dark:text-zinc-400 tabular-nums">
-                {c.records.toLocaleString()}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div>
+        {top.map((c) => (
+          <div
+            key={c.code}
+            className="flex items-baseline justify-between gap-2 text-[11px] py-px"
+          >
+            <span className="truncate text-zinc-700 dark:text-zinc-300">
+              {countryName(c.code)}
+              <span className="text-zinc-400 dark:text-zinc-500 ml-1">
+                ({c.code})
+              </span>
+            </span>
+            <span className="text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">
+              {c.records.toLocaleString()}
+            </span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }
@@ -1018,6 +965,47 @@ export default function CitesTradeSummary({
   const hasFilterCharts =
     sourceBars.length > 0 || purposeBars.length > 0 || commodityChart.length > 0;
 
+  // Trade-over-time chart, placed in the map's side column (or full width when
+  // there is no map).
+  const tradeOverTimeChart = (
+    <div>
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+          Trade over time
+        </span>
+        <span className="text-[11px] text-zinc-400 dark:text-zinc-500 normal-case">
+          (shipments)
+        </span>
+        {brush && (
+          <span className="text-[11px] text-blue-600 dark:text-blue-400 tabular-nums ml-auto">
+            {brush[0]}–{brush[1]}
+          </span>
+        )}
+      </div>
+      <TrendLineChart
+        data={chartByYear}
+        metric={metric}
+        minYear={minYear}
+        maxYear={maxYear}
+        brush={brush}
+        onBrushChange={setBrush}
+        provisionalFromYear={provisionalFromYear}
+      />
+      <p className="text-[10px] text-zinc-400 dark:text-zinc-500 mt-1 leading-snug">
+        Drag the handles to trim the year range.
+        {maxYear >= provisionalFromYear && (
+          <>
+            {" "}
+            Recent years (dashed, {provisionalFromYear}+) are{" "}
+            <span className="text-amber-500 dark:text-amber-400">provisional</span> —
+            CITES reporting lags by a few years, so they are usually incomplete
+            rather than showing a real drop.
+          </>
+        )}
+      </p>
+    </div>
+  );
+
   return (
     <div className="space-y-4">
       {/* Headline */}
@@ -1036,7 +1024,6 @@ export default function CitesTradeSummary({
             </span>
           )}
         </span>
-        <TrendSummary data={display.byYear} metric={metric} />
         {hasActiveFilters && (
           <button
             className="text-[11px] text-blue-600 dark:text-blue-400 hover:underline ml-auto"
@@ -1047,7 +1034,8 @@ export default function CitesTradeSummary({
         )}
       </div>
 
-      {/* Trade flow map with Top exporters / importers alongside it */}
+      {/* Trade flow map, with Top exporters / importers and the trade-over-time
+          chart stacked in the side column. */}
       {displayFlows.length > 0 ? (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
           <div className="lg:col-span-2 border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden bg-zinc-50 dark:bg-zinc-800/30">
@@ -1060,72 +1048,33 @@ export default function CitesTradeSummary({
               countryAnnotations={countryAnnotations}
             />
           </div>
-          <div className="space-y-4">
+          <div className="space-y-3">
             <CountryTable data={displayExporters} label="Top exporters" />
             <CountryTable data={displayImporters} label="Top importers" />
+            {tradeOverTimeChart}
           </div>
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <CountryTable data={displayExporters} label="Top exporters" />
-          <CountryTable data={displayImporters} label="Top importers" />
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <CountryTable data={displayExporters} label="Top exporters" />
+            <CountryTable data={displayImporters} label="Top importers" />
+          </div>
+          {tradeOverTimeChart}
         </div>
       )}
 
-      {/* Trade over time */}
-      <div>
-        <div className="flex items-center gap-2 mb-2">
-          <span className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
-            Trade over time
-          </span>
-          <span className="text-[11px] text-zinc-400 dark:text-zinc-500 normal-case">
-            (shipments)
-          </span>
-          {brush && (
-            <span className="text-[11px] text-blue-600 dark:text-blue-400 tabular-nums ml-auto">
-              {brush[0]}–{brush[1]}
-            </span>
-          )}
-        </div>
-        <TrendLineChart
-          data={chartByYear}
-          metric={metric}
-          minYear={minYear}
-          maxYear={maxYear}
-          brush={brush}
-          onBrushChange={setBrush}
-          provisionalFromYear={provisionalFromYear}
-        />
-        <p className="text-[10px] text-zinc-400 dark:text-zinc-500 mt-1 leading-snug">
-          Drag the handles to trim the year range.
-          {maxYear >= provisionalFromYear && (
-            <>
-              {" "}
-              Recent years (dashed, {provisionalFromYear}+) are{" "}
-              <span className="text-amber-500 dark:text-amber-400">provisional</span> —
-              CITES reporting lags by a few years, so they are usually incomplete
-              rather than showing a real drop.
-            </>
-          )}
-        </p>
-      </div>
-
-      {/* Filter charts — click a bar to cross-filter the whole summary.
-          Source bars are coloured wild (amber) vs captive (emerald). */}
+      {/* Filter charts below the map — click a bar to cross-filter the whole
+          summary. Source bars are coloured wild (amber) vs captive (emerald). */}
       {hasFilterCharts && (
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <FilterBarChart
-            title="Source"
-            bars={sourceBars}
-            onToggle={hasShipments ? toggleSource : undefined}
-          />
           <FilterBarChart
             title="Commodity"
             bars={commodityBars}
             onToggle={hasShipments ? toggleTerm : undefined}
             search={termSearch}
             onSearchChange={setTermSearch}
-            searchPlaceholder="Search commodities…"
+            searchPlaceholder="Search…"
             emptyHint={
               commoditySearch
                 ? `No commodities match “${termSearch}”.`
@@ -1136,6 +1085,11 @@ export default function CitesTradeSummary({
             title="Purpose"
             bars={purposeBars}
             onToggle={hasShipments ? togglePurpose : undefined}
+          />
+          <FilterBarChart
+            title="Source"
+            bars={sourceBars}
+            onToggle={hasShipments ? toggleSource : undefined}
           />
         </div>
       )}

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -221,12 +221,12 @@ function aggregateShipments(rows: CompactRecord[]): Aggregated {
 
   const topExporters = Array.from(exporterMap.entries())
     .sort(([, a], [, b]) => b.records - a.records)
-    .slice(0, 8)
+    .slice(0, 15)
     .map(([code, v]) => ({ code, ...v }));
 
   const topImporters = Array.from(importerMap.entries())
     .sort(([, a], [, b]) => b.records - a.records)
-    .slice(0, 8)
+    .slice(0, 15)
     .map(([code, v]) => ({ code, ...v }));
 
   const topFlows = Array.from(flowMap.entries())
@@ -651,32 +651,49 @@ function TrendLineChart({
 /*  Country table                                                      */
 /* ------------------------------------------------------------------ */
 
-function CountryTable({ data, label }: { data: CountryData[]; label: string }) {
+function CountryTable({
+  data,
+  label,
+  selected,
+  onSelect,
+}: {
+  data: CountryData[];
+  label: string;
+  selected?: string | null;
+  onSelect?: (code: string | null) => void;
+}) {
   if (data.length === 0) return null;
-  const top = [...data].sort((a, b) => b.records - a.records).slice(0, 5);
+  const top = [...data].sort((a, b) => b.records - a.records);
 
   return (
-    <div>
+    <div className="min-w-0">
       <h5 className="text-[10px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-0.5">
         {label}
       </h5>
-      <div>
-        {top.map((c) => (
-          <div
-            key={c.code}
-            className="flex items-baseline justify-between gap-2 text-[11px] py-px"
-          >
-            <span className="truncate text-zinc-700 dark:text-zinc-300">
-              {countryName(c.code)}
-              <span className="text-zinc-400 dark:text-zinc-500 ml-1">
-                ({c.code})
+      <div className="max-h-[116px] overflow-y-auto pr-1">
+        {top.map((c) => {
+          const isSel = selected === c.code;
+          return (
+            <div
+              key={c.code}
+              onClick={onSelect ? () => onSelect(isSel ? null : c.code) : undefined}
+              title={`${countryName(c.code)} — ${c.records.toLocaleString()} records`}
+              className={`flex items-baseline justify-between gap-1.5 text-[11px] py-px px-1 -mx-1 rounded ${
+                onSelect ? "cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-800/60" : ""
+              } ${isSel ? "bg-amber-100 dark:bg-amber-900/40" : ""}`}
+            >
+              <span className="truncate text-zinc-700 dark:text-zinc-300">
+                {countryName(c.code)}
+                <span className="text-zinc-400 dark:text-zinc-500 ml-1">
+                  ({c.code})
+                </span>
               </span>
-            </span>
-            <span className="text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">
-              {c.records.toLocaleString()}
-            </span>
-          </div>
-        ))}
+              <span className="text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">
+                {c.records.toLocaleString()}
+              </span>
+            </div>
+          );
+        })}
       </div>
     </div>
   );
@@ -720,6 +737,10 @@ export default function CitesTradeSummary({
 
   // Year-range trim (null = full range)
   const [brush, setBrush] = useState<[number, number] | null>(null);
+
+  // Country highlighted on the map (also set by clicking a Top exporters /
+  // importers row). Filters the map's flows to that country.
+  const [selectedCountry, setSelectedCountry] = useState<string | null>(null);
 
   // Use prefetched data from parent when available; fall back to own fetch
   const data = (prefetchedData as TradeData | null) ?? ownData;
@@ -790,8 +811,14 @@ export default function CitesTradeSummary({
     const anySourceOff = Object.values(checkedSources).some((v) => !v);
     const anyPurposeOff = Object.values(checkedPurposes).some((v) => !v);
     const anyTermOff = Object.values(checkedTerms).some((v) => !v);
-    return anySourceOff || anyPurposeOff || anyTermOff || brush !== null;
-  }, [checkedSources, checkedPurposes, checkedTerms, brush]);
+    return (
+      anySourceOff ||
+      anyPurposeOff ||
+      anyTermOff ||
+      brush !== null ||
+      selectedCountry !== null
+    );
+  }, [checkedSources, checkedPurposes, checkedTerms, brush, selectedCountry]);
 
   // Clear all filters (re-check everything, reset the year trim)
   const clearFilters = useCallback(() => {
@@ -812,6 +839,7 @@ export default function CitesTradeSummary({
     });
     setBrush(null);
     setTermSearch("");
+    setSelectedCountry(null);
   }, []);
 
   // Shipments passing the checkbox filters (all years) — drives the chart line.
@@ -967,14 +995,25 @@ export default function CitesTradeSummary({
 
   // Trade-over-time chart, placed in the map's side column (or full width when
   // there is no map).
+  const trendInfo =
+    "Drag the handles to trim the year range." +
+    (maxYear >= provisionalFromYear
+      ? ` Recent years (dashed, ${provisionalFromYear}+) are provisional — CITES reporting lags by a few years, so they are usually incomplete rather than showing a real drop.`
+      : "");
   const tradeOverTimeChart = (
     <div>
-      <div className="flex items-center gap-2 mb-2">
+      <div className="flex items-center gap-1.5 mb-2">
         <span className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
           Trade over time
         </span>
         <span className="text-[11px] text-zinc-400 dark:text-zinc-500 normal-case">
           (shipments)
+        </span>
+        <span
+          title={trendInfo}
+          className="flex items-center justify-center w-3.5 h-3.5 rounded-full border border-zinc-400 dark:border-zinc-500 text-[9px] font-semibold text-zinc-400 dark:text-zinc-500 cursor-help"
+        >
+          i
         </span>
         {brush && (
           <span className="text-[11px] text-blue-600 dark:text-blue-400 tabular-nums ml-auto">
@@ -991,18 +1030,6 @@ export default function CitesTradeSummary({
         onBrushChange={setBrush}
         provisionalFromYear={provisionalFromYear}
       />
-      <p className="text-[10px] text-zinc-400 dark:text-zinc-500 mt-1 leading-snug">
-        Drag the handles to trim the year range.
-        {maxYear >= provisionalFromYear && (
-          <>
-            {" "}
-            Recent years (dashed, {provisionalFromYear}+) are{" "}
-            <span className="text-amber-500 dark:text-amber-400">provisional</span> —
-            CITES reporting lags by a few years, so they are usually incomplete
-            rather than showing a real drop.
-          </>
-        )}
-      </p>
     </div>
   );
 
@@ -1037,7 +1064,7 @@ export default function CitesTradeSummary({
       {/* Trade flow map, with Top exporters / importers and the trade-over-time
           chart stacked in the side column. */}
       {displayFlows.length > 0 ? (
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 items-start">
           <div className="lg:col-span-2 border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden bg-zinc-50 dark:bg-zinc-800/30">
             <TradeFlowMap
               flows={displayFlows}
@@ -1046,19 +1073,43 @@ export default function CitesTradeSummary({
               importers={displayImporters}
               suspensionCountries={suspensionCountries}
               countryAnnotations={countryAnnotations}
+              selectedCountry={selectedCountry}
+              onSelectCountry={setSelectedCountry}
             />
           </div>
           <div className="space-y-3">
-            <CountryTable data={displayExporters} label="Top exporters" />
-            <CountryTable data={displayImporters} label="Top importers" />
+            <div className="grid grid-cols-2 gap-3">
+              <CountryTable
+                data={displayExporters}
+                label="Top exporters"
+                selected={selectedCountry}
+                onSelect={setSelectedCountry}
+              />
+              <CountryTable
+                data={displayImporters}
+                label="Top importers"
+                selected={selectedCountry}
+                onSelect={setSelectedCountry}
+              />
+            </div>
             {tradeOverTimeChart}
           </div>
         </div>
       ) : (
         <div className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <CountryTable data={displayExporters} label="Top exporters" />
-            <CountryTable data={displayImporters} label="Top importers" />
+            <CountryTable
+              data={displayExporters}
+              label="Top exporters"
+              selected={selectedCountry}
+              onSelect={setSelectedCountry}
+            />
+            <CountryTable
+              data={displayImporters}
+              label="Top importers"
+              selected={selectedCountry}
+              onSelect={setSelectedCountry}
+            />
           </div>
           {tradeOverTimeChart}
         </div>

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -94,6 +94,21 @@ function project(coords: [number, number]): [number, number] | null {
   return p ? [p[0] + MAP_OFFSET[0], p[1] + MAP_OFFSET[1]] : null;
 }
 
+function hexToRgb(hex: string): [number, number, number] {
+  const n = parseInt(hex.slice(1), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+/** Linearly interpolate between two hex colours (t in [0, 1]). */
+function mixColor(a: string, b: string, t: number): string {
+  const [ar, ag, ab] = hexToRgb(a);
+  const [br, bg, bb] = hexToRgb(b);
+  const r = Math.round(ar + (br - ar) * t);
+  const g = Math.round(ag + (bg - ag) * t);
+  const bl = Math.round(ab + (bb - ab) * t);
+  return `rgb(${r}, ${g}, ${bl})`;
+}
+
 /** Build a quadratic bezier arc from→to, curving left of the direction of travel */
 function arcPath(
   from: [number, number],
@@ -276,12 +291,29 @@ function TradeFlowMap({
     return ex > im ? "exporter" : "importer";
   }
 
+  // Colour depth scales (log) with a country's volume in its dominant role, so
+  // small importers/exporters are barely tinted and big ones are saturated.
+  let maxMagnitude = 1;
+  for (const v of exportRecords.values()) if (v > maxMagnitude) maxMagnitude = v;
+  for (const v of importRecords.values()) if (v > maxMagnitude) maxMagnitude = v;
+  const logMax = Math.log(maxMagnitude + 1);
+  function intensityOf(code: string, role: TradeRole): number {
+    const mag =
+      role === "exporter"
+        ? exportRecords.get(code) ?? 0
+        : importRecords.get(code) ?? 0;
+    if (mag <= 0) return 0;
+    return logMax > 0 ? Math.log(mag + 1) / logMax : 1;
+  }
+
   const maxRecords = visibleFlows.length > 0 ? Math.max(...visibleFlows.map((f) => f.records)) : 0;
 
-  // Theme-aware colors for SVG fills (can't use Tailwind classes in SVG)
+  // Theme-aware colors for SVG fills (can't use Tailwind classes in SVG). The
+  // exporter/importer values are the *saturated* end of the depth ramp (mixed
+  // toward `base` by intensity below); they match the marker dot colours.
   const colors = dark
-    ? { base: "#18181b", exporter: "#7f1d1d", importer: "#1e3a5f", stroke: "#27272a", arcDefault: "#f87171", arcHover: "#fbbf24", reExport: "#d97706" }
-    : { base: "#f4f4f5", exporter: "#fee2e2", importer: "#dbeafe", stroke: "#d4d4d8", arcDefault: "#ef4444", arcHover: "#f59e0b", reExport: "#d97706" };
+    ? { base: "#18181b", exporter: "#ef4444", importer: "#3b82f6", stroke: "#27272a", arcDefault: "#f87171", arcHover: "#fbbf24", reExport: "#d97706" }
+    : { base: "#f4f4f5", exporter: "#ef4444", importer: "#3b82f6", stroke: "#d4d4d8", arcDefault: "#ef4444", arcHover: "#f59e0b", reExport: "#d97706" };
 
   const hoveredFlowData = hoveredFlow !== null ? visibleFlows[hoveredFlow] : null;
   const hoveredReExportData =
@@ -409,8 +441,12 @@ function TradeFlowMap({
                   // filled a red almost identical to the exporter colour and
                   // read as an exporter. (#307)
                   let fill = colors.base;
-                  if (role === "exporter") fill = colors.exporter;
-                  else if (role === "importer") fill = colors.importer;
+                  if (role && alpha2)
+                    fill = mixColor(
+                      colors.base,
+                      colors[role],
+                      intensityOf(alpha2, role)
+                    );
 
                   const hasAnnotation = !!(alpha2 && countryAnnotations?.[alpha2]);
                   // Any country that traded is clickable (selecting it

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -217,17 +217,6 @@ function TradeFlowMap({
     [flows]
   );
 
-  // Countries that take part in at least one drawn flow — these are clickable
-  // (on the country shape or its dot) to filter the map to their trade.
-  const flowCountryCodes = useMemo(() => {
-    const codes = new Set<string>();
-    for (const f of renderableFlows) {
-      codes.add(f.from);
-      codes.add(f.to);
-    }
-    return codes;
-  }, [renderableFlows]);
-
   // Re-export legs (origin → re-exporter) with known centroids
   const renderableReExports = useMemo(
     () =>
@@ -424,10 +413,9 @@ function TradeFlowMap({
                   else if (role === "importer") fill = colors.importer;
 
                   const hasAnnotation = !!(alpha2 && countryAnnotations?.[alpha2]);
-                  // Clickable only for countries in a drawn flow (so the
-                  // selection actually filters something); the hover tooltip
-                  // shows for any country with trade totals or an annotation.
-                  const isClickable = alpha2 ? flowCountryCodes.has(alpha2) : false;
+                  // Any country that traded is clickable (selecting it
+                  // cross-filters the summary) and shows a hover tooltip.
+                  const isClickable = role !== null;
                   const showTooltip = role !== null || hasAnnotation;
                   const cursor = isClickable ? "pointer" : "default";
 

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo, memo } from "react";
+import React, { useState, useMemo, useRef, useEffect, useCallback, memo } from "react";
 import {
   ComposableMap,
   Geographies,
@@ -226,6 +226,80 @@ function TradeFlowMap({
   const setSelectedCountry = onSelectCountry ?? setInternalSelected;
   const [showReExports, setShowReExports] = useState(false);
 
+  /* ---- Pan / zoom -------------------------------------------------- */
+  // A single transform applied to all map content (geographies + arcs +
+  // markers), so they stay aligned. At {k:1,x:0,y:0} the map renders exactly as
+  // before — pan/zoom is purely additive.
+  const MIN_ZOOM = 1;
+  const MAX_ZOOM = 8;
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [view, setView] = useState({ k: 1, x: 0, y: 0 });
+  const drag = useRef<{ x: number; y: number; vx: number; vy: number } | null>(null);
+  const moved = useRef(false);
+
+  // Keep the (scaled) content covering the viewport.
+  const clampView = (k: number, x: number, y: number) => ({
+    k,
+    x: Math.min(0, Math.max(MAP_WIDTH * (1 - k), x)),
+    y: Math.min(0, Math.max(MAP_HEIGHT * (1 - k), y)),
+  });
+
+  // Pointer (viewBox) coords from a client event.
+  const toView = (clientX: number, clientY: number) => {
+    const rect = wrapRef.current?.getBoundingClientRect();
+    if (!rect) return [0, 0] as const;
+    return [
+      ((clientX - rect.left) / rect.width) * MAP_WIDTH,
+      ((clientY - rect.top) / rect.height) * MAP_HEIGHT,
+    ] as const;
+  };
+
+  const zoomBy = useCallback((factor: number, cx = MAP_WIDTH / 2, cy = MAP_HEIGHT / 2) => {
+    setView((v) => {
+      const k = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, v.k * factor));
+      const r = k / v.k;
+      return clampView(k, cx - (cx - v.x) * r, cy - (cy - v.y) * r);
+    });
+  }, []);
+
+  // Non-passive wheel listener so we can preventDefault the page scroll.
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const [cx, cy] = toView(e.clientX, e.clientY);
+      zoomBy(e.deltaY < 0 ? 1.2 : 1 / 1.2, cx, cy);
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, [zoomBy]);
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    drag.current = { x: e.clientX, y: e.clientY, vx: view.x, vy: view.y };
+    moved.current = false;
+    (e.target as Element).setPointerCapture?.(e.pointerId);
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (!drag.current) return;
+    const rect = wrapRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const dx = ((e.clientX - drag.current.x) / rect.width) * MAP_WIDTH;
+    const dy = ((e.clientY - drag.current.y) / rect.height) * MAP_HEIGHT;
+    if (Math.abs(e.clientX - drag.current.x) + Math.abs(e.clientY - drag.current.y) > 3)
+      moved.current = true;
+    setView((v) => clampView(v.k, drag.current!.vx + dx, drag.current!.vy + dy));
+  };
+  const onPointerUp = () => {
+    drag.current = null;
+  };
+  // Suppress the click that ends a drag (so panning doesn't select a country).
+  const consumeClick = () => {
+    const m = moved.current;
+    moved.current = false;
+    return m;
+  };
+
   // Only render flows where we have centroids for both endpoints
   const renderableFlows = useMemo(
     () => flows.filter((f) => COUNTRY_CENTROIDS[f.from] && COUNTRY_CENTROIDS[f.to]),
@@ -311,7 +385,7 @@ function TradeFlowMap({
   // exporter/importer values are the *saturated* end of the depth ramp (mixed
   // toward `base` by intensity below); they match the marker dot colours.
   const colors = dark
-    ? { base: "#18181b", exporter: "#ef4444", importer: "#3b82f6", stroke: "#27272a", arcDefault: "#f87171", arcHover: "#fbbf24", reExport: "#d97706" }
+    ? { base: "#3f3f46", exporter: "#ef4444", importer: "#3b82f6", stroke: "#71717a", arcDefault: "#f87171", arcHover: "#fbbf24", reExport: "#d97706" }
     : { base: "#f4f4f5", exporter: "#ef4444", importer: "#3b82f6", stroke: "#d4d4d8", arcDefault: "#ef4444", arcHover: "#f59e0b", reExport: "#d97706" };
 
   const hoveredFlowData = hoveredFlow !== null ? visibleFlows[hoveredFlow] : null;
@@ -414,6 +488,18 @@ function TradeFlowMap({
         </button>
       )}
 
+      <div
+        ref={wrapRef}
+        className="relative"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerLeave={onPointerUp}
+        style={{
+          touchAction: "none",
+          cursor: drag.current ? "grabbing" : view.k > 1 ? "grab" : "default",
+        }}
+      >
       <ComposableMap
         projection="geoNaturalEarth1"
         projectionConfig={{ scale: 160, center: [0, 0] }}
@@ -421,6 +507,7 @@ function TradeFlowMap({
         width={MAP_WIDTH}
         height={MAP_HEIGHT}
       >
+       <g transform={`translate(${view.x}, ${view.y}) scale(${view.k})`}>
         <g transform={`translate(${MAP_OFFSET[0]}, ${MAP_OFFSET[1]})`}>
           {/* Base map */}
           <Geographies geography={GEO_URL}>
@@ -462,15 +549,17 @@ function TradeFlowMap({
                       onMouseLeave={() => setHoveredCountry(null)}
                       onClick={
                         isClickable
-                          ? () =>
+                          ? () => {
+                              if (consumeClick()) return;
                               setSelectedCountry(
                                 selectedCountry === alpha2 ? null : alpha2
-                              )
+                              );
+                            }
                           : undefined
                       }
                       style={{
                         default: { outline: "none", cursor },
-                        hover: { outline: "none", fill: showTooltip ? (dark ? "#3f3f46" : "#e4e4e7") : fill, cursor },
+                        hover: { outline: "none", fill: showTooltip ? (dark ? "#52525b" : "#e4e4e7") : fill, cursor },
                         pressed: { outline: "none" },
                       }}
                     />
@@ -610,7 +699,10 @@ function TradeFlowMap({
                       stroke={dark ? "#18181b" : "#fff"}
                       strokeWidth={isSelected ? 1 : 0.5}
                       style={{ cursor: "pointer" }}
-                      onClick={() => setSelectedCountry(selectedCountry === code ? null : code)}
+                      onClick={() => {
+                        if (consumeClick()) return;
+                        setSelectedCountry(selectedCountry === code ? null : code);
+                      }}
                     />
                     {isSelected && (
                       <text
@@ -629,7 +721,30 @@ function TradeFlowMap({
             return markers;
           })()}
         </g>
+       </g>
       </ComposableMap>
+
+        {/* Zoom controls */}
+        <div className="absolute bottom-2 right-2 z-10 flex flex-col gap-1">
+          <button
+            type="button"
+            aria-label="Zoom in"
+            onClick={() => zoomBy(1.5)}
+            className="w-6 h-6 flex items-center justify-center rounded bg-white/90 dark:bg-zinc-800/90 border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-300 shadow-sm hover:bg-white dark:hover:bg-zinc-700 text-sm font-medium"
+          >
+            +
+          </button>
+          <button
+            type="button"
+            aria-label="Zoom out"
+            onClick={() => zoomBy(1 / 1.5)}
+            disabled={view.k <= MIN_ZOOM}
+            className="w-6 h-6 flex items-center justify-center rounded bg-white/90 dark:bg-zinc-800/90 border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-300 shadow-sm hover:bg-white dark:hover:bg-zinc-700 disabled:opacity-30 disabled:cursor-not-allowed text-sm font-medium"
+          >
+            −
+          </button>
+        </div>
+      </div>
 
       {/* Legend — labelled with CITES roles */}
       <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 mt-1 text-[10px] text-zinc-500 dark:text-zinc-400">

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -178,6 +178,13 @@ interface TradeFlowMapProps {
   suspensionCountries?: Set<string>;
   /** Per-country suspension/quota annotations for hover tooltip */
   countryAnnotations?: Record<string, CountryAnnotation>;
+  /**
+   * Optional controlled selection. When provided, the parent owns the selected
+   * country (so e.g. clicking a Top exporters row can drive the map too);
+   * otherwise the map keeps its own internal selection state.
+   */
+  selectedCountry?: string | null;
+  onSelectCountry?: (code: string | null) => void;
 }
 
 function TradeFlowMap({
@@ -187,12 +194,17 @@ function TradeFlowMap({
   importers,
   suspensionCountries,
   countryAnnotations,
+  selectedCountry: selectedCountryProp,
+  onSelectCountry,
 }: TradeFlowMapProps) {
   const { resolvedTheme } = useTheme();
   const [hoveredFlow, setHoveredFlow] = useState<number | null>(null);
   const [hoveredReExport, setHoveredReExport] = useState<number | null>(null);
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
-  const [selectedCountry, setSelectedCountry] = useState<string | null>(null);
+  const [internalSelected, setInternalSelected] = useState<string | null>(null);
+  const selectedCountry =
+    selectedCountryProp !== undefined ? selectedCountryProp : internalSelected;
+  const setSelectedCountry = onSelectCountry ?? setInternalSelected;
   const [showReExports, setShowReExports] = useState(false);
 
   // Only render flows where we have centroids for both endpoints
@@ -282,6 +294,13 @@ function TradeFlowMap({
   const hoveredReExportData =
     hoveredReExport !== null ? visibleReExports[hoveredReExport] : null;
 
+  // Trade totals + annotations for the hovered country tooltip
+  const hoveredExports = hoveredCountry ? exportRecords.get(hoveredCountry) ?? 0 : 0;
+  const hoveredImports = hoveredCountry ? importRecords.get(hoveredCountry) ?? 0 : 0;
+  const hoveredAnnotation = hoveredCountry
+    ? countryAnnotations?.[hoveredCountry]
+    : undefined;
+
   return (
     <div className="relative">
       {/* Direct-flow tooltip — labelled with CITES roles (Exporter → Importer) */}
@@ -318,21 +337,39 @@ function TradeFlowMap({
       )}
 
       {/* Country annotation tooltip (suspensions/quotas) */}
-      {hoveredCountry && !hoveredFlowData && !hoveredReExportData && countryAnnotations?.[hoveredCountry] && (
+      {hoveredCountry && !hoveredFlowData && !hoveredReExportData && (
         <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10 bg-zinc-800 dark:bg-zinc-700 text-white text-[11px] px-3 py-2 rounded-lg shadow-lg pointer-events-none max-w-[280px]">
           <div className="font-medium mb-1">{countryName(hoveredCountry)}</div>
-          {countryAnnotations[hoveredCountry].suspensions && countryAnnotations[hoveredCountry].suspensions!.length > 0 && (
+          {(hoveredExports > 0 || hoveredImports > 0) && (
+            <div className="mb-1 space-y-0.5">
+              {hoveredExports > 0 && (
+                <div>
+                  <span className="text-red-300">Exports</span>{" "}
+                  <span className="text-zinc-200 tabular-nums">{hoveredExports.toLocaleString()}</span>
+                  <span className="text-zinc-400"> records</span>
+                </div>
+              )}
+              {hoveredImports > 0 && (
+                <div>
+                  <span className="text-blue-300">Imports</span>{" "}
+                  <span className="text-zinc-200 tabular-nums">{hoveredImports.toLocaleString()}</span>
+                  <span className="text-zinc-400"> records</span>
+                </div>
+              )}
+            </div>
+          )}
+          {hoveredAnnotation?.suspensions && hoveredAnnotation.suspensions.length > 0 && (
             <div className="text-red-300">
-              {countryAnnotations[hoveredCountry].suspensions!.map((s, i) => (
+              {hoveredAnnotation.suspensions.map((s, i) => (
                 <div key={i}>
                   Trade suspension ({s.type}) since {new Date(s.startDate).toLocaleDateString("en-GB", { month: "short", year: "numeric" })}
                 </div>
               ))}
             </div>
           )}
-          {countryAnnotations[hoveredCountry].quotas && countryAnnotations[hoveredCountry].quotas!.length > 0 && (
+          {hoveredAnnotation?.quotas && hoveredAnnotation.quotas.length > 0 && (
             <div className="text-amber-300">
-              {countryAnnotations[hoveredCountry].quotas!.map((q, i) => (
+              {hoveredAnnotation.quotas.map((q, i) => (
                 <div key={i}>
                   Quota: {q.quota.toLocaleString()}{q.unit ? ` ${q.unit}` : ""}
                 </div>
@@ -382,10 +419,13 @@ function TradeFlowMap({
                   if (role === "exporter") fill = colors.exporter;
                   else if (role === "importer") fill = colors.importer;
 
-                  const hasAnnotation = alpha2 && countryAnnotations?.[alpha2];
-                  const isTradeCountry = alpha2 ? flowCountryCodes.has(alpha2) : false;
-                  const isClickable = isTradeCountry;
-                  const cursor = isClickable || hasAnnotation ? "pointer" : "default";
+                  const hasAnnotation = !!(alpha2 && countryAnnotations?.[alpha2]);
+                  // Clickable only for countries in a drawn flow (so the
+                  // selection actually filters something); the hover tooltip
+                  // shows for any country with trade totals or an annotation.
+                  const isClickable = alpha2 ? flowCountryCodes.has(alpha2) : false;
+                  const showTooltip = role !== null || hasAnnotation;
+                  const cursor = isClickable ? "pointer" : "default";
 
                   return (
                     <Geography
@@ -395,7 +435,7 @@ function TradeFlowMap({
                       stroke={isSuspended ? (dark ? "#f87171" : "#dc2626") : colors.stroke}
                       strokeWidth={isSuspended ? 1 : 0.4}
                       strokeDasharray={isSuspended ? "3,2" : undefined}
-                      onMouseEnter={() => hasAnnotation && setHoveredCountry(alpha2)}
+                      onMouseEnter={() => showTooltip && alpha2 && setHoveredCountry(alpha2)}
                       onMouseLeave={() => setHoveredCountry(null)}
                       onClick={
                         isClickable
@@ -407,7 +447,7 @@ function TradeFlowMap({
                       }
                       style={{
                         default: { outline: "none", cursor },
-                        hover: { outline: "none", fill: isClickable || hasAnnotation ? (dark ? "#3f3f46" : "#e4e4e7") : fill, cursor },
+                        hover: { outline: "none", fill: showTooltip ? (dark ? "#3f3f46" : "#e4e4e7") : fill, cursor },
                         pressed: { outline: "none" },
                       }}
                     />

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -75,12 +75,12 @@ const COUNTRY_CENTROIDS: Record<string, [number, number]> = {
 };
 
 const MAP_WIDTH = 800;
-// Cropped shorter than the projection's natural height to trim the empty band
-// of ocean below the southern continents (Antarctica is filtered out). The
-// extra y-offset keeps the land in the same place while the viewBox cuts the
-// bottom rather than re-centring the map.
-const MAP_HEIGHT = 340;
-const MAP_OFFSET: [number, number] = [30, 50];
+// Cropped a little shorter than the projection's natural height to trim some of
+// the empty ocean below the southern continents, while keeping New Zealand and
+// the southern tip of South America in frame. The extra y-offset keeps the land
+// in place while the viewBox cuts the bottom rather than re-centring the map.
+const MAP_HEIGHT = 372;
+const MAP_OFFSET: [number, number] = [30, 34];
 
 // Build projection that matches the ComposableMap settings
 const projection = geoNaturalEarth1()

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -75,8 +75,12 @@ const COUNTRY_CENTROIDS: Record<string, [number, number]> = {
 };
 
 const MAP_WIDTH = 800;
-const MAP_HEIGHT = 400;
-const MAP_OFFSET: [number, number] = [30, 20];
+// Cropped shorter than the projection's natural height to trim the empty band
+// of ocean below the southern continents (Antarctica is filtered out). The
+// extra y-offset keeps the land in the same place while the viewBox cuts the
+// bottom rather than re-centring the map.
+const MAP_HEIGHT = 340;
+const MAP_OFFSET: [number, number] = [30, 50];
 
 // Build projection that matches the ComposableMap settings
 const projection = geoNaturalEarth1()

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -291,19 +291,18 @@ function TradeFlowMap({
     return ex > im ? "exporter" : "importer";
   }
 
-  // Colour depth scales (log) with a country's volume in its dominant role, so
-  // small importers/exporters are barely tinted and big ones are saturated.
+  // Colour depth scales linearly with a country's NET trade (|exports −
+  // imports|) relative to the largest net trader, so depth faithfully reflects
+  // scale: a 900-net country next to an ~11k-net one reads as ~900/11k.
+  const netOf = (code: string) =>
+    Math.abs((exportRecords.get(code) ?? 0) - (importRecords.get(code) ?? 0));
   let maxMagnitude = 1;
-  for (const v of exportRecords.values()) if (v > maxMagnitude) maxMagnitude = v;
-  for (const v of importRecords.values()) if (v > maxMagnitude) maxMagnitude = v;
-  const logMax = Math.log(maxMagnitude + 1);
-  function intensityOf(code: string, role: TradeRole): number {
-    const mag =
-      role === "exporter"
-        ? exportRecords.get(code) ?? 0
-        : importRecords.get(code) ?? 0;
-    if (mag <= 0) return 0;
-    return logMax > 0 ? Math.log(mag + 1) / logMax : 1;
+  for (const code of new Set([...exportRecords.keys(), ...importRecords.keys()])) {
+    const net = netOf(code);
+    if (net > maxMagnitude) maxMagnitude = net;
+  }
+  function intensityOf(code: string): number {
+    return Math.min(1, netOf(code) / maxMagnitude);
   }
 
   const maxRecords = visibleFlows.length > 0 ? Math.max(...visibleFlows.map((f) => f.records)) : 0;
@@ -442,11 +441,7 @@ function TradeFlowMap({
                   // read as an exporter. (#307)
                   let fill = colors.base;
                   if (role && alpha2)
-                    fill = mixColor(
-                      colors.base,
-                      colors[role],
-                      intensityOf(alpha2, role)
-                    );
+                    fill = mixColor(colors.base, colors[role], intensityOf(alpha2));
 
                   const hasAnnotation = !!(alpha2 && countryAnnotations?.[alpha2]);
                   // Any country that traded is clickable (selecting it

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3381,12 +3381,18 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                                 >
                                   {gbifSpeciesKey ? "GBIF + iNat" : "iNaturalist"}
                                 </button>
+                                <button
+                                  className={`px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "cites" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
+                                  onClick={() => setActiveDetailTab("cites")}
+                                >
+                                  CITES
+                                </button>
                                 {(assessmentYear || s.category === "NE") && (
                                   <button
                                     className={`px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "literature" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
                                     onClick={() => setActiveDetailTab("literature")}
                                   >
-                                    Papers
+                                    Literature
                                   </button>
                                 )}
                                 {s.category !== "NE" && (
@@ -3398,22 +3404,16 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                                   </button>
                                 )}
                                 <button
-                                  className={`px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "cites" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
-                                  onClick={() => setActiveDetailTab("cites")}
+                                  className={`px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "col" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
+                                  onClick={() => setActiveDetailTab("col")}
                                 >
-                                  CITES
+                                  Catalogue of Life
                                 </button>
                                 <button
                                   className={`px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "wikipedia" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
                                   onClick={() => setActiveDetailTab("wikipedia")}
                                 >
                                   Wikipedia
-                                </button>
-                                <button
-                                  className={`px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "col" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
-                                  onClick={() => setActiveDetailTab("col")}
-                                >
-                                  Catalogue of Life
                                 </button>
                                 {s.category === "NE" && (
                                   <button

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3381,12 +3381,6 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                                 >
                                   {gbifSpeciesKey ? "GBIF + iNat" : "iNaturalist"}
                                 </button>
-                                <button
-                                  className={`px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "cites" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
-                                  onClick={() => setActiveDetailTab("cites")}
-                                >
-                                  CITES
-                                </button>
                                 {(assessmentYear || s.category === "NE") && (
                                   <button
                                     className={`px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "literature" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
@@ -3403,6 +3397,12 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                                     IUCN Red List
                                   </button>
                                 )}
+                                <button
+                                  className={`px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "cites" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
+                                  onClick={() => setActiveDetailTab("cites")}
+                                >
+                                  CITES
+                                </button>
                                 <button
                                   className={`px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "col" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
                                   onClick={() => setActiveDetailTab("col")}


### PR DESCRIPTION
Builds on the CITES trade-flow map work (#308). Reworks the trade summary so every chart is an interactive cross-filter, the map reads faithfully, and the surrounding CITES/Species+ UI is tighter.

## Filters: charts replace the sidebar
- Removed the checkbox filter sidebar entirely — the charts **are** the filters now.
- Three interactive bar charts below the map: **Commodity | Purpose | Source**. Clicking a bar **isolates** that category (selects only it); clicking the already-isolated bar resets to all.
- **Source** chart replaces the old Wild/Captive bar — every source code is its own bar, coloured wild (amber) vs captive (emerald).
- Commodity search box moved onto the Commodity chart header.
- Each chart aggregates rows passing every active filter **except its own dimension**, so a de-selected category stays visible to re-add.
- Explicit **"Unspecified"** (blank) category in the Source and Purpose charts (grey bar), so blank-value records are filterable rather than implicitly always-included. (Fixes a bug where isolating "Hunting trophy" for the savanna elephant showed 22,400 records — 11,531 H + 10,869 blank-purpose — instead of 11,531.)
- Removed the read-only Purpose row.

## Country cross-filter
- The **Top exporters / importers** lists are clickable, and selecting a country (from a list or the map) cross-filters the **whole** summary — headline, trend, bar charts, and map — to that country's trade.
- The lists and the map's colour-by-role use a country-excluded aggregate, so they stay global and let you switch country.
- Hovering a country on the map shows its export / import record totals (plus any suspension/quota note).

## Map
- Colours **every** country that traded (no longer capped at the top 15 — that previously hid genuine traders like Cameroon until a filter promoted them).
- Fill **depth scales linearly with net trade** (|exports − imports|) relative to the largest net trader, so small traders are barely tinted and big ones saturated. Saturated ends match the marker/legend colours.
- **Dark mode** readability fixed — land base and country outlines lightened so untraded countries and borders show on the dark container.
- **Pan / zoom** added (drag to pan, wheel or +/− buttons, 1–8×); all map content shares one transform group so arcs/markers stay aligned, and a drag doesn't trigger a country selection.
- Cropped some of the empty ocean below the southern continents while keeping New Zealand and the southern tip of South America in frame.

## Pagination
- The three bar charts and the country lists page 5 rows at a time with Prev/Next (shared `Pager`). Bars scale to the global max so widths stay comparable across pages.

## Layout
- Top exporters / importers + the **Trade over time** chart sit in a side column next to the map; the trend chart is anchored to the bottom so it lines up with the map base.
- The record count + year range + Clear filters moved into a map overlay (no dead headline row).
- Trade-over-time help is a hover info (ⓘ) popover; the provisional-year tooltip just says "provisional".

## Terminology
- Use **"records"** consistently instead of "shipments" (the CITES Trade Database Guide's counting unit is the *record*). Commodity tooltips show quantities in their own unit (e.g. "… / 1,234 kg"). Still adheres to the guide's other rules (exporter-reported quantity preferred, importer+exporter quantities never summed, quantities never aggregated across units, recent years flagged provisional).

## Species detail tabs
- Reordered to **GBIF + iNat · Literature · IUCN Red List · CITES · Catalogue of Life · Wikipedia**, and renamed *Papers* → *Literature*.

## Species+ listings panel
- Two columns: **Current Listings + Reservations** (left), **Trade Quotas + Trade Suspensions** (right).
- Suspensions sorted newest-first; quotas sorted largest-first.
- Each section paginates 5 at a time with Prev/Next (replacing expand-all toggles); truncated text (annotations, country names, quota notes, notification names) shows in full on hover.
- Denser, consistent styling (compact bordered lists; header-less tables).

## Testing
- `eslint` + `tsc` clean; full test suite (402 tests) passes.
- Not visually verified in a running app (no preview env here); the map crop amount, dark-mode shades, pan/zoom feel, and colour-ramp are best guesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrGUdeZ4Z3CeGgg1YpVzqi