### PR TITLE
Revert dashoflife page title to "Dashboard of Life"

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -47,7 +47,7 @@ export default function RedListPage() {
         {/* Header row: title + view mode toggle */}
         <div className="mb-3 md:mb-4 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
           <h1 className="text-xl sm:text-2xl md:text-3xl font-bold text-zinc-900 dark:text-zinc-100">
-            {brand.pageTitle ?? brand.title}
+            {brand.title}
           </h1>
           <div className="flex items-center gap-2 shrink-0">
             {/* View mode toggle */}

--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -1,7 +1,5 @@
 export type Brand = {
   title: string;
-  /** On-page heading. Falls back to `title` when omitted. */
-  pageTitle?: string;
   description: string;
 };
 
@@ -14,7 +12,6 @@ const DEFAULT_BRAND: Brand = {
 const BRANDS: Record<string, Brand> = {
   "dashoflife.org": {
     title: "Dashboard of Life",
-    pageTitle: "A Dashboard of Life on Earth",
     description: "IUCN Red List and GBIF occurrence data explorer",
   },
 };


### PR DESCRIPTION
Reverts the on-page title change for `dashoflife.org`.

This undoes the `pageTitle: "A Dashboard of Life on Earth"` override (added in #318), restoring the original title "Dashboard of Life" on the page. The `pageTitle` field is removed from the `Brand` type and the page heading goes back to using `brand.title`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013cbFDPoLtrNQTkyM5nVFBV)_