### PR TITLE
Emit a verifiable, consistent dashboard URL from the MCP/browse data surface

### DIFF
--- a/app/src/app/api/mcp/route.ts
+++ b/app/src/app/api/mcp/route.ts
@@ -15,9 +15,11 @@
  * would guard nothing it doesn't, while blocking claude.ai web connectors (which speak
  * OAuth, not static bearers). If abuse becomes a concern, rate-limit instead.
  */
+import { AsyncLocalStorage } from "node:async_hooks";
 import { createMcpHandler } from "mcp-handler";
 import { z } from "zod";
 import { runBrowseQuery, type BrowseInput } from "@/lib/browse-query";
+import { browseInputToDashboardUrl } from "@/lib/dashboard-url";
 import {
   FEATURED_TAXA, THREAT_CATEGORIES, ALL_CATEGORIES,
   taxonLabel, categoryLabel, SYSTEMS, POPULATION_TRENDS,
@@ -27,6 +29,22 @@ import { IUCN_REGION_ORDER } from "@/lib/regions";
 export const maxDuration = 60;
 
 const asText = (data: unknown) => ({ content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] });
+
+// Per-request origin (e.g. https://host), captured from the incoming request so
+// the dashboard links we emit point at THIS deployment — same approach as the
+// /browse and /llms.txt routes.
+const originStore = new AsyncLocalStorage<string>();
+const getOrigin = () => originStore.getStore() ?? "";
+
+// Standing instruction attached to every queryable result: the deterministic
+// dashboard link plus a nudge to surface it and have the user verify. We compute
+// it server-side (not via tool-prompt) so it can't be skipped by the agent.
+const VERIFY_NOTE =
+  "Always show `dashboard_url` to the user and encourage them to open it to inspect and verify the data themselves. It is the interactive dashboard pre-filtered to this exact query, so it reproduces the same species set you see here.";
+
+// Wrap a queryable result with the dashboard link + verify nudge for `input`.
+const withDashboard = (input: BrowseInput, data: object) =>
+  asText({ ...data, dashboard_url: browseInputToDashboardUrl(getOrigin(), input), verify_note: VERIFY_NOTE });
 
 // Shared optional-filter schema for browse_taxon.
 const FILTERS = {
@@ -58,7 +76,7 @@ const handler = createMcpHandler(
       async (args) => {
         const { taxa, region, ...rest } = args as { taxa: string; region?: string } & Record<string, unknown>;
         const input: BrowseInput = { ...(rest as BrowseInput), taxa: [taxa], region: region ? [region] : [] };
-        return asText(await runBrowseQuery(input));
+        return withDashboard(input, await runBrowseQuery(input));
       },
     );
 
@@ -71,7 +89,7 @@ const handler = createMcpHandler(
       },
       async (args) => {
         const { name } = args as { name: string };
-        return asText(await runBrowseQuery({ search: name }));
+        return withDashboard({ search: name }, await runBrowseQuery({ search: name }));
       },
     );
 
@@ -98,4 +116,16 @@ const handler = createMcpHandler(
   { basePath: "/api" },
 );
 
-export { handler as GET, handler as POST, handler as DELETE };
+// Run the MCP handler inside the origin context so tool callbacks can build
+// absolute dashboard links from this request's host.
+const withOrigin = (h: (req: Request) => Promise<Response> | Response) => (req: Request) => {
+  let origin = "";
+  try { origin = new URL(req.url).origin; } catch { /* leave empty → relative link */ }
+  return originStore.run(origin, () => h(req));
+};
+
+const GET = withOrigin(handler);
+const POST = withOrigin(handler);
+const DELETE = withOrigin(handler);
+
+export { GET, POST, DELETE };

--- a/app/src/app/browse/route.ts
+++ b/app/src/app/browse/route.ts
@@ -10,6 +10,7 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { runBrowseQuery, type BrowseInput, type BrowseResult, type BrowseSpecies } from "@/lib/browse-query";
+import { browseInputToDashboardUrl } from "@/lib/dashboard-url";
 import { CATEGORY_ORDER } from "@/config/taxa";
 import { CACHE_1H } from "@/lib/cache-headers";
 import {
@@ -110,6 +111,9 @@ export async function GET(req: NextRequest) {
         breakdown: result.breakdown,
         stats: result.stats,
         species: result.species,
+        // The interactive dashboard, pre-filtered to this same query — share it so
+        // a human can inspect and verify these results for themselves.
+        dashboard_url: browseInputToDashboardUrl(req.nextUrl.origin, input),
       },
       { headers: { ...CACHE_1H, ...NOINDEX } },
     );

--- a/app/src/app/llms.txt/route.ts
+++ b/app/src/app/llms.txt/route.ts
@@ -51,6 +51,9 @@ including synonyms / old names (they resolve to the accepted species).
 - Results cap at 200 rows; the total + a by-category breakdown are always shown.
 - Every response has a "stats" object (assessed / outdated / outdated_pct, the %
   of assessments older than 10 years) — use it for percentage questions directly.
+- Every response includes a "dashboard_url" — the interactive dashboard pre-filtered
+  to this same query. Show it to the user and encourage them to open it to inspect
+  and verify the data themselves.
 
 ## Parameters (values may be codes OR plain-English names)
 

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -333,6 +333,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     selectedAssessors, setSelectedAssessors,
     selectedReviewers, setSelectedReviewers,
     searchFilter, setSearchFilter,
+    exactFilters, setExactFilters,
     sortField, sortDirection, setSort,
     clearAllFilters,
     setViewMode: setUrlViewMode,
@@ -671,8 +672,41 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
         Array.from(selectedSubgroups).some(sg => speciesMatchesNode(s, sg))
       );
     }
+    // Exact URL-only base filters (outdated / obs / assessment-year / described-year
+    // bounds). Applied here on the base set so every chart AND the table inherit
+    // them — and identically to the bucket-free /browse + MCP query, which is what
+    // makes an agent's dashboard link reproduce the same species set. Mirrors
+    // species-store.isOutdated (calendar-year) + species-filter numeric bounds.
+    const { outdated, minObs, maxObs, minAssessmentYear, maxAssessmentYear, minDescribedYear, maxDescribedYear } = exactFilters;
+    if (outdated) {
+      const nowYear = new Date().getFullYear();
+      filtered = filtered.filter(s => {
+        const y = s.assessment_date ? parseInt(s.assessment_date.slice(0, 4), 10) : NaN;
+        const isOld = Number.isNaN(y) || nowYear - y > 10;
+        return isOld === (outdated === "yes");
+      });
+    }
+    if (minObs != null || maxObs != null) {
+      filtered = filtered.filter(s => {
+        const obs = s.gbif_occurrence_count ?? 0;
+        return (minObs == null || obs >= minObs) && (maxObs == null || obs <= maxObs);
+      });
+    }
+    if (minAssessmentYear != null || maxAssessmentYear != null) {
+      filtered = filtered.filter(s => {
+        const y = s.assessment_date ? parseInt(s.assessment_date.slice(0, 4), 10) : NaN;
+        if (Number.isNaN(y)) return false;
+        return (minAssessmentYear == null || y >= minAssessmentYear) && (maxAssessmentYear == null || y <= maxAssessmentYear);
+      });
+    }
+    if (minDescribedYear != null || maxDescribedYear != null) {
+      filtered = filtered.filter(s =>
+        s.described_year != null
+        && (minDescribedYear == null || s.described_year >= minDescribedYear)
+        && (maxDescribedYear == null || s.described_year <= maxDescribedYear));
+    }
     return filtered;
-  }, [species, selectedTaxa, selectedSubgroups, isNewAssessments]);
+  }, [species, selectedTaxa, selectedSubgroups, isNewAssessments, exactFilters]);
 
   // Helper to check if species matches year range filter
   const matchesYearRangeFilter = useCallback((assessmentDate: string | null, yearRanges: Set<string> = selectedYearRanges): boolean => {
@@ -2977,7 +3011,30 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                 <span className="text-xs">×</span>
               </button>
             ))}
-            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || hasMapFilter || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred) && (
+            {/* Exact URL-only filters (typically arrive via an agent/MCP dashboard
+                link). Shown as chips so a human can see and clear them. */}
+            {(() => {
+              const ef = exactFilters;
+              const chips: { key: keyof typeof ef; label: string }[] = [];
+              if (ef.outdated) chips.push({ key: "outdated", label: ef.outdated === "yes" ? "Outdated (>10 yrs)" : "Current (≤10 yrs)" });
+              if (ef.minObs != null) chips.push({ key: "minObs", label: `≥ ${ef.minObs.toLocaleString()} obs` });
+              if (ef.maxObs != null) chips.push({ key: "maxObs", label: `≤ ${ef.maxObs.toLocaleString()} obs` });
+              if (ef.minAssessmentYear != null) chips.push({ key: "minAssessmentYear", label: `Assessed ≥ ${ef.minAssessmentYear}` });
+              if (ef.maxAssessmentYear != null) chips.push({ key: "maxAssessmentYear", label: `Assessed ≤ ${ef.maxAssessmentYear}` });
+              if (ef.minDescribedYear != null) chips.push({ key: "minDescribedYear", label: `Described ≥ ${ef.minDescribedYear}` });
+              if (ef.maxDescribedYear != null) chips.push({ key: "maxDescribedYear", label: `Described ≤ ${ef.maxDescribedYear}` });
+              return chips.map(c => (
+                <button
+                  key={`ef-${c.key}`}
+                  onClick={() => setExactFilters({ [c.key]: null })}
+                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300 flex items-center gap-1 hover:opacity-80"
+                >
+                  {c.label}
+                  <span className="text-xs">×</span>
+                </button>
+              ));
+            })()}
+            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || hasMapFilter || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
               <button
                 onClick={() => { clearAllFilters(); setSelectedTaxa(new Set()); setSelectedSubgroups(new Set()); setSelectedObsRanges(new Set()); setSelectedSystems(new Set()); setHasMapFilter(null); setSelectedGrowthForms(new Set()); setSelectedPopulationTrends(new Set()); setSelectedMovementPatterns(new Set()); setSelectedThreats(new Set()); setSelectedAssessors(new Set()); setSelectedReviewers(new Set()); setShowOnlyStarred(false); }}
                 className="text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 underline"

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -799,16 +799,22 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   const YEARS_PAGE_SIZE = 10;
   const [yearsPage, setYearsPage] = useState(0);
 
-  // Helper to check if species matches the assessors filter
+  // Helper to check if species matches the assessors filter.
+  // Case-insensitive SUBSTRING match — same semantics as the /browse + MCP
+  // `assessors` filter, so an agent's dashboard link reproduces the same set.
+  // (A chart click adds a full name, which substring-matches itself; the only
+  // difference is the rare case where one full name is a substring of another.)
   const matchesAssessorsFilter = useCallback((s: Species): boolean => {
     if (selectedAssessors.size === 0) return true;
-    return getSpeciesAssessors(s).some(a => selectedAssessors.has(a));
+    const sels = [...selectedAssessors].map(x => x.toLowerCase());
+    return getSpeciesAssessors(s).some(a => { const al = a.toLowerCase(); return sels.some(x => al.includes(x)); });
   }, [selectedAssessors, getSpeciesAssessors]);
 
-  // Helper to check if species matches the reviewers filter
+  // Helper to check if species matches the reviewers filter (substring, as above).
   const matchesReviewersFilter = useCallback((s: Species): boolean => {
     if (selectedReviewers.size === 0) return true;
-    return getSpeciesReviewers(s).some(r => selectedReviewers.has(r));
+    const sels = [...selectedReviewers].map(x => x.toLowerCase());
+    return getSpeciesReviewers(s).some(r => { const rl = r.toLowerCase(); return sels.some(x => rl.includes(x)); });
   }, [selectedReviewers, getSpeciesReviewers]);
 
   // Species details cache (images, criteria, common names)

--- a/app/src/hooks/__tests__/filterParams.test.ts
+++ b/app/src/hooks/__tests__/filterParams.test.ts
@@ -186,6 +186,37 @@ describe("parseParams", () => {
     const result = parseParams("");
     expect(result.tab).toBe(null);
   });
+
+  it("parses the exact URL-only filters", () => {
+    const result = parseParams(
+      "?outdated=yes&minObs=100&maxObs=5000&minAssessmentYear=2010&maxAssessmentYear=2020&minDescribedYear=1990&maxDescribedYear=2000"
+    );
+    expect(result.outdated).toBe("yes");
+    expect(result.minObs).toBe(100);
+    expect(result.maxObs).toBe(5000);
+    expect(result.minAssessmentYear).toBe(2010);
+    expect(result.maxAssessmentYear).toBe(2020);
+    expect(result.minDescribedYear).toBe(1990);
+    expect(result.maxDescribedYear).toBe(2000);
+  });
+
+  it("defaults exact filters to null when absent / invalid", () => {
+    const result = parseParams("?outdated=maybe&minObs=abc");
+    expect(result.outdated).toBe(null);
+    expect(result.minObs).toBe(null);
+    expect(result.maxObs).toBe(null);
+  });
+
+  it("expands a region param into its country codes (no separate region state)", () => {
+    const result = parseParams("?region=Sub-Saharan+Africa");
+    expect(result.countries.size).toBeGreaterThan(0);
+  });
+
+  it("unions region countries with an explicit countries param", () => {
+    const result = parseParams("?countries=ZA&region=Europe");
+    expect(result.countries.has("ZA")).toBe(true);
+    expect(result.countries.size).toBeGreaterThan(1);
+  });
 });
 
 describe("buildQs", () => {
@@ -353,6 +384,41 @@ describe("buildQs", () => {
     const qs = buildQs({ ...emptyState, species: 176168, tab: "gbif" });
     const params = new URLSearchParams(qs);
     expect(params.has("tab")).toBe(false);
+  });
+
+  it("includes the exact URL-only filters when set", () => {
+    const qs = buildQs({
+      ...emptyState,
+      outdated: "yes", minObs: 100, maxObs: 5000,
+      minAssessmentYear: 2010, maxAssessmentYear: 2020,
+      minDescribedYear: 1990, maxDescribedYear: 2000,
+    });
+    const p = new URLSearchParams(qs);
+    expect(p.get("outdated")).toBe("yes");
+    expect(p.get("minObs")).toBe("100");
+    expect(p.get("maxObs")).toBe("5000");
+    expect(p.get("minAssessmentYear")).toBe("2010");
+    expect(p.get("maxAssessmentYear")).toBe("2020");
+    expect(p.get("minDescribedYear")).toBe("1990");
+    expect(p.get("maxDescribedYear")).toBe("2000");
+  });
+
+  it("omits exact filters when null/absent", () => {
+    const qs = buildQs({ ...emptyState, outdated: null, minObs: null });
+    expect(qs).toBe("");
+  });
+
+  it("round-trips the exact filters through parseParams", () => {
+    const qs = buildQs({
+      ...emptyState,
+      taxa: new Set(["mammals"]),
+      outdated: "no", minObs: 1, maxObs: 9, minAssessmentYear: 2000,
+    });
+    const parsed = parseParams(qs);
+    expect(parsed.outdated).toBe("no");
+    expect(parsed.minObs).toBe(1);
+    expect(parsed.maxObs).toBe(9);
+    expect(parsed.minAssessmentYear).toBe(2000);
   });
 });
 

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -1,16 +1,51 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { canonicalizeTaxonId } from "@/lib/data/taxonomy-constants";
+import { resolveRegions } from "@/lib/regions";
 
 // --- URL parsing helpers ---
 
 export type ViewMode = "reassessments" | "new-assessments";
 
+// Exact, URL-only base filters (no on-screen control — the charts use coarse
+// buckets). They let an agent/MCP dashboard link reproduce the exact /browse
+// query; each feeds the same predicate the dashboard already runs.
+export interface ExactFilters {
+  outdated: "yes" | "no" | null;
+  minObs: number | null;
+  maxObs: number | null;
+  minAssessmentYear: number | null;
+  maxAssessmentYear: number | null;
+  minDescribedYear: number | null;
+  maxDescribedYear: number | null;
+}
+
+export const EMPTY_EXACT_FILTERS: ExactFilters = {
+  outdated: null, minObs: null, maxObs: null,
+  minAssessmentYear: null, maxAssessmentYear: null,
+  minDescribedYear: null, maxDescribedYear: null,
+};
+
+const numParam = (p: URLSearchParams, key: string): number | null => {
+  const v = p.get(key);
+  if (v == null) return null;
+  const n = parseInt(v, 10);
+  return Number.isNaN(n) ? null : n;
+};
+
 export function parseParams(search: string) {
   const p = new URLSearchParams(search);
   const sortParam = p.get("sort");
   const viewParam = p.get("view");
+  // A `region` param expands to its country codes (the dashboard has no separate
+  // region state — it stores a region AS its countries and re-derives the chip).
+  const countryCodes = new Set<string>(
+    p.get("countries") ? p.get("countries")!.split(",").filter(Boolean) : []
+  );
+  if (p.get("region")) {
+    resolveRegions(p.get("region")!.split(",").filter(Boolean)).codes.forEach((c) => countryCodes.add(c));
+  }
   return {
     viewMode: (viewParam === "new-assessments" ? "new-assessments" : "reassessments") as ViewMode,
     // Map legacy IDs (e.g. mammalia → mammals) so old shared/bookmarked URLs keep working.
@@ -33,9 +68,7 @@ export function parseParams(search: string) {
     describedYears: p.get("describedYears")
       ? new Set(p.get("describedYears")!.split(",").filter(Boolean))
       : new Set<string>(),
-    countries: p.get("countries")
-      ? new Set(p.get("countries")!.split(",").filter(Boolean))
-      : new Set<string>(),
+    countries: countryCodes,
     obsRanges: p.get("obsRanges")
       ? new Set(p.get("obsRanges")!.split(",").filter(Boolean))
       : new Set<string>(),
@@ -62,6 +95,14 @@ export function parseParams(search: string) {
       ? new Set(p.get("reviewers")!.split("|").filter(Boolean))
       : new Set<string>(),
     search: p.get("search") || "",
+    // Exact URL-only base filters (see ExactFilters).
+    outdated: (p.get("outdated") === "yes" ? "yes" : p.get("outdated") === "no" ? "no" : null) as "yes" | "no" | null,
+    minObs: numParam(p, "minObs"),
+    maxObs: numParam(p, "maxObs"),
+    minAssessmentYear: numParam(p, "minAssessmentYear"),
+    maxAssessmentYear: numParam(p, "maxAssessmentYear"),
+    minDescribedYear: numParam(p, "minDescribedYear"),
+    maxDescribedYear: numParam(p, "maxDescribedYear"),
     sortField: (
       sortParam === "category" ? "category" :
       sortParam === "year" ? "year" :
@@ -96,6 +137,13 @@ export function buildQs(state: {
   assessors: Set<string>;
   reviewers: Set<string>;
   search: string;
+  outdated?: "yes" | "no" | null;
+  minObs?: number | null;
+  maxObs?: number | null;
+  minAssessmentYear?: number | null;
+  maxAssessmentYear?: number | null;
+  minDescribedYear?: number | null;
+  maxDescribedYear?: number | null;
   sortField: "year" | "category" | "totalGbif" | "newGbif" | "pctNewGbif" | "describedYear" | null;
   sortDirection: "asc" | "desc";
   species: number | null;
@@ -120,6 +168,13 @@ export function buildQs(state: {
   if (state.assessors.size > 0) p.set("assessors", [...state.assessors].join("|"));
   if (state.reviewers.size > 0) p.set("reviewers", [...state.reviewers].join("|"));
   if (state.search) p.set("search", state.search);
+  if (state.outdated) p.set("outdated", state.outdated);
+  if (state.minObs != null) p.set("minObs", String(state.minObs));
+  if (state.maxObs != null) p.set("maxObs", String(state.maxObs));
+  if (state.minAssessmentYear != null) p.set("minAssessmentYear", String(state.minAssessmentYear));
+  if (state.maxAssessmentYear != null) p.set("maxAssessmentYear", String(state.maxAssessmentYear));
+  if (state.minDescribedYear != null) p.set("minDescribedYear", String(state.minDescribedYear));
+  if (state.maxDescribedYear != null) p.set("maxDescribedYear", String(state.maxDescribedYear));
   if (state.species != null) p.set("species", String(state.species));
   if (state.species != null && state.tab && state.tab !== "gbif") p.set("tab", state.tab);
   // null / "year" desc is the default — only write non-default sort to URL
@@ -378,6 +433,30 @@ export function useFilterParams() {
     [syncUrl]
   );
 
+  // Stable identity (keyed on the 7 primitive fields) so consumers can use it as a
+  // memo/effect dep without recomputing every render.
+  const exactFilters = useMemo<ExactFilters>(() => ({
+    outdated: state.outdated,
+    minObs: state.minObs,
+    maxObs: state.maxObs,
+    minAssessmentYear: state.minAssessmentYear,
+    maxAssessmentYear: state.maxAssessmentYear,
+    minDescribedYear: state.minDescribedYear,
+    maxDescribedYear: state.maxDescribedYear,
+  }), [state.outdated, state.minObs, state.maxObs, state.minAssessmentYear, state.maxAssessmentYear, state.minDescribedYear, state.maxDescribedYear]);
+
+  // Patch one or more exact URL-only filters (outdated / obs / year bounds).
+  const setExactFilters = useCallback(
+    (patch: Partial<ExactFilters>) => {
+      setState(prev => {
+        const next = { ...prev, ...patch };
+        queueMicrotask(() => syncUrl(next, false));
+        return next;
+      });
+    },
+    [syncUrl]
+  );
+
   const setViewMode = useCallback(
     (mode: ViewMode) => {
       setState(prev => {
@@ -443,6 +522,7 @@ export function useFilterParams() {
         assessors: new Set<string>(),
         reviewers: new Set<string>(),
         search: "",
+        ...EMPTY_EXACT_FILTERS,
         sortField: null,
         sortDirection: "desc" as const,
         species: null,
@@ -474,6 +554,7 @@ export function useFilterParams() {
         assessors: new Set<string>(),
         reviewers: new Set<string>(),
         search: "",
+        ...EMPTY_EXACT_FILTERS,
         sortField: null,
         sortDirection: "desc" as const,
         species: null,
@@ -503,6 +584,8 @@ export function useFilterParams() {
     selectedAssessors: state.assessors,
     selectedReviewers: state.reviewers,
     searchFilter: state.search,
+    exactFilters,
+    setExactFilters,
     sortField: state.sortField,
     sortDirection: state.sortDirection,
 

--- a/app/src/lib/__tests__/dashboard-url.test.ts
+++ b/app/src/lib/__tests__/dashboard-url.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { browseInputToDashboardQuery, browseInputToDashboardUrl } from "../dashboard-url";
+import { parseParams } from "@/hooks/useFilterParams";
+
+const params = (input: Parameters<typeof browseInputToDashboardQuery>[0]) =>
+  new URLSearchParams(browseInputToDashboardQuery(input));
+
+describe("browseInputToDashboardQuery", () => {
+  it("returns empty string when nothing resolves", () => {
+    expect(browseInputToDashboardQuery({})).toBe("");
+    expect(browseInputToDashboardQuery({ taxa: ["not-a-real-thing!!"] })).toBe("");
+  });
+
+  it("maps a featured taxon", () => {
+    expect(params({ taxa: ["mammals"] }).get("taxa")).toBe("mammals");
+  });
+
+  it("maps a scientific-rank taxon to taxa (no subgroup)", () => {
+    const p = params({ taxa: ["felidae"] });
+    expect(p.get("taxa")).toBe("felidae");
+    expect(p.has("subgroups")).toBe(false);
+  });
+
+  it("maps a curated sub-group to subgroups + its display root in taxa", () => {
+    const p = params({ taxa: ["sharks-rays"] });
+    expect(p.get("subgroups")).toBe("sharks-rays");
+    expect(p.get("taxa")).toBeTruthy(); // the parent display root, so its species load
+  });
+
+  it("resolves category aliases (threatened → CR,EN,VU)", () => {
+    expect(params({ taxa: ["mammals"], categories: ["threatened"] }).get("categories")).toBe("CR,EN,VU");
+  });
+
+  it("resolves threat aliases (climate-change → 11)", () => {
+    expect(params({ taxa: ["corals"], threats: ["climate-change"] }).get("threats")).toBe("11");
+  });
+
+  it("expands a region into countries (lossless) and emits no region param", () => {
+    const p = params({ taxa: ["amphibians"], region: ["Sub-Saharan Africa"] });
+    expect(p.has("region")).toBe(false);
+    expect((p.get("countries") ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("emits the exact continuous params verbatim", () => {
+    const p = params({
+      taxa: ["mammals"],
+      outdated: "yes",
+      minObs: 100, maxObs: 5000,
+      minAssessmentYear: 2010, maxAssessmentYear: 2020,
+      minDescribedYear: 1990, maxDescribedYear: 2000,
+    });
+    expect(p.get("outdated")).toBe("yes");
+    expect(p.get("minObs")).toBe("100");
+    expect(p.get("maxObs")).toBe("5000");
+    expect(p.get("minAssessmentYear")).toBe("2010");
+    expect(p.get("maxAssessmentYear")).toBe("2020");
+    expect(p.get("minDescribedYear")).toBe("1990");
+    expect(p.get("maxDescribedYear")).toBe("2000");
+  });
+
+  it("joins assessors/reviewers with the dashboard's pipe delimiter", () => {
+    const p = params({ taxa: ["mammals"], assessors: ["Smith"], reviewers: ["Jones"] });
+    expect(p.get("assessors")).toBe("Smith");
+    expect(p.get("reviewers")).toBe("Jones");
+  });
+
+  it("emits hasMap / systems / trends", () => {
+    const p = params({ taxa: ["mammals"], hasMap: "yes", systems: ["Marine"], trends: ["Decreasing"] });
+    expect(p.get("hasMap")).toBe("yes");
+    expect(p.get("systems")).toBe("Marine");
+    expect(p.get("trends")).toBe("Decreasing");
+  });
+
+  it("maps a species lookup to a name search", () => {
+    expect(params({ search: "tiger" }).get("search")).toBe("tiger");
+  });
+
+  it("prefixes an origin for the absolute URL", () => {
+    expect(browseInputToDashboardUrl("https://example.com", { taxa: ["mammals"] }))
+      .toBe("https://example.com/?taxa=mammals");
+  });
+});
+
+// The whole point of the shared translator: what it emits, the dashboard reads
+// back into the same filter state — so the agent and the human see one view.
+describe("browseInputToDashboardQuery → parseParams round-trip", () => {
+  it("round-trips taxa + categories + exact filters", () => {
+    const qs = browseInputToDashboardQuery({
+      taxa: ["mammals"],
+      categories: ["threatened"],
+      outdated: "yes",
+      minObs: 100,
+      minAssessmentYear: 2010,
+    });
+    const parsed = parseParams(qs);
+    expect(parsed.taxa).toEqual(new Set(["mammals"]));
+    expect(parsed.categories).toEqual(new Set(["CR", "EN", "VU"]));
+    expect(parsed.outdated).toBe("yes");
+    expect(parsed.minObs).toBe(100);
+    expect(parsed.minAssessmentYear).toBe(2010);
+  });
+
+  it("round-trips a region as the same country set the dashboard would hold", () => {
+    const qs = browseInputToDashboardQuery({ taxa: ["amphibians"], region: ["Sub-Saharan Africa"] });
+    const parsed = parseParams(qs);
+    expect(parsed.countries.size).toBeGreaterThan(0);
+  });
+});

--- a/app/src/lib/browse-query.ts
+++ b/app/src/lib/browse-query.ts
@@ -15,7 +15,7 @@ import { findNode, speciesMatchesNode } from "@/lib/taxonomy-utils";
 import { matchesSpeciesFilter, type SpeciesFilterCriteria, type FilterableSpecies } from "@/lib/species-filter";
 import type { RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
 import { parseAssessors } from "@/lib/parseAssessors";
-import { IUCN_REGION_ORDER, iucnRegionCountries } from "@/lib/regions";
+import { resolveRegions } from "@/lib/regions";
 import { CATEGORY_ORDER } from "@/config/taxa";
 import {
   resolveTaxa, resolveThreats, resolveCategories, resolveCountries,
@@ -90,19 +90,9 @@ type Row = FilterableSpecies & {
   matched_synonym?: string | null;
 };
 
-// Resolve IUCN region names (case-insensitive, hyphen/space tolerant) to their
-// country codes — the dashboard's region dropdown expands to countries the same way.
-export function resolveRegions(values: string[]): { codes: string[]; unresolved: string[] } {
-  const codes = new Set<string>();
-  const unresolved: string[] = [];
-  const norm = (s: string) => s.toLowerCase().replace(/[\s_-]+/g, " ").trim();
-  for (const v of values) {
-    const hit = IUCN_REGION_ORDER.find((r) => norm(r) === norm(v));
-    if (hit) iucnRegionCountries(hit).forEach((c) => codes.add(c));
-    else unresolved.push(v);
-  }
-  return { codes: [...codes], unresolved };
-}
+// resolveRegions now lives in @/lib/regions (shared with the dashboard-URL
+// translator); re-exported here for existing importers.
+export { resolveRegions } from "@/lib/regions";
 
 function searchHitToRow(h: SearchResult): Row {
   return {

--- a/app/src/lib/dashboard-url.ts
+++ b/app/src/lib/dashboard-url.ts
@@ -21,11 +21,9 @@
  *    display-root in `taxa` (the dashboard filters sub-groups out of the parent's
  *    loaded set); a scientific-rank taxon (e.g. `felidae`) → `taxa=<id>` (matched
  *    by class/order/family); a featured group → `taxa=<id>`.
- *
- * Residual, intentionally-approximate cases (documented, not silently wrong):
- *  - `assessors`/`reviewers`: /browse matches a substring; the dashboard matches a
- *    full assessor/reviewer name. A full name is exact; a partial name may select
- *    a broader set in the dashboard.
+ *  - `assessors`/`reviewers`: both surfaces case-insensitively SUBSTRING-match the
+ *    name (the dashboard predicate mirrors /browse), so a partial name selects the
+ *    same species set in each.
  */
 import type { BrowseInput } from "@/lib/browse-query";
 import {

--- a/app/src/lib/dashboard-url.ts
+++ b/app/src/lib/dashboard-url.ts
@@ -1,0 +1,122 @@
+/**
+ * Single source of truth for turning a /browse + MCP query (`BrowseInput`) into
+ * the interactive dashboard URL that reproduces the SAME species set.
+ *
+ * The MCP tools and the /browse route answer from `runBrowseQuery`; this builds
+ * the `/?…` link a human opens to verify that answer in the dashboard. To make
+ * "the agent and the human see the same view" a guarantee rather than a hope,
+ * every filter maps to a dashboard URL param that feeds the *same* filter
+ * predicate the dashboard already runs (see useFilterParams.parseParams +
+ * RedListView). It resolves values the same way runBrowseQuery does (via the
+ * shared filter-vocab resolvers), so the two can't drift.
+ *
+ * Mapping notes (where the two vocabularies differ):
+ *  - `region` → expanded to its `countries` (the dashboard stores a region AS its
+ *    country set and re-derives the region chip), so it's lossless.
+ *  - `outdated`, `minObs`/`maxObs`, `minAssessmentYear`/`maxAssessmentYear`,
+ *    `minDescribedYear`/`maxDescribedYear` → emitted as exact URL params. The
+ *    dashboard's on-screen charts use coarse buckets; these URL-only params feed
+ *    the exact same numeric/`isOutdated` predicate so the result is identical.
+ *  - a curated sub-group taxon (e.g. `sharks-rays`) → `subgroups=<id>` plus its
+ *    display-root in `taxa` (the dashboard filters sub-groups out of the parent's
+ *    loaded set); a scientific-rank taxon (e.g. `felidae`) → `taxa=<id>` (matched
+ *    by class/order/family); a featured group → `taxa=<id>`.
+ *
+ * Residual, intentionally-approximate cases (documented, not silently wrong):
+ *  - `assessors`/`reviewers`: /browse matches a substring; the dashboard matches a
+ *    full assessor/reviewer name. A full name is exact; a partial name may select
+ *    a broader set in the dashboard.
+ */
+import type { BrowseInput } from "@/lib/browse-query";
+import {
+  resolveTaxa, resolveCategories, resolveThreats, resolveCountries,
+} from "@/lib/filter-vocab";
+import { resolveRegions } from "@/lib/regions";
+import { findNode, getViewRootForNode } from "@/lib/taxonomy-utils";
+
+const arr = (a?: string[]) => (a ?? []).map((s) => s.trim()).filter(Boolean);
+
+// Split resolved taxon ids into the dashboard's `taxa` (display roots + arbitrary
+// scientific ranks) vs `subgroups` (a curated node below a display root, which
+// also needs its root selected so the parent's species load).
+function splitTaxa(ids: string[]): { taxa: string[]; subgroups: string[] } {
+  const taxa = new Set<string>();
+  const subgroups = new Set<string>();
+  for (const id of ids) {
+    if (!findNode(id)) { taxa.add(id); continue; } // arbitrary scientific rank
+    const root = getViewRootForNode(id);
+    if (root && root !== id) { subgroups.add(id); taxa.add(root); }
+    else taxa.add(id); // a display root (or a node outside the default view)
+  }
+  return { taxa: [...taxa], subgroups: [...subgroups] };
+}
+
+/**
+ * Build the dashboard query string (`?…`, or `""` when nothing resolved) that
+ * reproduces `input`'s species set in the interactive dashboard at `/`.
+ */
+export function browseInputToDashboardQuery(input: BrowseInput): string {
+  const p = new URLSearchParams();
+
+  if (input.search && input.search.trim()) {
+    // Species lookup → name search (substring on scientific/common name).
+    p.set("search", input.search.trim());
+  }
+
+  const taxaIds = resolveTaxa(arr(input.taxa)).ids;
+  if (taxaIds.length) {
+    const { taxa, subgroups } = splitTaxa(taxaIds);
+    if (taxa.length) p.set("taxa", taxa.join(","));
+    if (subgroups.length) p.set("subgroups", subgroups.join(","));
+  }
+
+  const categories = resolveCategories(arr(input.categories)).codes;
+  if (categories.length) p.set("categories", categories.join(","));
+
+  const threats = resolveThreats(arr(input.threats)).codes;
+  if (threats.length) p.set("threats", threats.join(","));
+
+  // Countries + region (region expands to its country set — lossless).
+  const countries = new Set<string>([
+    ...resolveCountries(arr(input.countries)).codes,
+    ...resolveRegions(arr(input.region)).codes,
+  ]);
+  if (countries.size) p.set("countries", [...countries].join(","));
+
+  const systems = arr(input.systems);
+  if (systems.length) p.set("systems", systems.join(","));
+
+  const trends = arr(input.trends);
+  if (trends.length) p.set("trends", trends.join(","));
+
+  const movement = arr(input.movement);
+  if (movement.length) p.set("movement", movement.join(","));
+
+  const growthForms = arr(input.growthForms);
+  if (growthForms.length) p.set("growthForms", growthForms.join(","));
+
+  if (input.hasMap === "yes" || input.hasMap === "no") p.set("hasMap", input.hasMap);
+
+  const assessors = arr(input.assessors);
+  if (assessors.length) p.set("assessors", assessors.join("|"));
+  const reviewers = arr(input.reviewers);
+  if (reviewers.length) p.set("reviewers", reviewers.join("|"));
+
+  // Exact numeric / outdated params (URL-only; feed the same predicate the
+  // dashboard runs, so the result matches the bucket-free /browse query).
+  if (input.outdated === "yes" || input.outdated === "no") p.set("outdated", input.outdated);
+  if (input.minObs != null) p.set("minObs", String(input.minObs));
+  if (input.maxObs != null) p.set("maxObs", String(input.maxObs));
+  if (input.minAssessmentYear != null) p.set("minAssessmentYear", String(input.minAssessmentYear));
+  if (input.maxAssessmentYear != null) p.set("maxAssessmentYear", String(input.maxAssessmentYear));
+  if (input.minDescribedYear != null) p.set("minDescribedYear", String(input.minDescribedYear));
+  if (input.maxDescribedYear != null) p.set("maxDescribedYear", String(input.maxDescribedYear));
+
+  const qs = p.toString();
+  return qs ? `?${qs}` : "";
+}
+
+/** Absolute dashboard URL for `input`, given the request origin (e.g. https://host). */
+export function browseInputToDashboardUrl(origin: string, input: BrowseInput): string {
+  return `${origin}/${browseInputToDashboardQuery(input)}`;
+}

--- a/app/src/lib/regions.ts
+++ b/app/src/lib/regions.ts
@@ -322,3 +322,20 @@ export function iucnRegionCountries(region: string): string[] {
     .filter(([, r]) => r === region)
     .map(([code]) => code);
 }
+
+/**
+ * Resolve IUCN region names (case-insensitive, hyphen/space tolerant) to their
+ * country codes — the dashboard's region dropdown expands to countries the same
+ * way, so a region filter and its expanded country set select identically.
+ */
+export function resolveRegions(values: string[]): { codes: string[]; unresolved: string[] } {
+  const codes = new Set<string>();
+  const unresolved: string[] = [];
+  const norm = (s: string) => s.toLowerCase().replace(/[\s_-]+/g, " ").trim();
+  for (const v of values) {
+    const hit = IUCN_REGION_ORDER.find((r) => norm(r) === norm(v));
+    if (hit) iucnRegionCountries(hit).forEach((c) => codes.add(c));
+    else unresolved.push(v);
+  }
+  return { codes: [...codes], unresolved };
+}


### PR DESCRIPTION
## Why

When an agent queries the dashboard data via the MCP tools (or `/browse`), it gets back JSON only — the user has no easy way to open the dashboard and check the data for themselves. This adds a `dashboard_url` to every result and, crucially, makes that URL reproduce the **exact same species set** the agent saw, so the agent and the human are guaranteed to be looking at the same view.

## What

Every `browse_taxon` / `find_species` result (and the `/browse?…&format=json` response) now carries:
- **`dashboard_url`** — the interactive dashboard pre-filtered to the same query.
- **`verify_note`** — a standing instruction to surface the link and encourage the user to inspect/verify the data themselves.

Both are computed **server-side** (request origin captured per-request via `AsyncLocalStorage`, same approach as `/llms.txt`), so the behaviour can't be skipped by the agent.

## Forcing the two vocabularies to be consistent

A single shared translator, `lib/dashboard-url.ts`, is the one source of truth both surfaces use, so they can't drift. The gaps between the MCP/`/browse` filter vocabulary and the dashboard's URL params were closed so the mapping is lossless:

| Filter | Mapping |
|---|---|
| taxa, categories, threats, countries, systems, trends, hasMap, search | already share the dashboard's filter engine → 1:1 |
| `region` | expanded to its country set (the dashboard stores a region *as* its countries) — lossless |
| curated sub-group (e.g. `sharks-rays`) | `subgroups=…` + its display root in `taxa` |
| **`outdated`, `minObs`/`maxObs`, assessment-year & described-year bounds** | the dashboard previously could only express these as coarse chart *buckets*. Added as **exact URL-only params** that feed the same predicate on the dashboard's base species set, so every chart and the table reproduce the identical set. They surface as clearable filter chips. |
| **assessors / reviewers** | the dashboard matched by exact full name while MCP matches by case-insensitive substring → an agent's `assessors=Smith` reproduced as an *empty* view. Converged the dashboard onto substring matching (keeps the agent-friendly partial-name lookup that `llms.txt` advertises and avoids silent-empty results). |

## Notes

- The exact filters are applied once on the shared base set (`taxaFilteredSpecies`), so charts and the table stay consistent with each other and with `runBrowseQuery`'s AND semantics.
- `resolveRegions` moved to `lib/regions.ts` (shared between `browse-query` and the translator; re-exported from `browse-query` for existing importers).

## Tests

- New `dashboard-url.test.ts` (translator + round-trip: emitted query → `parseParams` yields the same filter state).
- Extended `filterParams.test.ts` for the new URL params (parse / build / round-trip).
- Full suite: **423 passing**; `tsc --noEmit` and ESLint clean.
- Not run: a live `next build`/dev smoke test (requires R2 credentials for `app/data/`); the new logic is covered by unit + round-trip tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyY1VFTPv7EHV58J9hpmAg)_