### PR TITLE
Use distinct on-page title for dashoflife

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -47,7 +47,7 @@ export default function RedListPage() {
         {/* Header row: title + view mode toggle */}
         <div className="mb-3 md:mb-4 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
           <h1 className="text-xl sm:text-2xl md:text-3xl font-bold text-zinc-900 dark:text-zinc-100">
-            {brand.title}
+            {brand.pageTitle ?? brand.title}
           </h1>
           <div className="flex items-center gap-2 shrink-0">
             {/* View mode toggle */}

--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -1,5 +1,7 @@
 export type Brand = {
   title: string;
+  /** On-page heading. Falls back to `title` when omitted. */
+  pageTitle?: string;
   description: string;
 };
 
@@ -12,6 +14,7 @@ const DEFAULT_BRAND: Brand = {
 const BRANDS: Record<string, Brand> = {
   "dashoflife.org": {
     title: "Dashboard of Life",
+    pageTitle: "A Dashboard of Life on Earth",
     description: "IUCN Red List and GBIF occurrence data explorer",
   },
 };


### PR DESCRIPTION
Add an optional pageTitle to the brand config so the dashoflife.org
page heading reads "A Dashboard of Life on Earth" while the browser
tab continues to show "Dashboard of Life".

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013cbFDPoLtrNQTkyM5nVFBV