### PR TITLE
Set dashboard title per domain

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,9 +1,12 @@
 import type { Metadata, Viewport } from "next";
+import { headers } from "next/headers";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { ThemeProvider } from "../components/ThemeProvider";
+import { BrandProvider } from "../components/BrandProvider";
 import { PostHogProvider } from "../components/PostHogProvider";
+import { brandForHost } from "../config/brand";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
@@ -22,24 +25,30 @@ export const viewport: Viewport = {
   initialScale: 1,
 };
 
-export const metadata: Metadata = {
-  title: "IUCN Red List Assessments Dashboard",
-  description: "IUCN Red List and GBIF occurrence data explorer",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const brand = brandForHost((await headers()).get("host"));
+  return {
+    title: brand.title,
+    description: brand.description,
+  };
+}
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const brand = brandForHost((await headers()).get("host"));
   return (
     <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <PostHogProvider>
-          <ThemeProvider>{children}</ThemeProvider>
-        </PostHogProvider>
+        <BrandProvider brand={brand}>
+          <PostHogProvider>
+            <ThemeProvider>{children}</ThemeProvider>
+          </PostHogProvider>
+        </BrandProvider>
         <Analytics />
         <SpeedInsights />
       </body>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import dynamic from "next/dynamic";
 import { ThemeToggle } from "../components/ThemeToggle";
 import { SpeciesSearchBar } from "../components/SpeciesSearchBar";
+import { useBrand } from "../components/BrandProvider";
 import { parseParams, type ViewMode } from "../hooks/useFilterParams";
 
 // Dynamically import view component
@@ -22,6 +23,7 @@ const RedListView = dynamic(
 );
 
 export default function RedListPage() {
+  const brand = useBrand();
   const [viewMode, setViewMode] = useState<ViewMode>("reassessments");
 
   // Hydrate viewMode from URL on mount + sync on popstate (back/forward)
@@ -45,7 +47,7 @@ export default function RedListPage() {
         {/* Header row: title + view mode toggle */}
         <div className="mb-3 md:mb-4 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
           <h1 className="text-xl sm:text-2xl md:text-3xl font-bold text-zinc-900 dark:text-zinc-100">
-            IUCN Red List Assessments Dashboard
+            {brand.title}
           </h1>
           <div className="flex items-center gap-2 shrink-0">
             {/* View mode toggle */}

--- a/app/src/components/BrandProvider.tsx
+++ b/app/src/components/BrandProvider.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { Brand } from "../config/brand";
+
+const BrandContext = createContext<Brand>({
+  title: "IUCN Red List Assessments Dashboard",
+  description: "IUCN Red List and GBIF occurrence data explorer",
+});
+
+export function BrandProvider({
+  brand,
+  children,
+}: {
+  brand: Brand;
+  children: React.ReactNode;
+}) {
+  return <BrandContext.Provider value={brand}>{children}</BrandContext.Provider>;
+}
+
+export function useBrand(): Brand {
+  return useContext(BrandContext);
+}

--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -1,0 +1,24 @@
+export type Brand = {
+  title: string;
+  description: string;
+};
+
+const DEFAULT_BRAND: Brand = {
+  title: "IUCN Red List Assessments Dashboard",
+  description: "IUCN Red List and GBIF occurrence data explorer",
+};
+
+// Per-hostname overrides. Keys are bare hostnames (no port, no "www.").
+const BRANDS: Record<string, Brand> = {
+  "dashoflife.org": {
+    title: "Dashboard of Life",
+    description: "IUCN Red List and GBIF occurrence data explorer",
+  },
+};
+
+/** Resolve the brand for an incoming request's `Host` header. */
+export function brandForHost(host: string | null | undefined): Brand {
+  if (!host) return DEFAULT_BRAND;
+  const hostname = host.split(":")[0].toLowerCase().replace(/^www\./, "");
+  return BRANDS[hostname] ?? DEFAULT_BRAND;
+}


### PR DESCRIPTION
## What

The dashboard title now varies by the request's `Host` header:

- **dashoflife.org** → "Dashboard of Life"
- **red.cst.cam.ac.uk** (and Vercel previews / localhost) → "IUCN Red List Assessments Dashboard" (unchanged)

This drives both the browser tab `<title>`/meta description and the visible `<h1>`, server-rendered so there is no flicker.

## How

- `app/src/config/brand.ts` (new) — hostname → brand map with a default fallback. Adding a domain is a one-line entry.
- `app/src/app/layout.tsx` — `generateMetadata` and the layout read `headers()` and resolve the brand.
- `app/src/components/BrandProvider.tsx` (new) — provides the resolved brand to the client tree.
- `app/src/app/page.tsx` — `<h1>` renders `brand.title` via `useBrand()`.

## Notes

- Reading `headers()` opts the root layout into dynamic rendering. The HTML shell is small and all dashboard data still loads client-side, so the cost is negligible.
- Assumes dashoflife.org reaches this same deployment directly. If it is served through a proxy that rewrites Host, `brandForHost` would need to read `x-forwarded-host` instead.
- `/browse` and `/llms.txt` still use their existing hardcoded titles — left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)