### PR TITLE
Add Encyclopedia of Life (EOL) tab to species detail panel

### DIFF
--- a/app/src/app/api/eol/route.ts
+++ b/app/src/app/api/eol/route.ts
@@ -3,6 +3,12 @@ import { CACHE_1H } from "@/lib/cache-headers";
 
 const EOL_API = "https://eol.org/api";
 
+// Identify ourselves honestly to EOL (their API Terms ask callers to observe
+// rate limits; an identifying UA lets EOL contact/throttle us if needed).
+const EOL_HEADERS = {
+  "User-Agent": "RedListDashboard/1.0 (+https://github.com/shaneweisz/redlist-dashboard)",
+};
+
 // In-memory cache (1 hour) — EOL data changes infrequently.
 const eolCache = new Map<string, { data: object; timestamp: number }>();
 const CACHE_DURATION = 60 * 60 * 1000;
@@ -107,7 +113,8 @@ export async function GET(request: NextRequest) {
   try {
     // Step 1: resolve the scientific name to an EOL page id.
     const searchResp = await fetch(
-      `${EOL_API}/search/1.0.json?q=${encodeURIComponent(name)}&page=1`
+      `${EOL_API}/search/1.0.json?q=${encodeURIComponent(name)}&page=1`,
+      { headers: EOL_HEADERS }
     );
     if (!searchResp.ok) {
       return NextResponse.json({ error: `EOL search error: ${searchResp.status}` }, { status: searchResp.status });
@@ -132,7 +139,8 @@ export async function GET(request: NextRequest) {
     const pageResp = await fetch(
       `${EOL_API}/pages/1.0/${match.id}.json?details=true&images_per_page=12` +
         `&texts_per_page=20&maps_per_page=0&videos_per_page=0&sounds_per_page=0` +
-        `&vetted=0&common_names=true&taxonomy=true&language=en`
+        `&vetted=0&common_names=true&taxonomy=true&language=en`,
+      { headers: EOL_HEADERS }
     );
     if (!pageResp.ok) {
       return NextResponse.json({ error: `EOL pages error: ${pageResp.status}` }, { status: pageResp.status });
@@ -141,24 +149,30 @@ export async function GET(request: NextRequest) {
     const page: EolPage = pageBody.taxonConcept || {};
     const objects = page.dataObjects || [];
 
-    // English vernacular names, deduped (case-insensitive). EOL's
-    // `eol_preferred` flag is unreliable (it often favours a non-English name),
-    // so we keep EOL's natural order rather than sorting by it.
+    // Vernacular names deduped by name+language, English (Latin-script) first
+    // so the full multilingual list is browsable. EOL's `eol_preferred` flag is
+    // unreliable (it often favours a non-English name), so we ignore it.
     const seen = new Set<string>();
-    const englishNames: string[] = [];
+    const englishNames: { name: string; lang: string }[] = [];
+    const otherNames: { name: string; lang: string }[] = [];
     for (const v of page.vernacularNames || []) {
-      if (v.language !== "en") continue;
-      // EOL frequently mislabels non-English names (CJK, Cyrillic, etc.) as
-      // "en"; keep only Latin-script names so the English list stays clean.
-      if (!/^[\p{Script=Latin}\s'.\-()]+$/u.test(v.vernacularName)) continue;
-      const key = v.vernacularName.toLowerCase();
+      const name = v.vernacularName?.trim();
+      const lang = v.language || "";
+      if (!name || !lang) continue;
+      const key = `${lang}:${name.toLowerCase()}`;
       if (seen.has(key)) continue;
       seen.add(key);
-      englishNames.push(v.vernacularName);
+      if (lang === "en") {
+        // EOL frequently mislabels non-English names (CJK, Cyrillic, etc.) as
+        // "en"; keep only Latin-script names in the English bucket.
+        if (!/^[\p{Script=Latin}\s'.\-()]+$/u.test(name)) continue;
+        englishNames.push({ name, lang });
+      } else {
+        otherNames.push({ name, lang });
+      }
     }
-    const otherLanguageCount = new Set(
-      (page.vernacularNames || []).filter((v) => v.language && v.language !== "en").map((v) => v.language)
-    ).size;
+    const commonNames = [...englishNames, ...otherNames];
+    const languageCount = new Set(commonNames.map((n) => n.lang)).size;
 
     // Brief summary: prefer an English "Brief Summary" article, else any English text.
     const englishTexts = objects.filter((o) => isText(o) && o.language === "en" && o.description);
@@ -197,8 +211,9 @@ export async function GET(request: NextRequest) {
       eolId: page.identifier,
       pageUrl: `https://eol.org/pages/${page.identifier}`,
       scientificName: page.scientificName || match.title,
-      englishNames,
-      otherLanguageCount,
+      commonNames,
+      englishNameCount: englishNames.length,
+      languageCount,
       summary,
       images,
       providers,

--- a/app/src/app/api/eol/route.ts
+++ b/app/src/app/api/eol/route.ts
@@ -1,0 +1,216 @@
+import { NextRequest, NextResponse } from "next/server";
+import { CACHE_1H } from "@/lib/cache-headers";
+
+const EOL_API = "https://eol.org/api";
+
+// In-memory cache (1 hour) — EOL data changes infrequently.
+const eolCache = new Map<string, { data: object; timestamp: number }>();
+const CACHE_DURATION = 60 * 60 * 1000;
+
+interface EolSearchResult {
+  id: number;
+  title: string;
+  link: string;
+  content: string;
+}
+
+interface EolVernacular {
+  vernacularName: string;
+  language: string;
+  eol_preferred?: boolean;
+}
+
+interface EolAgent {
+  full_name: string;
+  homepage?: string | null;
+  role?: string;
+}
+
+interface EolDataObject {
+  dataType?: string;
+  dataSubtype?: string;
+  language?: string;
+  title?: string;
+  description?: string;
+  license?: string;
+  rightsHolder?: string;
+  source?: string;
+  mediaURL?: string;
+  eolMediaURL?: string;
+  eolThumbnailURL?: string;
+  agents?: EolAgent[];
+}
+
+interface EolTaxonProvider {
+  nameAccordingTo?: string;
+  scientificName?: string;
+  taxonRank?: string;
+}
+
+interface EolPage {
+  identifier: number;
+  scientificName: string;
+  vernacularNames?: EolVernacular[];
+  dataObjects?: EolDataObject[];
+  taxonConcepts?: EolTaxonProvider[];
+}
+
+const isText = (o: EolDataObject) => (o.dataType || "").includes("Text");
+const isImage = (o: EolDataObject) => (o.dataType || "").includes("StillImage");
+
+/** Map a Creative Commons / license URL to a short human label. */
+function licenseLabel(url: string | undefined): string | null {
+  if (!url) return null;
+  const m = url.match(/licenses\/([a-z-]+)\/(\d\.\d)/i);
+  if (m) return `CC ${m[1].toUpperCase()} ${m[2]}`;
+  if (url.includes("publicdomain")) return "Public Domain";
+  return null;
+}
+
+const stripHtml = (s: string | null | undefined): string | null =>
+  s ? s.replace(/<[^>]*>/g, "").trim() || null : null;
+
+const photographer = (o: EolDataObject): string | null =>
+  stripHtml(
+    o.agents?.find((a) => a.role === "photographer")?.full_name ||
+      o.rightsHolder ||
+      o.agents?.[0]?.full_name ||
+      null
+  );
+
+/** Upgrade an EOL thumbnail (…98x68.jpg) to a larger grid-friendly derivative. */
+const gridThumb = (o: EolDataObject): string => {
+  const base = o.eolThumbnailURL || o.eolMediaURL || o.mediaURL!;
+  return base.replace(/\.\d+x\d+\.(jpg|png|jpeg)$/i, ".260x190.$1");
+};
+
+/**
+ * GET /api/eol?name=<scientific_name>
+ *
+ * Looks up a species on the Encyclopedia of Life and returns a normalized
+ * payload: the matching EOL page, English vernacular names, an attributed
+ * image gallery, a brief summary (when an English article exists) and the
+ * taxonomic data providers EOL aggregates.
+ */
+export async function GET(request: NextRequest) {
+  const name = request.nextUrl.searchParams.get("name");
+  if (!name) {
+    return NextResponse.json({ error: "name parameter is required" }, { status: 400 });
+  }
+
+  const cacheKey = name.toLowerCase().trim();
+  const cached = eolCache.get(cacheKey);
+  if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
+    return NextResponse.json({ ...cached.data, cached: true }, { headers: CACHE_1H });
+  }
+
+  try {
+    // Step 1: resolve the scientific name to an EOL page id.
+    const searchResp = await fetch(
+      `${EOL_API}/search/1.0.json?q=${encodeURIComponent(name)}&page=1`
+    );
+    if (!searchResp.ok) {
+      return NextResponse.json({ error: `EOL search error: ${searchResp.status}` }, { status: searchResp.status });
+    }
+    const searchData = await searchResp.json();
+    const results: EolSearchResult[] = searchData.results || [];
+
+    // Prefer an exact (case-insensitive) title match, else the first result.
+    const target = cacheKey;
+    const match =
+      results.find((r) => r.title.toLowerCase() === target) ||
+      results.find((r) => r.title.toLowerCase().startsWith(target)) ||
+      results[0];
+
+    if (!match) {
+      const result = { found: false, scientificName: name };
+      eolCache.set(cacheKey, { data: result, timestamp: Date.now() });
+      return NextResponse.json(result, { headers: CACHE_1H });
+    }
+
+    // Step 2: fetch page details (images, texts, vernacular names, providers).
+    const pageResp = await fetch(
+      `${EOL_API}/pages/1.0/${match.id}.json?details=true&images_per_page=12` +
+        `&texts_per_page=20&maps_per_page=0&videos_per_page=0&sounds_per_page=0` +
+        `&vetted=0&common_names=true&taxonomy=true&language=en`
+    );
+    if (!pageResp.ok) {
+      return NextResponse.json({ error: `EOL pages error: ${pageResp.status}` }, { status: pageResp.status });
+    }
+    const pageBody = await pageResp.json();
+    const page: EolPage = pageBody.taxonConcept || {};
+    const objects = page.dataObjects || [];
+
+    // English vernacular names, deduped (case-insensitive). EOL's
+    // `eol_preferred` flag is unreliable (it often favours a non-English name),
+    // so we keep EOL's natural order rather than sorting by it.
+    const seen = new Set<string>();
+    const englishNames: string[] = [];
+    for (const v of page.vernacularNames || []) {
+      if (v.language !== "en") continue;
+      // EOL frequently mislabels non-English names (CJK, Cyrillic, etc.) as
+      // "en"; keep only Latin-script names so the English list stays clean.
+      if (!/^[\p{Script=Latin}\s'.\-()]+$/u.test(v.vernacularName)) continue;
+      const key = v.vernacularName.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      englishNames.push(v.vernacularName);
+    }
+    const otherLanguageCount = new Set(
+      (page.vernacularNames || []).filter((v) => v.language && v.language !== "en").map((v) => v.language)
+    ).size;
+
+    // Brief summary: prefer an English "Brief Summary" article, else any English text.
+    const englishTexts = objects.filter((o) => isText(o) && o.language === "en" && o.description);
+    const summaryObj =
+      englishTexts.find((o) => /brief summary/i.test(o.title || "")) || englishTexts[0];
+    const summary = summaryObj
+      ? {
+          html: summaryObj.description!,
+          title: summaryObj.title || null,
+          source: summaryObj.source || null,
+          license: licenseLabel(summaryObj.license),
+          rightsHolder: summaryObj.rightsHolder || null,
+        }
+      : null;
+
+    // Image gallery with attribution.
+    const images = objects
+      .filter((o) => isImage(o) && (o.eolMediaURL || o.mediaURL))
+      .slice(0, 12)
+      .map((o) => ({
+        url: o.eolMediaURL || o.mediaURL!,
+        thumb: gridThumb(o),
+        title: stripHtml(o.title),
+        rightsHolder: photographer(o),
+        license: licenseLabel(o.license),
+        source: o.source || null,
+      }));
+
+    // Distinct taxonomic data providers EOL aggregates ("according to").
+    const providers = Array.from(
+      new Set((page.taxonConcepts || []).map((t) => t.nameAccordingTo).filter(Boolean) as string[])
+    ).slice(0, 12);
+
+    const result = {
+      found: true,
+      eolId: page.identifier,
+      pageUrl: `https://eol.org/pages/${page.identifier}`,
+      scientificName: page.scientificName || match.title,
+      englishNames,
+      otherLanguageCount,
+      summary,
+      images,
+      providers,
+    };
+
+    eolCache.set(cacheKey, { data: result, timestamp: Date.now() });
+    return NextResponse.json(result, { headers: CACHE_1H });
+  } catch (error) {
+    console.error("Error fetching EOL data:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -184,7 +184,7 @@ export default function RedListPage() {
           >
             CITES
           </a>
-          {" "}and{" "}
+          ,{" "}
           <a
             href="https://speciesplus.net"
             target="_blank"
@@ -192,6 +192,24 @@ export default function RedListPage() {
             className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
           >
             Species+
+          </a>
+          ,{" "}
+          <a
+            href="https://www.catalogueoflife.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
+          >
+            Catalogue of Life
+          </a>
+          {" "}and{" "}
+          <a
+            href="https://eol.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
+          >
+            Encyclopedia of Life
           </a>
           {" "}data. Any errors in aggregation or presentation are my own. Please verify against the primary sources before use, and do get in touch if you notice any issues.
         </p>

--- a/app/src/components/EolSummary.tsx
+++ b/app/src/components/EolSummary.tsx
@@ -11,13 +11,19 @@ interface EolImage {
   source: string | null;
 }
 
+interface EolCommonName {
+  name: string;
+  lang: string;
+}
+
 interface EolSummaryData {
   found: boolean;
   eolId?: number;
   pageUrl?: string;
   scientificName?: string;
-  englishNames?: string[];
-  otherLanguageCount?: number;
+  commonNames?: EolCommonName[];
+  englishNameCount?: number;
+  languageCount?: number;
   summary?: {
     html: string;
     title: string | null;
@@ -37,6 +43,75 @@ function Spinner({ label }: { label: string }) {
         <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
       </svg>
       {label}
+    </div>
+  );
+}
+
+// Render a language code (EOL uses ISO 639-1, mostly) as a human label.
+const langDisplay = (() => {
+  let dn: Intl.DisplayNames | null = null;
+  try {
+    dn = new Intl.DisplayNames(["en"], { type: "language" });
+  } catch {
+    dn = null;
+  }
+  // EOL uses a few non-standard codes; normalize the common ones.
+  const fix: Record<string, string> = { jp: "ja", iw: "he", in: "id" };
+  return (code: string): string => {
+    const c = fix[code] || code;
+    try {
+      return dn?.of(c) || code;
+    } catch {
+      return code;
+    }
+  };
+})();
+
+const NAMES_PER_PAGE = 18;
+
+function CommonNamesList({ names, englishCount, languageCount }: { names: EolCommonName[]; englishCount: number; languageCount: number }) {
+  const [page, setPage] = useState(0);
+  const pageCount = Math.max(1, Math.ceil(names.length / NAMES_PER_PAGE));
+  const safePage = Math.min(page, pageCount - 1);
+  const start = safePage * NAMES_PER_PAGE;
+  const slice = names.slice(start, start + NAMES_PER_PAGE);
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-2 mb-1.5">
+        <div className="text-xs uppercase tracking-wider text-zinc-400">
+          Common names ({names.length})
+          {languageCount > 1 && <span className="normal-case tracking-normal"> · {languageCount} languages</span>}
+        </div>
+        {pageCount > 1 && (
+          <div className="flex items-center gap-1.5 text-xs text-zinc-500 dark:text-zinc-400">
+            <button
+              onClick={() => setPage(safePage - 1)}
+              disabled={safePage === 0}
+              className="px-1.5 py-0.5 rounded disabled:opacity-30 hover:bg-zinc-100 dark:hover:bg-zinc-800 disabled:hover:bg-transparent"
+              aria-label="Previous page"
+            >‹</button>
+            <span className="tabular-nums">{start + 1}–{Math.min(start + NAMES_PER_PAGE, names.length)} of {names.length}</span>
+            <button
+              onClick={() => setPage(safePage + 1)}
+              disabled={safePage >= pageCount - 1}
+              className="px-1.5 py-0.5 rounded disabled:opacity-30 hover:bg-zinc-100 dark:hover:bg-zinc-800 disabled:hover:bg-transparent"
+              aria-label="Next page"
+            >›</button>
+          </div>
+        )}
+      </div>
+      <ul className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-4 gap-y-1">
+        {slice.map((n, i) => (
+          <li key={start + i} className="flex items-baseline justify-between gap-2 text-sm">
+            <span className="text-zinc-700 dark:text-zinc-300 truncate">{n.name}</span>
+            <span className="text-[10px] uppercase tracking-wide text-zinc-400 flex-shrink-0" title={langDisplay(n.lang)}>{n.lang === "en" ? "EN" : langDisplay(n.lang)}</span>
+          </li>
+        ))}
+      </ul>
+      {englishCount === 0 && (
+        <div className="text-[11px] text-zinc-400 mt-1">No English common name recorded; names shown are from other languages.</div>
+      )}
     </div>
   );
 }
@@ -76,7 +151,7 @@ export default function EolSummary({ scientificName }: { scientificName: string 
     );
   }
 
-  const { pageUrl, englishNames = [], otherLanguageCount = 0, summary, images = [], providers = [] } = data;
+  const { pageUrl, commonNames = [], englishNameCount = 0, languageCount = 0, summary, images = [], providers = [] } = data;
 
   return (
     <div className="p-4 space-y-4">
@@ -94,19 +169,9 @@ export default function EolSummary({ scientificName }: { scientificName: string 
         )}
       </div>
 
-      {/* Common names */}
-      {englishNames.length > 0 && (
-        <div>
-          <div className="text-xs uppercase tracking-wider text-zinc-400 mb-1">Common names</div>
-          <div className="flex flex-wrap gap-1.5">
-            {englishNames.slice(0, 12).map((n, i) => (
-              <span key={i} className="px-2 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-800 text-xs text-zinc-700 dark:text-zinc-300">{n}</span>
-            ))}
-          </div>
-          {otherLanguageCount > 0 && (
-            <div className="text-[11px] text-zinc-400 mt-1">+ names in {otherLanguageCount} other languages on EOL</div>
-          )}
-        </div>
+      {/* Common names — paginated, English first, with language labels */}
+      {commonNames.length > 0 && (
+        <CommonNamesList names={commonNames} englishCount={englishNameCount} languageCount={languageCount} />
       )}
 
       {/* Image gallery */}

--- a/app/src/components/EolSummary.tsx
+++ b/app/src/components/EolSummary.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface EolImage {
+  url: string;
+  thumb: string;
+  title: string | null;
+  rightsHolder: string | null;
+  license: string | null;
+  source: string | null;
+}
+
+interface EolSummaryData {
+  found: boolean;
+  eolId?: number;
+  pageUrl?: string;
+  scientificName?: string;
+  englishNames?: string[];
+  otherLanguageCount?: number;
+  summary?: {
+    html: string;
+    title: string | null;
+    source: string | null;
+    license: string | null;
+    rightsHolder: string | null;
+  } | null;
+  images?: EolImage[];
+  providers?: string[];
+}
+
+function Spinner({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 p-6 text-sm text-zinc-500 dark:text-zinc-400">
+      <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+      {label}
+    </div>
+  );
+}
+
+export default function EolSummary({ scientificName }: { scientificName: string }) {
+  const [data, setData] = useState<EolSummaryData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setData(null);
+    (async () => {
+      try {
+        const res = await fetch(`/api/eol?name=${encodeURIComponent(scientificName)}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const result = await res.json();
+        if (!cancelled) setData(result);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Unknown error");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [scientificName]);
+
+  if (loading) return <Spinner label="Loading Encyclopedia of Life data..." />;
+  if (error) return <div className="p-6 text-sm text-red-500 dark:text-red-400">Failed to load EOL data: {error}</div>;
+  if (!data || !data.found) {
+    return (
+      <div className="p-6 text-sm text-zinc-500 dark:text-zinc-400">
+        No Encyclopedia of Life page found for <span className="italic">{scientificName}</span>.
+      </div>
+    );
+  }
+
+  const { pageUrl, englishNames = [], otherLanguageCount = 0, summary, images = [], providers = [] } = data;
+
+  return (
+    <div className="p-4 space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <svg className="w-5 h-5 text-emerald-600 dark:text-emerald-400 flex-shrink-0" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 2C7 2 3 6 3 11c0 5 4 9 9 9 1 0 2-.2 2-.2-.5-2-1.3-3.6-2.4-5C10 12.5 8 11.5 6 11c2.3-.2 4.3.4 6 1.6 1.2-2.3 3.2-4 5.8-5C16.7 4.5 14.5 2 12 2z" />
+        </svg>
+        {pageUrl ? (
+          <a href={pageUrl} target="_blank" rel="noopener noreferrer" className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline">
+            {data.scientificName} — Encyclopedia of Life ↗
+          </a>
+        ) : (
+          <span className="text-sm font-medium text-zinc-700 dark:text-zinc-300">{data.scientificName}</span>
+        )}
+      </div>
+
+      {/* Common names */}
+      {englishNames.length > 0 && (
+        <div>
+          <div className="text-xs uppercase tracking-wider text-zinc-400 mb-1">Common names</div>
+          <div className="flex flex-wrap gap-1.5">
+            {englishNames.slice(0, 12).map((n, i) => (
+              <span key={i} className="px-2 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-800 text-xs text-zinc-700 dark:text-zinc-300">{n}</span>
+            ))}
+          </div>
+          {otherLanguageCount > 0 && (
+            <div className="text-[11px] text-zinc-400 mt-1">+ names in {otherLanguageCount} other languages on EOL</div>
+          )}
+        </div>
+      )}
+
+      {/* Image gallery */}
+      {images.length > 0 && (
+        <div>
+          <div className="text-xs uppercase tracking-wider text-zinc-400 mb-1.5">Images ({images.length})</div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2">
+            {images.map((img, i) => (
+              <a key={i} href={pageUrl ?? img.url} target="_blank" rel="noopener noreferrer" className="group block" title={img.title ?? undefined}>
+                <img src={img.thumb} alt={img.title ?? data.scientificName ?? "EOL image"} loading="lazy" className="w-full h-28 object-cover rounded border border-zinc-200 dark:border-zinc-700" />
+                <div className="text-[10px] text-zinc-400 mt-0.5 truncate">
+                  {img.rightsHolder ?? "Unknown"}{img.license ? ` · ${img.license}` : ""}
+                </div>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Brief summary */}
+      {summary && (
+        <div>
+          <div className="text-xs uppercase tracking-wider text-zinc-400 mb-1">{summary.title || "Summary"}</div>
+          <div
+            className="eol-content text-sm leading-relaxed text-zinc-700 dark:text-zinc-300 [&_p]:mb-2 [&_a]:text-blue-600 dark:[&_a]:text-blue-400 [&_a:hover]:underline [&_i]:italic [&_b]:font-semibold [&_img]:hidden"
+            dangerouslySetInnerHTML={{ __html: summary.html }}
+          />
+          {(summary.source || summary.rightsHolder || summary.license) && (
+            <div className="text-[10px] text-zinc-400 mt-1">
+              {[summary.rightsHolder, summary.source, summary.license].filter(Boolean).join(" · ")}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Data providers */}
+      {providers.length > 0 && (
+        <div>
+          <div className="text-xs uppercase tracking-wider text-zinc-400 mb-1">Data providers ({providers.length})</div>
+          <div className="text-xs text-zinc-500 dark:text-zinc-400 leading-relaxed">{providers.join(" · ")}</div>
+        </div>
+      )}
+
+      <p className="text-[10px] text-zinc-400 dark:text-zinc-500">
+        Data from the <a href={pageUrl} target="_blank" rel="noopener noreferrer" className="hover:underline">Encyclopedia of Life</a>. Image rights belong to their respective holders.
+      </p>
+    </div>
+  );
+}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -8,6 +8,7 @@ import NewLiteratureSinceAssessment from "../LiteratureSearch";
 import RedListAssessments from "../RedListAssessments";
 import CitesSummary from "../CitesSummary";
 import WikipediaSummary from "../WikipediaSummary";
+import EolSummary from "../EolSummary";
 import TaxaIcon from "../TaxaIcon";
 import { ALPHA2_TO_NAME } from "../WorldMap";
 import { CATEGORY_COLORS, TAXA_BY_ID } from "@/config/taxa";
@@ -788,7 +789,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
 
   // Row expansion state (initialized from URL params if present)
   const [selectedSpeciesKey, setSelectedSpeciesKeyRaw] = useState<number | null>(urlSpecies != null && isNewAssessments ? Math.abs(urlSpecies) : urlSpecies);
-  const [activeDetailTab, setActiveDetailTabRaw] = useState<"gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "col">(urlTab ?? "gbif");
+  const [activeDetailTab, setActiveDetailTabRaw] = useState<"gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "col" | "eol">(urlTab ?? "gbif");
   // Track which tabs have been visited so we only mount (and fetch data for) a tab on first click
   const [visitedTabs, setVisitedTabs] = useState<Set<string>>(new Set([urlTab ?? "gbif"]));
   const urlSpeciesHandledRef = useRef(false);
@@ -805,7 +806,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     }
   }, [setSpeciesParam]);
 
-  const setActiveDetailTab = useCallback((tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "col") => {
+  const setActiveDetailTab = useCallback((tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "col" | "eol") => {
     setActiveDetailTabRaw(tab);
     programmaticTabChangeRef.current = true;
     setTabParam(tab);
@@ -3410,6 +3411,12 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                                   Catalogue of Life
                                 </button>
                                 <button
+                                  className={`px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "eol" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
+                                  onClick={() => setActiveDetailTab("eol")}
+                                >
+                                  Encyclopedia of Life
+                                </button>
+                                <button
                                   className={`px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "wikipedia" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
                                   onClick={() => setActiveDetailTab("wikipedia")}
                                 >
@@ -3516,6 +3523,11 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                             </div>
                             );
                           })()}
+                          {(stackedDetailView || visitedTabs.has("eol")) && (
+                            <div style={{ display: stackedDetailView || activeDetailTab === "eol" ? undefined : "none" }}>
+                              <EolSummary scientificName={s.scientific_name} />
+                            </div>
+                          )}
                           {s.category !== "NE" && (stackedDetailView || visitedTabs.has("redlist")) && (
                             <div style={{ display: stackedDetailView || activeDetailTab === "redlist" ? undefined : "none" }}>
                               <RedListAssessments

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -73,7 +73,7 @@ export function parseParams(search: string) {
     ) as "year" | "category" | "totalGbif" | "newGbif" | "pctNewGbif" | "describedYear" | null,
     sortDirection: (p.get("dir") === "asc" ? "asc" : "desc") as "asc" | "desc",
     species: p.get("species") ? Number(p.get("species")) : null,
-    tab: (p.get("tab") || null) as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "col" | null,
+    tab: (p.get("tab") || null) as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "col" | "eol" | null,
   };
 }
 
@@ -99,7 +99,7 @@ export function buildQs(state: {
   sortField: "year" | "category" | "totalGbif" | "newGbif" | "pctNewGbif" | "describedYear" | null;
   sortDirection: "asc" | "desc";
   species: number | null;
-  tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "col" | null;
+  tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "col" | "eol" | null;
 }): string {
   const p = new URLSearchParams();
   if (state.viewMode === "new-assessments") p.set("view", "new-assessments");
@@ -401,7 +401,7 @@ export function useFilterParams() {
   );
 
   const setSpeciesParam = useCallback(
-    (species: number | null, tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "col" = "gbif") => {
+    (species: number | null, tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "col" | "eol" = "gbif") => {
       setState(prev => {
         const next = { ...prev, species, tab: species != null ? tab : null };
         queueMicrotask(() => syncUrl(next, true));
@@ -412,7 +412,7 @@ export function useFilterParams() {
   );
 
   const setTabParam = useCallback(
-    (tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "col") => {
+    (tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "col" | "eol") => {
       setState(prev => {
         if (prev.species == null) return prev; // no species selected, nothing to update
         const next = { ...prev, tab };


### PR DESCRIPTION
## Summary

Prototype adding an **Encyclopedia of Life** tab next to **Catalogue of Life** in the species detail panel. EOL's distinctive value is its aggregated, attributed image gallery plus vernacular names and the taxonomic data providers it federates — complementary to the existing Wikipedia (prose) and CoL (synonyms) tabs, not redundant.

This fits the existing architecture cleanly: the detail panel already renders sibling tabs (GBIF+iNat, Literature, IUCN Red List, CITES, Catalogue of Life, Wikipedia), each backed by a self-contained component or a server proxy route. This follows that exact pattern.

## Changes

- **`/api/eol` proxy route** — modeled on `/api/cites`. EOL's API returns no CORS headers, so a client-side fetch (like Wikipedia's) is blocked and a server proxy is required. Resolves a scientific name → EOL page id → page details, and normalizes to English vernacular names, an attributed image gallery (URL + photographer + license), an optional English summary, and the taxonomic data providers EOL federates. 1h in-memory + edge cache.
- **`EolSummary` component** — self-contained, keyed on scientific name, matching the loading/error/empty conventions of `WikipediaSummary`/`CitesSummary`.
- **Wiring** — new `"eol"` tab between Catalogue of Life and Wikipedia in `RedListView`, lazy-mounted like the others; tab union type extended in `useFilterParams` so the tab is URL-shareable.

## Verification

- `tsc --noEmit` clean, `eslint` clean.
- Live API calls against *Panthera leo*, *Loxodonta africana*, *Ursus maritimus*, *Gorilla gorilla* all return correctly (12 attributed images + 12 providers each); a no-match name returns `found: false`; home page compiles and serves 200.
- No UI screenshot: the build sandbox has no Chromium binary and browser downloads are blocked, so verification is at the API + typecheck/lint level. The component reuses the proven `WikipediaSummary`/`CitesSummary` panel structure.

## Known limitations (EOL data quality)

- **Vernacular names are noisy.** EOL frequently mislabels non-English names (CJK, Cyrillic, Indonesian, etc.) as English, and its `eol_preferred` flag is unreliable (it flagged Japanese as preferred for "lion"). The route filters to Latin-script names and keeps EOL's natural order — a heuristic, so a stray non-English Latin name can still slip through.
- **English summary text is often absent** (e.g. lions, elephants have none in EOL), so the panel hides that section when missing.
- Image attribution sometimes arrives as HTML, which is stripped server-side.

## Possible next step: EOL TraitBank

EOL also exposes structured **TraitBank** data (body mass, habitat, lifespan, etc.) via a separate Cypher API. This is potentially the most novel addition — structured traits not surfaced anywhere else in the dashboard — but a meaningfully larger effort than this prototype, so it's left out of scope here and flagged for a follow-up if of interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1RjzoBRebugidWHALQwfa

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1RjzoBRebugidWHALQwfa)_