### PR TITLE
CITES trade map: flow-count slider, volume-scaled flows, side-by-side quotas/suspensions, and a records table

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -50,3 +50,45 @@ th.sticky {
   background: none !important;
   border: none !important;
 }
+
+/* Extra-small range slider (used for the trade-flow-count control): a thin
+   track with a tiny thumb, so it reads as an unobtrusive inline control. */
+input[type="range"].slider-xs {
+  -webkit-appearance: none;
+  appearance: none;
+  height: 8px;
+  background: transparent;
+}
+input[type="range"].slider-xs::-webkit-slider-runnable-track {
+  height: 2px;
+  border-radius: 9999px;
+  background: #d4d4d8;
+}
+.dark input[type="range"].slider-xs::-webkit-slider-runnable-track {
+  background: #52525b;
+}
+input[type="range"].slider-xs::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 7px;
+  height: 7px;
+  margin-top: -2.5px;
+  border: none;
+  border-radius: 9999px;
+  background: #ef4444;
+}
+input[type="range"].slider-xs::-moz-range-track {
+  height: 2px;
+  border-radius: 9999px;
+  background: #d4d4d8;
+}
+.dark input[type="range"].slider-xs::-moz-range-track {
+  background: #52525b;
+}
+input[type="range"].slider-xs::-moz-range-thumb {
+  width: 7px;
+  height: 7px;
+  border: none;
+  border-radius: 9999px;
+  background: #ef4444;
+}

--- a/app/src/components/CitesSummary.tsx
+++ b/app/src/components/CitesSummary.tsx
@@ -421,94 +421,99 @@ export default function CitesSummary({
         </div>
       )}
 
-      {/* Trade Quotas */}
-      {sortedQuotas.length > 0 && (
-        <div>
-          <SectionHeader title="Trade Quotas" count={sortedQuotas.length} />
-          <PagedList items={sortedQuotas}>
-            {(slice) => (
-              <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
-                <table className="w-full text-[11px] table-fixed">
-                  <tbody>
-                    {slice.map((q, i) => (
-                      <tr
-                        key={i}
-                        className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
-                      >
-                        <td
-                          title={q.country}
-                          className="px-3 py-1 text-zinc-700 dark:text-zinc-300 truncate w-[28%]"
-                        >
-                          {q.country}
-                        </td>
-                        <td className="px-3 py-1 text-right text-zinc-700 dark:text-zinc-300 tabular-nums whitespace-nowrap w-[16%]">
-                          {q.quota != null ? q.quota.toLocaleString() : "—"}
-                          {q.unit ? ` ${q.unit}` : ""}
-                        </td>
-                        <td
-                          title={q.notes || undefined}
-                          className="px-3 py-1 text-zinc-400 truncate"
-                        >
-                          {q.notes || "—"}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </PagedList>
-        </div>
-      )}
-
-      {/* Trade Suspensions */}
-      {sortedSuspensions.length > 0 && (
-        <div>
-          <SectionHeader title="Trade Suspensions" count={sortedSuspensions.length} />
-          <PagedList items={sortedSuspensions}>
-            {(slice) => (
-              <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
-                <table className="w-full text-[11px]">
-                  <tbody>
-                    {slice.map((s, i) => (
-                      <tr
-                        key={i}
-                        className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
-                      >
-                        <td className="px-3 py-1 text-zinc-700 dark:text-zinc-300">
-                          {s.country}
-                        </td>
-                        <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 capitalize whitespace-nowrap">
-                          {s.appliesTo}
-                        </td>
-                        <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 whitespace-nowrap tabular-nums">
-                          {new Date(s.startDate).toLocaleDateString("en-GB", {
-                            year: "numeric",
-                            month: "short",
-                          })}
-                        </td>
-                        <td className="px-3 py-1 text-right hidden md:table-cell">
-                          {s.notification?.url ? (
-                            <a
-                              href={s.notification.url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              title={s.notification.name}
-                              className="text-blue-600 dark:text-blue-400 hover:underline"
+      {/* Trade Quotas and Suspensions, side by side */}
+      {(sortedQuotas.length > 0 || sortedSuspensions.length > 0) && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+          {/* Trade Quotas */}
+          {sortedQuotas.length > 0 && (
+            <div>
+              <SectionHeader title="Trade Quotas" count={sortedQuotas.length} />
+              <PagedList items={sortedQuotas}>
+                {(slice) => (
+                  <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+                    <table className="w-full text-[11px] table-fixed">
+                      <tbody>
+                        {slice.map((q, i) => (
+                          <tr
+                            key={i}
+                            className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
+                          >
+                            <td
+                              title={q.country}
+                              className="px-3 py-1 text-zinc-700 dark:text-zinc-300 truncate w-[28%]"
                             >
-                              {s.notification.name}
-                            </a>
-                          ) : (
-                            <span className="text-zinc-400">{s.notification?.name || "—"}</span>
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </PagedList>
+                              {q.country}
+                            </td>
+                            <td className="px-3 py-1 text-right text-zinc-700 dark:text-zinc-300 tabular-nums whitespace-nowrap w-[16%]">
+                              {q.quota != null ? q.quota.toLocaleString() : "—"}
+                              {q.unit ? ` ${q.unit}` : ""}
+                            </td>
+                            <td
+                              title={q.notes || undefined}
+                              className="px-3 py-1 text-zinc-400 truncate"
+                            >
+                              {q.notes || "—"}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </PagedList>
+            </div>
+          )}
+
+          {/* Trade Suspensions */}
+          {sortedSuspensions.length > 0 && (
+            <div>
+              <SectionHeader title="Trade Suspensions" count={sortedSuspensions.length} />
+              <PagedList items={sortedSuspensions}>
+                {(slice) => (
+                  <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+                    <table className="w-full text-[11px]">
+                      <tbody>
+                        {slice.map((s, i) => (
+                          <tr
+                            key={i}
+                            className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
+                          >
+                            <td className="px-3 py-1 text-zinc-700 dark:text-zinc-300">
+                              {s.country}
+                            </td>
+                            <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 capitalize whitespace-nowrap">
+                              {s.appliesTo}
+                            </td>
+                            <td className="px-3 py-1 text-zinc-500 dark:text-zinc-400 whitespace-nowrap tabular-nums">
+                              {new Date(s.startDate).toLocaleDateString("en-GB", {
+                                year: "numeric",
+                                month: "short",
+                              })}
+                            </td>
+                            <td className="px-3 py-1 text-right hidden md:table-cell">
+                              {s.notification?.url ? (
+                                <a
+                                  href={s.notification.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  title={s.notification.name}
+                                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                                >
+                                  {s.notification.name}
+                                </a>
+                              ) : (
+                                <span className="text-zinc-400">{s.notification?.name || "—"}</span>
+                              )}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </PagedList>
+            </div>
+          )}
         </div>
       )}
 

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -318,12 +318,14 @@ function Pager({
   page,
   total,
   onPage,
+  pageSize = PAGE_SIZE,
 }: {
   page: number;
   total: number;
   onPage: (p: number) => void;
+  pageSize?: number;
 }) {
-  const totalPages = Math.ceil(total / PAGE_SIZE);
+  const totalPages = Math.ceil(total / pageSize);
   if (totalPages <= 1) return null;
   return (
     <div className="flex items-center justify-between mt-1 text-[10px] text-zinc-400 dark:text-zinc-500">
@@ -335,7 +337,7 @@ function Pager({
         Prev
       </button>
       <span className="tabular-nums">
-        {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, total)} of {total}
+        {page * pageSize + 1}–{Math.min((page + 1) * pageSize, total)} of {total}
       </span>
       <button
         onClick={() => onPage(Math.min(totalPages - 1, page + 1))}
@@ -787,6 +789,110 @@ function CountryTable({
 }
 
 /* ------------------------------------------------------------------ */
+/*  Individual shipment records table                                  */
+/* ------------------------------------------------------------------ */
+
+/** Rows shown per page in the individual-records table. */
+const RECORDS_PAGE_SIZE = 10;
+
+/**
+ * A paginated table of the individual shipment records behind the summary,
+ * reflecting every active filter. Sorted most-recent-first so the latest trade
+ * is on top. Quantities follow the CITES guide (exporter-reported preferred);
+ * a re-export origin, when present, is shown ahead of the exporter.
+ */
+function RecordsTable({ rows }: { rows: CompactRecord[] }) {
+  const [page, setPage] = useState(0);
+  if (rows.length === 0) return null;
+  const totalPages = Math.max(1, Math.ceil(rows.length / RECORDS_PAGE_SIZE));
+  const safePage = Math.min(page, totalPages - 1);
+  const pageRows = rows.slice(
+    safePage * RECORDS_PAGE_SIZE,
+    safePage * RECORDS_PAGE_SIZE + RECORDS_PAGE_SIZE
+  );
+
+  return (
+    <div className="min-w-0">
+      <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
+        Records{" "}
+        <span className="text-zinc-400 dark:text-zinc-500 normal-case tabular-nums">
+          ({rows.length.toLocaleString()})
+        </span>
+      </h5>
+      <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-x-auto">
+        <table className="w-full text-[11px] whitespace-nowrap">
+          <thead>
+            <tr className="text-left text-zinc-400 dark:text-zinc-500 border-b border-zinc-100 dark:border-zinc-800">
+              <th className="px-2.5 py-1 font-medium">Year</th>
+              <th className="px-2.5 py-1 font-medium">Commodity</th>
+              <th className="px-2.5 py-1 font-medium text-right">Qty</th>
+              <th className="px-2.5 py-1 font-medium">Exporter &rarr; Importer</th>
+              <th className="px-2.5 py-1 font-medium">Source</th>
+              <th className="px-2.5 py-1 font-medium">Purpose</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pageRows.map((r, i) => (
+              <tr
+                key={i}
+                className="border-t first:border-t-0 border-zinc-100 dark:border-zinc-800"
+              >
+                <td className="px-2.5 py-1 tabular-nums text-zinc-600 dark:text-zinc-300">
+                  {r.y}
+                </td>
+                <td className="px-2.5 py-1 text-zinc-700 dark:text-zinc-300 capitalize">
+                  {r.t}
+                  {r.u && (
+                    <span className="text-zinc-400 dark:text-zinc-500 ml-1 normal-case">
+                      {r.u}
+                    </span>
+                  )}
+                </td>
+                <td className="px-2.5 py-1 text-right tabular-nums text-zinc-600 dark:text-zinc-300">
+                  {r.q > 0 ? fmtQty(r.q) : "—"}
+                </td>
+                <td className="px-2.5 py-1 text-zinc-700 dark:text-zinc-300">
+                  {r.o && (
+                    <span
+                      className="text-amber-600 dark:text-amber-400"
+                      title={`Origin ${countryName(r.o)}`}
+                    >
+                      {countryName(r.o)}{" "}
+                      <span className="text-zinc-400 dark:text-zinc-500">&rarr;</span>{" "}
+                    </span>
+                  )}
+                  {r.e ? countryName(r.e) : "—"}{" "}
+                  <span className="text-zinc-400 dark:text-zinc-500">&rarr;</span>{" "}
+                  {r.i ? countryName(r.i) : "—"}
+                </td>
+                <td
+                  className="px-2.5 py-1 text-zinc-500 dark:text-zinc-400"
+                  title={r.s ? `${SOURCE_LABELS[r.s] || r.s} (${r.s})` : undefined}
+                >
+                  {r.s ? SOURCE_LABELS[r.s] || r.s : "—"}
+                </td>
+                <td
+                  className="px-2.5 py-1 text-zinc-500 dark:text-zinc-400"
+                  title={r.p ? `${PURPOSE_LABELS[r.p] || r.p} (${r.p})` : undefined}
+                >
+                  {r.p ? PURPOSE_LABELS[r.p] || r.p : "—"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <Pager
+        page={safePage}
+        total={rows.length}
+        onPage={setPage}
+        pageSize={RECORDS_PAGE_SIZE}
+      />
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /*  Main component                                                     */
 /* ------------------------------------------------------------------ */
 
@@ -984,13 +1090,18 @@ export default function CitesTradeSummary({
   // Chart series (all years, checkbox-filtered)
   const chartAgg = useMemo(() => aggregateShipments(checkboxRows), [checkboxRows]);
 
-  // Everything else also respects the year-range trim
-  const display = useMemo(() => {
+  // The individual records behind the summary: every active filter applied
+  // (checkboxes, country, and the year-range trim), sorted most-recent-first
+  // (largest quantity breaks ties) so the records table leads with recent trade.
+  const displayRows = useMemo(() => {
     const rows = brush
       ? checkboxRows.filter((r) => r.y >= brush[0] && r.y <= brush[1])
       : checkboxRows;
-    return aggregateShipments(rows);
+    return [...rows].sort((a, b) => b.y - a.y || b.q - a.q);
   }, [checkboxRows, brush]);
+
+  // Everything else also respects the year-range trim
+  const display = useMemo(() => aggregateShipments(displayRows), [displayRows]);
 
   // Cross-filter views: each interactive chart aggregates rows passing every
   // active filter EXCEPT its own dimension, so its categories stay visible and
@@ -1316,6 +1427,10 @@ export default function CitesTradeSummary({
           />
         </div>
       )}
+
+      {/* The individual shipment records behind everything above, paginated and
+          reflecting all active filters. */}
+      {hasShipments && <RecordsTable rows={displayRows} />}
     </div>
   );
 }

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -257,9 +257,12 @@ function aggregateShipments(rows: CompactRecord[]): Aggregated {
     .sort(([, a], [, b]) => b.records - a.records)
     .map(([code, v]) => ({ code, ...v }));
 
+  // Full sorted flow lists (not capped here): the map applies a user-controlled
+  // cap on how many of the top flows to draw via its "Flows shown" control, so
+  // we hand it everything and let it slice. Flows stay sorted by record count so
+  // slicing the top N keeps the largest.
   const topFlows = Array.from(flowMap.entries())
     .sort(([, a], [, b]) => b.records - a.records)
-    .slice(0, 12)
     .map(([key, v]) => {
       const [from, to] = key.split("->");
       return { from, to, ...v };
@@ -267,7 +270,6 @@ function aggregateShipments(rows: CompactRecord[]): Aggregated {
 
   const reExportFlows = Array.from(reExportMap.entries())
     .sort(([, a], [, b]) => b.records - a.records)
-    .slice(0, 12)
     .map(([key, v]) => {
       const [from, to] = key.split("->");
       return { from, to, ...v };

--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -740,43 +740,60 @@ function CountryTable({
   label,
   selected,
   onSelect,
+  barClass,
 }: {
   data: CountryData[];
   label: string;
   selected?: string | null;
   onSelect?: (code: string | null) => void;
+  /** Tailwind classes for the (unselected) bar fill. */
+  barClass: string;
 }) {
   const [page, setPage] = useState(0);
   if (data.length === 0) return null;
   const sorted = [...data].sort((a, b) => b.records - a.records);
+  // Scale bars against the global max so widths stay comparable across pages.
+  const max = sorted.reduce((m, c) => Math.max(m, c.records), 0);
   const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
   const safePage = Math.min(page, totalPages - 1);
   const pageRows = sorted.slice(safePage * PAGE_SIZE, safePage * PAGE_SIZE + PAGE_SIZE);
 
   return (
     <div className="min-w-0">
-      <h5 className="text-[10px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-0.5">
+      <h5 className="text-[10px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1">
         {label}
       </h5>
-      <div>
+      <div className="space-y-1">
         {pageRows.map((c) => {
           const isSel = selected === c.code;
+          const pct = max > 0 ? (c.records / max) * 100 : 0;
           return (
             <div
               key={c.code}
               onClick={onSelect ? () => onSelect(isSel ? null : c.code) : undefined}
               title={`${countryName(c.code)} — ${c.records.toLocaleString()} records`}
-              className={`flex items-baseline justify-between gap-1.5 text-[11px] py-px px-1 -mx-1 rounded ${
-                onSelect ? "cursor-pointer hover:bg-zinc-100 dark:hover:bg-zinc-800/60" : ""
-              } ${isSel ? "bg-amber-100 dark:bg-amber-900/40" : ""}`}
+              className={`flex items-center gap-1.5 text-[11px] select-none ${
+                onSelect ? "cursor-pointer" : ""
+              }`}
             >
-              <span className="truncate text-zinc-700 dark:text-zinc-300">
+              <span
+                className={`w-16 shrink-0 truncate ${
+                  isSel
+                    ? "text-amber-600 dark:text-amber-400 font-medium"
+                    : "text-zinc-700 dark:text-zinc-300"
+                }`}
+              >
                 {countryName(c.code)}
-                <span className="text-zinc-400 dark:text-zinc-500 ml-1">
-                  ({c.code})
-                </span>
               </span>
-              <span className="text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">
+              <div className="flex-1 h-3 bg-zinc-100 dark:bg-zinc-800 rounded overflow-hidden">
+                <div
+                  className={`h-full rounded ${
+                    isSel ? "bg-amber-400 dark:bg-amber-500" : barClass
+                  }`}
+                  style={{ width: `${Math.max(pct, 1)}%` }}
+                />
+              </div>
+              <span className="w-9 text-right text-zinc-500 dark:text-zinc-400 tabular-nums shrink-0">
                 {c.records.toLocaleString()}
               </span>
             </div>
@@ -793,7 +810,7 @@ function CountryTable({
 /* ------------------------------------------------------------------ */
 
 /** Rows shown per page in the individual-records table. */
-const RECORDS_PAGE_SIZE = 10;
+const RECORDS_PAGE_SIZE = 5;
 
 /**
  * A paginated table of the individual shipment records behind the summary,
@@ -853,10 +870,7 @@ function RecordsTable({ rows }: { rows: CompactRecord[] }) {
                 </td>
                 <td className="px-2.5 py-1 text-zinc-700 dark:text-zinc-300">
                   {r.o && (
-                    <span
-                      className="text-amber-600 dark:text-amber-400"
-                      title={`Origin ${countryName(r.o)}`}
-                    >
+                    <span title={`Origin ${countryName(r.o)}`}>
                       {countryName(r.o)}{" "}
                       <span className="text-zinc-400 dark:text-zinc-500">&rarr;</span>{" "}
                     </span>
@@ -1341,8 +1355,8 @@ export default function CitesTradeSummary({
       {/* Trade flow map (with the record count overlaid), and Top exporters /
           importers + the trade-over-time chart in the side column. */}
       {displayFlows.length > 0 ? (
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
-          <div className="lg:col-span-2 relative border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden bg-zinc-50 dark:bg-zinc-800/30">
+        <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
+          <div className="lg:col-span-3 relative border border-zinc-200 dark:border-zinc-700 rounded-lg overflow-hidden bg-zinc-50 dark:bg-zinc-800/30">
             <div className="absolute top-2 left-3 z-10 bg-zinc-50/70 dark:bg-zinc-900/40 backdrop-blur-sm rounded-md px-2 py-1">
               {headline}
             </div>
@@ -1359,19 +1373,21 @@ export default function CitesTradeSummary({
           </div>
           {/* Side column stretches to the map's height; the trade-over-time
               chart is pushed to the bottom so it lines up with the map base. */}
-          <div className="flex flex-col gap-3">
+          <div className="lg:col-span-2 flex flex-col gap-3">
             <div className="grid grid-cols-2 gap-3">
               <CountryTable
                 data={tableExporters}
                 label="Top exporters"
                 selected={selectedCountry}
                 onSelect={setSelectedCountry}
+                barClass="bg-red-400 dark:bg-red-500"
               />
               <CountryTable
                 data={tableImporters}
                 label="Top importers"
                 selected={selectedCountry}
                 onSelect={setSelectedCountry}
+                barClass="bg-blue-400 dark:bg-blue-500"
               />
             </div>
             <div className="mt-auto">{tradeOverTimeChart}</div>
@@ -1386,12 +1402,14 @@ export default function CitesTradeSummary({
               label="Top exporters"
               selected={selectedCountry}
               onSelect={setSelectedCountry}
+              barClass="bg-red-400 dark:bg-red-500"
             />
             <CountryTable
               data={tableImporters}
               label="Top importers"
               selected={selectedCountry}
               onSelect={setSelectedCountry}
+              barClass="bg-blue-400 dark:bg-blue-500"
             />
           </div>
           {tradeOverTimeChart}

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -225,9 +225,9 @@ function TradeFlowMap({
     selectedCountryProp !== undefined ? selectedCountryProp : internalSelected;
   const setSelectedCountry = onSelectCountry ?? setInternalSelected;
   const [showReExports, setShowReExports] = useState(false);
-  // How many of the top bilateral flows to draw. The default of 12 preserves the
-  // previous hard-coded cap; the top-right slider lets users widen it or show all.
-  const [flowLimit, setFlowLimit] = useState(12);
+  // How many of the top bilateral flows to draw. The default of 10 keeps the
+  // map legible; the top-right slider lets users widen it or show all.
+  const [flowLimit, setFlowLimit] = useState(10);
 
   /* ---- Pan / zoom -------------------------------------------------- */
   // A single transform applied to all map content (geographies + arcs +
@@ -682,10 +682,10 @@ function TradeFlowMap({
 
           const ratio = maxRecords > 0 ? flow.records / maxRecords : 0;
           const strokeWidth = 1.5 + ratio * 2.5;
-          // Opacity also scales with volume, so the busiest corridors read
-          // strongest while small flows stay faint. The floor keeps the
-          // smallest flow visible rather than fully transparent.
-          const baseOpacity = (dark ? 0.4 : 0.3) + ratio * (dark ? 0.5 : 0.45);
+          // Opacity also nudges up with volume, so the busiest corridors read a
+          // touch stronger — kept subtle so it reinforces the stroke-width cue
+          // rather than washing the smaller flows out.
+          const baseOpacity = (dark ? 0.6 : 0.4) + ratio * 0.25;
           const isHovered = hoveredFlow === i;
 
           // Arrowhead at destination

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -495,38 +495,16 @@ function TradeFlowMap({
         </div>
       )}
 
-      {/* Top-right controls: a slider for how many flows to draw, with the
-          selected-country filter chip stacked beneath it. */}
-      <div className="absolute top-2 right-2 z-10 flex flex-col items-end gap-1.5">
-        {totalFlows > 1 && (
-          <div className="flex items-center gap-1.5 bg-zinc-50/80 dark:bg-zinc-900/60 backdrop-blur-sm rounded px-1.5 py-0.5 shadow-sm">
-            <span className="text-[9px] text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
-              Flows{" "}
-              <span className="tabular-nums font-medium text-zinc-700 dark:text-zinc-200">
-                {showingAll ? `all ${totalFlows}` : shownFlows}
-              </span>
-            </span>
-            <input
-              type="range"
-              min={1}
-              max={totalFlows}
-              value={shownFlows}
-              onChange={(e) => setFlowLimit(Number(e.target.value))}
-              aria-label="Number of trade flows to show"
-              className="w-12 h-0.5 cursor-pointer accent-red-500"
-            />
-          </div>
-        )}
-        {selectedCountry && (
-          <button
-            className="bg-zinc-800 dark:bg-zinc-700 text-white text-[11px] px-2.5 py-1 rounded-full flex items-center gap-1.5 hover:bg-zinc-700 dark:hover:bg-zinc-600 transition-colors"
-            onClick={() => setSelectedCountry(null)}
-          >
-            {countryName(selectedCountry)}
-            <span className="text-zinc-400">&times;</span>
-          </button>
-        )}
-      </div>
+      {/* Selected country filter chip */}
+      {selectedCountry && (
+        <button
+          className="absolute top-2 right-2 z-10 bg-zinc-800 dark:bg-zinc-700 text-white text-[11px] px-2.5 py-1 rounded-full flex items-center gap-1.5 hover:bg-zinc-700 dark:hover:bg-zinc-600 transition-colors"
+          onClick={() => setSelectedCountry(null)}
+        >
+          {countryName(selectedCountry)}
+          <span className="text-zinc-400">&times;</span>
+        </button>
+      )}
 
       <div
         ref={wrapRef}
@@ -837,7 +815,26 @@ function TradeFlowMap({
             </label>
           </>
         )}
-        <span className="text-zinc-400 dark:text-zinc-500 italic">click dot to filter</span>
+        {totalFlows > 1 && (
+          <label className="flex items-center gap-1.5 select-none">
+            <span className="whitespace-nowrap">
+              Flows{" "}
+              <span className="tabular-nums font-medium text-zinc-600 dark:text-zinc-300">
+                {showingAll ? `all ${totalFlows}` : shownFlows}
+              </span>
+            </span>
+            <input
+              type="range"
+              min={1}
+              max={totalFlows}
+              value={shownFlows}
+              onChange={(e) => setFlowLimit(Number(e.target.value))}
+              aria-label="Number of trade flows to show"
+              className="slider-xs w-16 cursor-pointer"
+            />
+          </label>
+        )}
+        <span className="text-zinc-400 dark:text-zinc-500 italic">click to filter</span>
       </div>
     </div>
   );

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -499,8 +499,8 @@ function TradeFlowMap({
           selected-country filter chip stacked beneath it. */}
       <div className="absolute top-2 right-2 z-10 flex flex-col items-end gap-1.5">
         {totalFlows > 1 && (
-          <div className="flex items-center gap-2 bg-zinc-50/80 dark:bg-zinc-900/60 backdrop-blur-sm rounded-md px-2 py-1 shadow-sm">
-            <span className="text-[10px] text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
+          <div className="flex items-center gap-1.5 bg-zinc-50/80 dark:bg-zinc-900/60 backdrop-blur-sm rounded px-1.5 py-0.5 shadow-sm">
+            <span className="text-[9px] text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
               Flows{" "}
               <span className="tabular-nums font-medium text-zinc-700 dark:text-zinc-200">
                 {showingAll ? `all ${totalFlows}` : shownFlows}
@@ -513,7 +513,7 @@ function TradeFlowMap({
               value={shownFlows}
               onChange={(e) => setFlowLimit(Number(e.target.value))}
               aria-label="Number of trade flows to show"
-              className="w-24 h-1 cursor-pointer accent-red-500"
+              className="w-12 h-0.5 cursor-pointer accent-red-500"
             />
           </div>
         )}

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -225,6 +225,9 @@ function TradeFlowMap({
     selectedCountryProp !== undefined ? selectedCountryProp : internalSelected;
   const setSelectedCountry = onSelectCountry ?? setInternalSelected;
   const [showReExports, setShowReExports] = useState(false);
+  // How many of the top bilateral flows to draw. The default of 12 preserves the
+  // previous hard-coded cap; the legend control lets users widen it or show all.
+  const [flowLimit, setFlowLimit] = useState<number | "all">(12);
 
   /* ---- Pan / zoom -------------------------------------------------- */
   // A single transform applied to all map content (geographies + arcs +
@@ -319,13 +322,26 @@ function TradeFlowMap({
 
   const dark = resolvedTheme === "dark";
 
-  // Filter flows to selected country (if any)
-  const visibleFlows = selectedCountry
+  // Filter flows to selected country (if any) — these are the candidates the
+  // "Flows shown" control then caps.
+  const countryFlows = selectedCountry
     ? renderableFlows.filter((f) => f.from === selectedCountry || f.to === selectedCountry)
     : renderableFlows;
 
-  // Re-export legs to show: only when toggled on, respecting any country filter
-  const visibleReExports =
+  // Resolve the cap against what's actually available: a numeric limit that's
+  // already >= the number of flows is equivalent to "all", so we normalise it so
+  // the legend select stays in sync with what's drawn.
+  const totalFlows = countryFlows.length;
+  const effectiveLimit: number | "all" =
+    flowLimit !== "all" && flowLimit < totalFlows ? flowLimit : "all";
+
+  // Flows are pre-sorted by record count, so slicing keeps the largest.
+  const visibleFlows =
+    effectiveLimit === "all" ? countryFlows : countryFlows.slice(0, effectiveLimit);
+
+  // Re-export legs to show: only when toggled on, respecting any country filter,
+  // and capped by the same flow limit so the overlay stays bounded.
+  const countryReExports =
     showReExports && renderableReExports.length > 0
       ? selectedCountry
         ? renderableReExports.filter(
@@ -333,6 +349,10 @@ function TradeFlowMap({
           )
         : renderableReExports
       : [];
+  const visibleReExports =
+    effectiveLimit === "all"
+      ? countryReExports
+      : countryReExports.slice(0, effectiveLimit);
 
   // Per-country export vs import volume, used to colour each country by its
   // DOMINANT role. Earlier this was derived purely from whether a country
@@ -792,6 +812,29 @@ function TradeFlowMap({
               Re-exports (Origin &rarr; Exporter)
             </label>
           </>
+        )}
+        {[6, 12, 25, 50].some((n) => n < totalFlows) && (
+          <label className="flex items-center gap-1 select-none">
+            <span>Flows shown</span>
+            <select
+              value={effectiveLimit === "all" ? "all" : String(effectiveLimit)}
+              onChange={(e) =>
+                setFlowLimit(
+                  e.target.value === "all" ? "all" : Number(e.target.value)
+                )
+              }
+              className="rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-600 dark:text-zinc-300 px-1 py-0.5 text-[10px]"
+            >
+              {[6, 12, 25, 50]
+                .filter((n) => n < totalFlows)
+                .map((n) => (
+                  <option key={n} value={n}>
+                    Top {n}
+                  </option>
+                ))}
+              <option value="all">All ({totalFlows})</option>
+            </select>
+          </label>
         )}
         <span className="text-zinc-400 dark:text-zinc-500 italic">click dot to filter</span>
       </div>

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -74,13 +74,16 @@ const COUNTRY_CENTROIDS: Record<string, [number, number]> = {
   PS: [35.2, 32.0], XK: [21.0, 42.6], MK: [21.7, 41.5],
 };
 
-const MAP_WIDTH = 800;
-// Cropped a little shorter than the projection's natural height to trim some of
-// the empty ocean below the southern continents, while keeping New Zealand and
-// the southern tip of South America in frame. The extra y-offset keeps the land
-// in place while the viewBox cuts the bottom rather than re-centring the map.
+// The natural-earth world is slightly wider than the viewBox at this scale, so
+// the far east (NZ / the dateline) would otherwise sit just past the right edge
+// while a broad band of empty eastern Pacific padded the left (west of the
+// Americas). The negative x-offset pans the content left: it trims that western
+// ocean down to a thin margin AND pulls New Zealand / Fiji fully back into
+// frame. The y-offset + shortened height crop empty ocean below the southern
+// continents while keeping the southern tip of South America in view.
+const MAP_WIDTH = 760;
 const MAP_HEIGHT = 372;
-const MAP_OFFSET: [number, number] = [30, 34];
+const MAP_OFFSET: [number, number] = [-70, 34];
 
 // Build projection that matches the ComposableMap settings
 const projection = geoNaturalEarth1()

--- a/app/src/components/TradeFlowMap.tsx
+++ b/app/src/components/TradeFlowMap.tsx
@@ -226,8 +226,8 @@ function TradeFlowMap({
   const setSelectedCountry = onSelectCountry ?? setInternalSelected;
   const [showReExports, setShowReExports] = useState(false);
   // How many of the top bilateral flows to draw. The default of 12 preserves the
-  // previous hard-coded cap; the legend control lets users widen it or show all.
-  const [flowLimit, setFlowLimit] = useState<number | "all">(12);
+  // previous hard-coded cap; the top-right slider lets users widen it or show all.
+  const [flowLimit, setFlowLimit] = useState(12);
 
   /* ---- Pan / zoom -------------------------------------------------- */
   // A single transform applied to all map content (geographies + arcs +
@@ -328,16 +328,15 @@ function TradeFlowMap({
     ? renderableFlows.filter((f) => f.from === selectedCountry || f.to === selectedCountry)
     : renderableFlows;
 
-  // Resolve the cap against what's actually available: a numeric limit that's
-  // already >= the number of flows is equivalent to "all", so we normalise it so
-  // the legend select stays in sync with what's drawn.
+  // The slider runs 1..totalFlows; clamp so a value left over from a larger set
+  // (e.g. before a country filter shrank it) still resolves sensibly, and detect
+  // when we're effectively showing everything.
   const totalFlows = countryFlows.length;
-  const effectiveLimit: number | "all" =
-    flowLimit !== "all" && flowLimit < totalFlows ? flowLimit : "all";
+  const shownFlows = Math.min(flowLimit, totalFlows);
+  const showingAll = shownFlows >= totalFlows;
 
   // Flows are pre-sorted by record count, so slicing keeps the largest.
-  const visibleFlows =
-    effectiveLimit === "all" ? countryFlows : countryFlows.slice(0, effectiveLimit);
+  const visibleFlows = countryFlows.slice(0, shownFlows);
 
   // Re-export legs to show: only when toggled on, respecting any country filter,
   // and capped by the same flow limit so the overlay stays bounded.
@@ -349,10 +348,9 @@ function TradeFlowMap({
           )
         : renderableReExports
       : [];
-  const visibleReExports =
-    effectiveLimit === "all"
-      ? countryReExports
-      : countryReExports.slice(0, effectiveLimit);
+  const visibleReExports = showingAll
+    ? countryReExports
+    : countryReExports.slice(0, shownFlows);
 
   // Per-country export vs import volume, used to colour each country by its
   // DOMINANT role. Earlier this was derived purely from whether a country
@@ -497,16 +495,38 @@ function TradeFlowMap({
         </div>
       )}
 
-      {/* Selected country filter chip */}
-      {selectedCountry && (
-        <button
-          className="absolute top-2 right-2 z-10 bg-zinc-800 dark:bg-zinc-700 text-white text-[11px] px-2.5 py-1 rounded-full flex items-center gap-1.5 hover:bg-zinc-700 dark:hover:bg-zinc-600 transition-colors"
-          onClick={() => setSelectedCountry(null)}
-        >
-          {countryName(selectedCountry)}
-          <span className="text-zinc-400">&times;</span>
-        </button>
-      )}
+      {/* Top-right controls: a slider for how many flows to draw, with the
+          selected-country filter chip stacked beneath it. */}
+      <div className="absolute top-2 right-2 z-10 flex flex-col items-end gap-1.5">
+        {totalFlows > 1 && (
+          <div className="flex items-center gap-2 bg-zinc-50/80 dark:bg-zinc-900/60 backdrop-blur-sm rounded-md px-2 py-1 shadow-sm">
+            <span className="text-[10px] text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
+              Flows{" "}
+              <span className="tabular-nums font-medium text-zinc-700 dark:text-zinc-200">
+                {showingAll ? `all ${totalFlows}` : shownFlows}
+              </span>
+            </span>
+            <input
+              type="range"
+              min={1}
+              max={totalFlows}
+              value={shownFlows}
+              onChange={(e) => setFlowLimit(Number(e.target.value))}
+              aria-label="Number of trade flows to show"
+              className="w-24 h-1 cursor-pointer accent-red-500"
+            />
+          </div>
+        )}
+        {selectedCountry && (
+          <button
+            className="bg-zinc-800 dark:bg-zinc-700 text-white text-[11px] px-2.5 py-1 rounded-full flex items-center gap-1.5 hover:bg-zinc-700 dark:hover:bg-zinc-600 transition-colors"
+            onClick={() => setSelectedCountry(null)}
+          >
+            {countryName(selectedCountry)}
+            <span className="text-zinc-400">&times;</span>
+          </button>
+        )}
+      </div>
 
       <div
         ref={wrapRef}
@@ -662,6 +682,10 @@ function TradeFlowMap({
 
           const ratio = maxRecords > 0 ? flow.records / maxRecords : 0;
           const strokeWidth = 1.5 + ratio * 2.5;
+          // Opacity also scales with volume, so the busiest corridors read
+          // strongest while small flows stay faint. The floor keeps the
+          // smallest flow visible rather than fully transparent.
+          const baseOpacity = (dark ? 0.4 : 0.3) + ratio * (dark ? 0.5 : 0.45);
           const isHovered = hoveredFlow === i;
 
           // Arrowhead at destination
@@ -676,7 +700,7 @@ function TradeFlowMap({
                 stroke={isHovered ? colors.arcHover : colors.arcDefault}
                 strokeWidth={isHovered ? strokeWidth + 1 : strokeWidth}
                 strokeLinecap="round"
-                strokeOpacity={isHovered ? 0.95 : dark ? 0.7 : 0.45}
+                strokeOpacity={isHovered ? 0.95 : baseOpacity}
                 onMouseEnter={() => setHoveredFlow(i)}
                 onMouseLeave={() => setHoveredFlow(null)}
                 style={{ cursor: "pointer" }}
@@ -686,7 +710,7 @@ function TradeFlowMap({
                 <polygon
                   points="-5,-3 0,0 -5,3"
                   fill={isHovered ? colors.arcHover : colors.arcDefault}
-                  fillOpacity={isHovered ? 0.95 : dark ? 0.85 : 0.7}
+                  fillOpacity={isHovered ? 0.95 : Math.min(0.95, baseOpacity + 0.15)}
                   transform={`translate(${dest[0]},${dest[1]}) rotate(${angle})`}
                 />
               )}
@@ -812,29 +836,6 @@ function TradeFlowMap({
               Re-exports (Origin &rarr; Exporter)
             </label>
           </>
-        )}
-        {[6, 12, 25, 50].some((n) => n < totalFlows) && (
-          <label className="flex items-center gap-1 select-none">
-            <span>Flows shown</span>
-            <select
-              value={effectiveLimit === "all" ? "all" : String(effectiveLimit)}
-              onChange={(e) =>
-                setFlowLimit(
-                  e.target.value === "all" ? "all" : Number(e.target.value)
-                )
-              }
-              className="rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-600 dark:text-zinc-300 px-1 py-0.5 text-[10px]"
-            >
-              {[6, 12, 25, 50]
-                .filter((n) => n < totalFlows)
-                .map((n) => (
-                  <option key={n} value={n}>
-                    Top {n}
-                  </option>
-                ))}
-              <option value="all">All ({totalFlows})</option>
-            </select>
-          </label>
         )}
         <span className="text-zinc-400 dark:text-zinc-500 italic">click dot to filter</span>
       </div>


### PR DESCRIPTION
## Summary

A set of improvements to the CITES trade section of the species dashboard — the trade-flow map, the data behind it, and the surrounding layout.

## Changes

### Trade flow map
- **Flow-count slider** — replaced the previous hard-coded cap of 12 bilateral flows with a small slider in the map legend (next to the re-exports toggle). Users choose how many of the top flows to draw (1 … all); default is **10**.
  - `aggregateShipments` now returns the full sorted flow lists; the map applies the user-selected cap at render time (after country/centroid filtering, so you reliably see N drawn flows). The same limit bounds the re-export overlay.
  - The slider uses a custom `.slider-xs` style — a thin track and a tiny thumb — so it reads as an unobtrusive inline control.
- **Volume-scaled flows** — arc thickness was already proportional to record count; arc **opacity** now also nudges up subtly with volume so the busiest corridors read strongest without washing out smaller flows.
- **Cropped western dead space** — panned the projection left (`MAP_WIDTH 800→760`, `MAP_OFFSET x 30→-70`) to trim the empty eastern-Pacific band west of the Americas (~150px → ~30px), which also pulls New Zealand / Fiji fully into frame. Framing verified via d3-geo projection maths.
- Legend hint reworded "click dot to filter" → "click to filter"; the selected-country chip stays top-right.

### Top exporters / importers
- Turned the two country lists into **horizontal bar charts** (red for exporters, blue for importers; the selected country highlighted amber), keeping click-to-filter and pagination.

### Quotas & suspensions
- The **Trade Quotas** and **Trade Suspensions** sections now sit **side by side** in a responsive two-column grid instead of stacking.

### Individual records table
- Added a paginated **"Records"** table beneath the filter charts, showing the actual CITES shipment records behind the summary.
  - **5 per page** with Prev/Next (the shared `Pager` now takes a configurable page size).
  - Reflects every active filter — source/purpose/commodity checkboxes, selected country, and the year-range trim.
  - Sorted most-recent-first (largest quantity breaks ties).
  - Columns: year, commodity (term + unit), quantity, exporter → importer (re-export origin shown when present), source, purpose. Country codes render as full names; source/purpose show full labels with the code in the tooltip.

### Layout
- Gave the trade-over-time chart (and the country bar charts) more room: the map / side-column grid is now **3:2** (was 2:1).

## Notes
- The API route's fallback flow cap was left as-is, since the client always recomputes flows from the per-shipment `shipments` payload (the path the map actually uses).
- The records table paginates client-side from data already in memory (no extra fetching); only a page of rows is mounted at a time.
- The map crop was tuned analytically from projected coordinates rather than a live screenshot (rendering needs the external TopoJSON CDN); the numbers check out but the offset is a trivial tweak if anything looks off.

All changed files typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)