### PR TITLE
Single flat taxa param in the dashboard URL

### DIFF
--- a/app/src/config/__tests__/taxonomy-tree.test.ts
+++ b/app/src/config/__tests__/taxonomy-tree.test.ts
@@ -803,3 +803,46 @@ describe("node-children-summaries.json", () => {
     }
   });
 });
+
+// ─── Flat taxa-token URL mapping (the single-`taxa`-param invariant) ────────
+
+import {
+  stripNodePrefix,
+  expandTaxaToken,
+  collapseTaxaToTokens,
+  getViewRootForNode,
+} from "@/lib/taxonomy-utils";
+
+describe("flat taxa-token mapping is a bijection over the default view", () => {
+  // Every default-view node (a display root or a node under one) must round-trip
+  // through its flat URL token. If a future tree change makes two nodes share a
+  // token, this fails in CI instead of silently emitting a wrong-taxon URL.
+  it("each default-view node round-trips: node → token → node", () => {
+    const collisions: string[] = [];
+    for (const id of NODE_INDEX.keys()) {
+      if (!getViewRootForNode(id)) continue; // skip nodes outside the default view
+      const { taxa, subgroup } = expandTaxaToken(stripNodePrefix(id));
+      const resolved = subgroup ?? taxa;
+      if (resolved !== id) collisions.push(`${id} → '${stripNodePrefix(id)}' → ${resolved}`);
+    }
+    expect(collisions).toEqual([]);
+  });
+
+  it("collapse ∘ expand is identity for a root + sub-group selection", () => {
+    // Sample a few representative pairs across the prefixed roots.
+    const cases: Array<[string, string]> = [
+      ["invertebrates", "inv-corals"],
+      ["invertebrates", "inv-beetles"],
+      ["fishes", "sharks-rays"],
+      ["plantae", "pl-flowering_plants"],
+      ["fungi", "fu-mushrooms"],
+    ];
+    for (const [root, sg] of cases) {
+      const tokens = collapseTaxaToTokens([root], [sg]);
+      expect(tokens).toEqual([stripNodePrefix(sg)]);
+      const { taxa, subgroup } = expandTaxaToken(tokens[0]);
+      expect(taxa).toBe(root);
+      expect(subgroup).toBe(sg);
+    }
+  });
+});

--- a/app/src/hooks/__tests__/filterParams.test.ts
+++ b/app/src/hooks/__tests__/filterParams.test.ts
@@ -33,18 +33,30 @@ describe("parseParams", () => {
     expect(result.taxa).toEqual(new Set(["mammals", "birds"]));
   });
 
-  it("maps legacy taxa IDs to current ones (back-compat for old URLs)", () => {
-    const result = parseParams("?taxa=mammalia,aves,reptilia,amphibia,arachnida,mollusca,crustacea");
-    expect(result.taxa).toEqual(
-      new Set(["mammals", "birds", "reptiles", "amphibians", "arachnids", "molluscs", "crustaceans"])
-    );
+  it("maps legacy vertebrate taxa IDs to current root ids (back-compat for old URLs)", () => {
+    const result = parseParams("?taxa=mammalia,aves,reptilia,amphibia");
+    expect(result.taxa).toEqual(new Set(["mammals", "birds", "reptiles", "amphibians"]));
+    expect(result.subgroups.size).toBe(0);
   });
 
-  it("leaves unchanged and unknown taxa IDs as-is, and dedupes legacy+current", () => {
-    // legacy latin ids collapse to current ones (mammalia → mammals, dedup; insecta →
-    // insects); beetles unchanged; unknown passes through.
+  it("expands legacy invertebrate taxa tokens to invertebrates + sub-group", () => {
+    // arachnida/mollusca/crustacea map to groups stored under `invertebrates`, so a
+    // single flat token expands to the root + its sub-group node.
+    const result = parseParams("?taxa=arachnida,mollusca,crustacea");
+    expect(result.taxa).toEqual(new Set(["invertebrates"]));
+    expect(result.subgroups).toEqual(new Set(["inv-arachnids", "inv-molluscs", "inv-crustaceans"]));
+  });
+
+  it("dedupes roots, expands group tokens, and passes unknown tokens through", () => {
     const result = parseParams("?taxa=mammalia,mammals,insecta,beetles,unknownthing");
-    expect(result.taxa).toEqual(new Set(["mammals", "insects", "beetles", "unknownthing"]));
+    expect(result.taxa).toEqual(new Set(["mammals", "invertebrates", "unknownthing"]));
+    expect(result.subgroups).toEqual(new Set(["inv-insects", "inv-beetles"]));
+  });
+
+  it("expands a single flat group token (corals → invertebrates + inv-corals)", () => {
+    const result = parseParams("?taxa=corals");
+    expect(result.taxa).toEqual(new Set(["invertebrates"]));
+    expect(result.subgroups).toEqual(new Set(["inv-corals"]));
   });
 
   it("maps legacy IDs in the subgroups param too", () => {
@@ -303,18 +315,27 @@ describe("buildQs", () => {
     expect(params.get("search")).toBe("elephant");
   });
 
-  it("includes subgroups when set", () => {
+  it("collapses a sub-group into the flat taxa token (no subgroups param)", () => {
     const qs = buildQs({ ...emptyState, subgroups: new Set(["sharks-rays"]) });
     const params = new URLSearchParams(qs);
-    expect(params.get("subgroups")).toBe("sharks-rays");
+    expect(params.get("taxa")).toBe("sharks-rays");
+    expect(params.has("subgroups")).toBe(false);
   });
 
-  it("includes multiple subgroups", () => {
+  it("collapses multiple sub-groups into the flat taxa list", () => {
     const qs = buildQs({ ...emptyState, subgroups: new Set(["sharks-rays", "ray-finned-fishes"]) });
     const params = new URLSearchParams(qs);
-    const sgs = params.get("subgroups")!.split(",");
-    expect(sgs).toContain("sharks-rays");
-    expect(sgs).toContain("ray-finned-fishes");
+    const t = params.get("taxa")!.split(",");
+    expect(t).toContain("sharks-rays");
+    expect(t).toContain("ray-finned-fishes");
+    expect(params.has("subgroups")).toBe(false);
+  });
+
+  it("collapses root + sub-group to a single flat token (invertebrates + inv-corals → corals)", () => {
+    const qs = buildQs({ ...emptyState, taxa: new Set(["invertebrates"]), subgroups: new Set(["inv-corals"]) });
+    const params = new URLSearchParams(qs);
+    expect(params.get("taxa")).toBe("corals");
+    expect(params.has("subgroups")).toBe(false);
   });
 
   it("omits subgroups when empty", () => {

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { canonicalizeTaxonId } from "@/lib/data/taxonomy-constants";
 import { resolveRegions } from "@/lib/regions";
+import { expandTaxaToken, collapseTaxaToTokens, getViewRootForNode } from "@/lib/taxonomy-utils";
 
 // --- URL parsing helpers ---
 
@@ -46,15 +47,27 @@ export function parseParams(search: string) {
   if (p.get("region")) {
     resolveRegions(p.get("region")!.split(",").filter(Boolean)).codes.forEach((c) => countryCodes.add(c));
   }
+  // Taxa: the URL carries a single flat `taxa` token list; expand each into the
+  // internal display-root + (optional) sub-group. Legacy `subgroups=` links still
+  // parse (their values are added directly, with the parent root ensured present).
+  const taxaSet = new Set<string>();
+  const subgroupSet = new Set<string>();
+  for (const tok of p.get("taxa")?.split(",").filter(Boolean) ?? []) {
+    const { taxa, subgroup } = expandTaxaToken(tok);
+    taxaSet.add(taxa);
+    if (subgroup) subgroupSet.add(subgroup);
+  }
+  for (const sg of p.get("subgroups")?.split(",").filter(Boolean) ?? []) {
+    const id = canonicalizeTaxonId(sg);
+    subgroupSet.add(id);
+    const root = getViewRootForNode(id);
+    if (root) taxaSet.add(root);
+  }
   return {
     viewMode: (viewParam === "new-assessments" ? "new-assessments" : "reassessments") as ViewMode,
-    // Map legacy IDs (e.g. mammalia → mammals) so old shared/bookmarked URLs keep working.
-    taxa: p.get("taxa")
-      ? new Set(p.get("taxa")!.split(",").filter(Boolean).map(canonicalizeTaxonId))
-      : new Set<string>(),
-    subgroups: p.get("subgroups")
-      ? new Set(p.get("subgroups")!.split(",").filter(Boolean).map(canonicalizeTaxonId))
-      : new Set<string>(),
+    // Expanded from the flat `taxa` token list (+ legacy `subgroups=`) above.
+    taxa: taxaSet,
+    subgroups: subgroupSet,
     categories: p.get("categories")
       ? new Set(p.get("categories")!.split(",").filter(Boolean))
       : new Set<string>(),
@@ -151,8 +164,10 @@ export function buildQs(state: {
 }): string {
   const p = new URLSearchParams();
   if (state.viewMode === "new-assessments") p.set("view", "new-assessments");
-  if (state.taxa.size > 0) p.set("taxa", [...state.taxa].join(","));
-  if (state.subgroups.size > 0) p.set("subgroups", [...state.subgroups].join(","));
+  // taxa + subgroups collapse to a single flat `taxa` token list (e.g.
+  // invertebrates + inv-corals → taxa=corals); no separate subgroups param.
+  const taxaTokens = collapseTaxaToTokens(state.taxa, state.subgroups);
+  if (taxaTokens.length > 0) p.set("taxa", taxaTokens.join(","));
   if (state.categories.size > 0) p.set("categories", [...state.categories].join(","));
   if (state.yearRanges.size > 0) p.set("years", [...state.yearRanges].join(","));
   if (state.assessmentYears.size > 0) p.set("assessmentYears", [...state.assessmentYears].join(","));

--- a/app/src/lib/__tests__/dashboard-url.test.ts
+++ b/app/src/lib/__tests__/dashboard-url.test.ts
@@ -24,7 +24,15 @@ describe("browseInputToDashboardQuery", () => {
   it("maps a curated sub-group to subgroups + its display root in taxa", () => {
     const p = params({ taxa: ["sharks-rays"] });
     expect(p.get("subgroups")).toBe("sharks-rays");
-    expect(p.get("taxa")).toBeTruthy(); // the parent display root, so its species load
+    expect(p.get("taxa")).toBe("fishes");
+  });
+
+  it("maps a Table-1a group under a virtual root to root + prefixed sub-group", () => {
+    // corals species carry taxon_id=invertebrates, so taxa=corals alone matches
+    // nothing — the dashboard's working form is invertebrates + inv-corals.
+    const p = params({ taxa: ["corals"] });
+    expect(p.get("taxa")).toBe("invertebrates");
+    expect(p.get("subgroups")).toBe("inv-corals");
   });
 
   it("resolves category aliases (threatened → CR,EN,VU)", () => {

--- a/app/src/lib/__tests__/dashboard-url.test.ts
+++ b/app/src/lib/__tests__/dashboard-url.test.ts
@@ -21,18 +21,13 @@ describe("browseInputToDashboardQuery", () => {
     expect(p.has("subgroups")).toBe(false);
   });
 
-  it("maps a curated sub-group to subgroups + its display root in taxa", () => {
-    const p = params({ taxa: ["sharks-rays"] });
-    expect(p.get("subgroups")).toBe("sharks-rays");
-    expect(p.get("taxa")).toBe("fishes");
-  });
-
-  it("maps a Table-1a group under a virtual root to root + prefixed sub-group", () => {
-    // corals species carry taxon_id=invertebrates, so taxa=corals alone matches
-    // nothing — the dashboard's working form is invertebrates + inv-corals.
+  it("emits taxa as a single flat token list (no subgroups param)", () => {
+    // The dashboard's parseParams expands these tokens (corals → invertebrates +
+    // inv-corals; sharks-rays → fishes + sharks-rays) — see the round-trip below.
+    expect(params({ taxa: ["sharks-rays"] }).get("taxa")).toBe("sharks-rays");
     const p = params({ taxa: ["corals"] });
-    expect(p.get("taxa")).toBe("invertebrates");
-    expect(p.get("subgroups")).toBe("inv-corals");
+    expect(p.get("taxa")).toBe("corals");
+    expect(p.has("subgroups")).toBe(false);
   });
 
   it("resolves category aliases (threatened → CR,EN,VU)", () => {
@@ -112,5 +107,15 @@ describe("browseInputToDashboardQuery → parseParams round-trip", () => {
     const qs = browseInputToDashboardQuery({ taxa: ["amphibians"], region: ["Sub-Saharan Africa"] });
     const parsed = parseParams(qs);
     expect(parsed.countries.size).toBeGreaterThan(0);
+  });
+
+  it("a flat group token expands to the dashboard's root + sub-group selection", () => {
+    // The agent emits taxa=corals; the dashboard expands it to the working
+    // invertebrates + inv-corals — so the link reproduces the same view.
+    const qs = browseInputToDashboardQuery({ taxa: ["corals"] });
+    expect(qs).toBe("?taxa=corals");
+    const parsed = parseParams(qs);
+    expect(parsed.taxa).toEqual(new Set(["invertebrates"]));
+    expect(parsed.subgroups).toEqual(new Set(["inv-corals"]));
   });
 });

--- a/app/src/lib/dashboard-url.ts
+++ b/app/src/lib/dashboard-url.ts
@@ -30,21 +30,44 @@ import {
   resolveTaxa, resolveCategories, resolveThreats, resolveCountries,
 } from "@/lib/filter-vocab";
 import { resolveRegions } from "@/lib/regions";
-import { findNode, getViewRootForNode } from "@/lib/taxonomy-utils";
+import { findNode } from "@/lib/taxonomy-utils";
+import { TAXONOMY_VIEWS } from "@/config/taxonomy-views";
 
 const arr = (a?: string[]) => (a ?? []).map((s) => s.trim()).filter(Boolean);
 
-// Split resolved taxon ids into the dashboard's `taxa` (display roots + arbitrary
-// scientific ranks) vs `subgroups` (a curated node below a display root, which
-// also needs its root selected so the parent's species load).
+// The dashboard's default view shows 8 roots; the invertebrate/plant/fungi
+// Table-1a groups (corals, insects, …) are cloned UNDER those roots with these
+// prefixes (e.g. corals → inv-corals).
+const DEFAULT_ROOTS = TAXONOMY_VIEWS.default.roots;
+const stripNodePrefix = (id: string) => id.replace(/^(inv-|pl-|fu-)/, "");
+
+// Resolve a taxon id to the dashboard's (taxa, subgroup) selection — mirroring
+// its own click logic (TaxaSummary), so a link reproduces the dashboard's native
+// view rather than a form it can't match:
+//   - a default-view root (mammals, fishes, invertebrates) → `taxa` directly;
+//   - a Table-1a group under a virtual root (corals/insects/… under
+//     `invertebrates`; plants under `plantae`; fungi under `fungi`) → that root in
+//     `taxa` + the matching sub-group node. This is REQUIRED: species rows carry
+//     the root's taxon_id (mapTaxonId: corals → invertebrates), so `taxa=corals`
+//     alone matches nothing;
+//   - a vertebrate sub-group (e.g. `sharks-rays` under `fishes`) → root + subgroup;
+//   - an arbitrary scientific rank (`felidae`) has no node → passed through as
+//     `taxa` (the dashboard matches it by class/order/family).
 function splitTaxa(ids: string[]): { taxa: string[]; subgroups: string[] } {
   const taxa = new Set<string>();
   const subgroups = new Set<string>();
   for (const id of ids) {
-    if (!findNode(id)) { taxa.add(id); continue; } // arbitrary scientific rank
-    const root = getViewRootForNode(id);
-    if (root && root !== id) { subgroups.add(id); taxa.add(root); }
-    else taxa.add(id); // a display root (or a node outside the default view)
+    if (DEFAULT_ROOTS.includes(id)) { taxa.add(id); continue; }
+    let matched = false;
+    for (const rootId of DEFAULT_ROOTS) {
+      const root = findNode(rootId);
+      const child =
+        root?.children?.find((c) => stripNodePrefix(c.id) === id) ??
+        root?.children?.find((c) => c.filter.csvGroups.length === 1 && c.filter.csvGroups[0] === id) ??
+        root?.children?.find((c) => c.filter.csvGroups.includes(id));
+      if (child) { taxa.add(rootId); subgroups.add(child.id); matched = true; break; }
+    }
+    if (!matched) taxa.add(id); // a scientific rank, or a node with no default-view home
   }
   return { taxa: [...taxa], subgroups: [...subgroups] };
 }

--- a/app/src/lib/dashboard-url.ts
+++ b/app/src/lib/dashboard-url.ts
@@ -17,10 +17,10 @@
  *    `minDescribedYear`/`maxDescribedYear` → emitted as exact URL params. The
  *    dashboard's on-screen charts use coarse buckets; these URL-only params feed
  *    the exact same numeric/`isOutdated` predicate so the result is identical.
- *  - a curated sub-group taxon (e.g. `sharks-rays`) → `subgroups=<id>` plus its
- *    display-root in `taxa` (the dashboard filters sub-groups out of the parent's
- *    loaded set); a scientific-rank taxon (e.g. `felidae`) → `taxa=<id>` (matched
- *    by class/order/family); a featured group → `taxa=<id>`.
+ *  - taxa are emitted as a single flat token list (`taxa=corals,felidae`); the
+ *    dashboard's parseParams expands each token to its display-root + sub-group
+ *    (corals → invertebrates + inv-corals) — see taxonomy-utils. A scientific-rank
+ *    taxon (`felidae`) has no node and is matched by class/order/family.
  *  - `assessors`/`reviewers`: both surfaces case-insensitively SUBSTRING-match the
  *    name (the dashboard predicate mirrors /browse), so a partial name selects the
  *    same species set in each.
@@ -30,47 +30,8 @@ import {
   resolveTaxa, resolveCategories, resolveThreats, resolveCountries,
 } from "@/lib/filter-vocab";
 import { resolveRegions } from "@/lib/regions";
-import { findNode } from "@/lib/taxonomy-utils";
-import { TAXONOMY_VIEWS } from "@/config/taxonomy-views";
 
 const arr = (a?: string[]) => (a ?? []).map((s) => s.trim()).filter(Boolean);
-
-// The dashboard's default view shows 8 roots; the invertebrate/plant/fungi
-// Table-1a groups (corals, insects, …) are cloned UNDER those roots with these
-// prefixes (e.g. corals → inv-corals).
-const DEFAULT_ROOTS = TAXONOMY_VIEWS.default.roots;
-const stripNodePrefix = (id: string) => id.replace(/^(inv-|pl-|fu-)/, "");
-
-// Resolve a taxon id to the dashboard's (taxa, subgroup) selection — mirroring
-// its own click logic (TaxaSummary), so a link reproduces the dashboard's native
-// view rather than a form it can't match:
-//   - a default-view root (mammals, fishes, invertebrates) → `taxa` directly;
-//   - a Table-1a group under a virtual root (corals/insects/… under
-//     `invertebrates`; plants under `plantae`; fungi under `fungi`) → that root in
-//     `taxa` + the matching sub-group node. This is REQUIRED: species rows carry
-//     the root's taxon_id (mapTaxonId: corals → invertebrates), so `taxa=corals`
-//     alone matches nothing;
-//   - a vertebrate sub-group (e.g. `sharks-rays` under `fishes`) → root + subgroup;
-//   - an arbitrary scientific rank (`felidae`) has no node → passed through as
-//     `taxa` (the dashboard matches it by class/order/family).
-function splitTaxa(ids: string[]): { taxa: string[]; subgroups: string[] } {
-  const taxa = new Set<string>();
-  const subgroups = new Set<string>();
-  for (const id of ids) {
-    if (DEFAULT_ROOTS.includes(id)) { taxa.add(id); continue; }
-    let matched = false;
-    for (const rootId of DEFAULT_ROOTS) {
-      const root = findNode(rootId);
-      const child =
-        root?.children?.find((c) => stripNodePrefix(c.id) === id) ??
-        root?.children?.find((c) => c.filter.csvGroups.length === 1 && c.filter.csvGroups[0] === id) ??
-        root?.children?.find((c) => c.filter.csvGroups.includes(id));
-      if (child) { taxa.add(rootId); subgroups.add(child.id); matched = true; break; }
-    }
-    if (!matched) taxa.add(id); // a scientific rank, or a node with no default-view home
-  }
-  return { taxa: [...taxa], subgroups: [...subgroups] };
-}
 
 /**
  * Build the dashboard query string (`?…`, or `""` when nothing resolved) that
@@ -84,12 +45,10 @@ export function browseInputToDashboardQuery(input: BrowseInput): string {
     p.set("search", input.search.trim());
   }
 
+  // A single flat `taxa` token list (e.g. corals, felidae); the dashboard's
+  // parseParams expands each token to its display-root + sub-group as needed.
   const taxaIds = resolveTaxa(arr(input.taxa)).ids;
-  if (taxaIds.length) {
-    const { taxa, subgroups } = splitTaxa(taxaIds);
-    if (taxa.length) p.set("taxa", taxa.join(","));
-    if (subgroups.length) p.set("subgroups", subgroups.join(","));
-  }
+  if (taxaIds.length) p.set("taxa", taxaIds.join(","));
 
   const categories = resolveCategories(arr(input.categories)).codes;
   if (categories.length) p.set("categories", categories.join(","));

--- a/app/src/lib/taxonomy-utils.ts
+++ b/app/src/lib/taxonomy-utils.ts
@@ -72,6 +72,72 @@ export function getViewRootForNode(nodeId: string): string | null {
   return null;
 }
 
+// ─── Flat taxa-token URL mapping ─────────────────────────────────────────
+//
+// The URL carries a single, flat `taxa` list. Internally a selection is a
+// display-root + (optional) sub-group node (e.g. `invertebrates` + `inv-corals`,
+// because species rows store the coarse root taxon_id: corals → invertebrates).
+// These helpers translate between the two so the URL stays clean while the
+// dashboard's two-level model is unchanged.
+//
+// A node's flat token is its id with the virtual-root prefix stripped
+// (inv-corals → corals); display roots and arbitrary scientific ranks are their
+// own token. The token↔node mapping must be a bijection over the default view —
+// enforced by a whole-tree round-trip test (taxonomy-tree.test.ts).
+
+const NODE_ID_PREFIX_RE = /^(inv-|pl-|fu-)/;
+
+/** A node id with its virtual-root prefix (inv-/pl-/fu-) removed. */
+export const stripNodePrefix = (id: string) => id.replace(NODE_ID_PREFIX_RE, "");
+
+// token → default-view sub-group node id (built once at import). Only nodes BELOW
+// a default root are indexed; the flat Table-1a clones live under `all` and are
+// excluded (getViewRootForNode === null), so a token never resolves to one.
+const DEFAULT_VIEW_TOKEN_INDEX = new Map<string, string>();
+for (const id of NODE_INDEX.keys()) {
+  if (DEFAULT_VIEW_ROOTS.has(id)) continue;
+  if (!getViewRootForNode(id)) continue;
+  const token = stripNodePrefix(id);
+  if (!DEFAULT_VIEW_TOKEN_INDEX.has(token)) DEFAULT_VIEW_TOKEN_INDEX.set(token, id);
+}
+
+/**
+ * Expand one flat URL token into the internal selection it represents:
+ * `{ taxa }` for a display root or an arbitrary scientific rank, or
+ * `{ taxa, subgroup }` for a default-view sub-group (corals → invertebrates +
+ * inv-corals). Accepts legacy/prefixed ids too (canonicalized first).
+ */
+export function expandTaxaToken(token: string): { taxa: string; subgroup?: string } {
+  const id = canonicalizeTaxonId(token.trim());
+  if (DEFAULT_VIEW_ROOTS.has(id)) return { taxa: id };
+  const nodeId = DEFAULT_VIEW_TOKEN_INDEX.get(id) ?? DEFAULT_VIEW_TOKEN_INDEX.get(stripNodePrefix(id));
+  if (nodeId) {
+    const root = getViewRootForNode(nodeId);
+    if (root) return { taxa: root, subgroup: nodeId };
+  }
+  return { taxa: id }; // a display root outside the default view, or an arbitrary rank
+}
+
+/**
+ * Collapse an internal taxa + subgroups selection into the flat URL token list.
+ * A selected sub-group is emitted as its token (and its root is dropped, since the
+ * sub-group implies it); a root with no sub-group is emitted whole.
+ */
+export function collapseTaxaToTokens(taxa: Iterable<string>, subgroups: Iterable<string>): string[] {
+  const tokens = new Set<string>();
+  const rootsWithSubgroup = new Set<string>();
+  for (const sg of subgroups) {
+    tokens.add(stripNodePrefix(sg));
+    const root = getViewRootForNode(sg);
+    if (root) rootsWithSubgroup.add(root);
+  }
+  for (const t of taxa) {
+    if (rootsWithSubgroup.has(t)) continue; // represented by its sub-group token(s)
+    tokens.add(stripNodePrefix(t));
+  }
+  return [...tokens];
+}
+
 // ─── CSV group resolution ────────────────────────────────────────────
 
 /** Get the CSV groups needed to load data for a node. */


### PR DESCRIPTION
Follow-up to #313. Makes the dashboard URL use a **single, flat `taxa` param** — `taxa=corals` instead of `taxa=invertebrates&subgroups=inv-corals` — for both the dashboard's own URLs and the agent `dashboard_url`.

## Background

Groups like corals/insects/molluscs aren't top-level taxa in the dashboard's data model: species rows store the **coarse root** `taxon_id` (`mapTaxonId: corals → invertebrates`, `taxonomy-constants.ts`), and the default view nests them under `invertebrates` as `inv-corals`. So the dashboard represents corals as `taxa=invertebrates&subgroups=inv-corals`, and a bare `taxa=corals` matches **nothing**.

This PR contains two commits:

1. **Fix the agent link for these groups** — the `dashboard_url` translator was emitting `taxa=corals`, which produced an empty dashboard (broke the same-view guarantee for every invertebrate/plant/fungi group).
2. **Collapse to a single flat param** — the change you asked for, done as a URL-serialization shim.

## How the single param works

The change is confined to URL serialization; the dashboard's internal two-level selection model is **untouched**:
- `parseParams` expands each flat token to its display root + sub-group (`corals → invertebrates + inv-corals`); legacy `?subgroups=` links still parse.
- `buildQs` collapses the internal selection back to flat tokens.
- Expansion lives in **one place** (`taxonomy-utils`: `expandTaxaToken` / `collapseTaxaToTokens`), shared by the dashboard and the agent link. The translator's old `splitTaxa` is removed.

Because only serialization changed, the filtering predicate, data fetch, charts, and the `TaxaSummary` drill-down UI all behave exactly as before — the only difference is the URL string.

## Guardrail (the bit that keeps us from regretting this)

The flat-token ↔ node mapping relies on an invariant: every default-view node's token must resolve back to that node uniquely. The taxonomy tree changes periodically, so a future rename could introduce a collision and silently emit a wrong-taxon URL.

`taxonomy-tree.test.ts` now round-trips **every default-view node** (`node → token → node`) and asserts the mapping is a bijection — so a collision fails in **CI**, not in production. Verified: zero collisions across the current tree.

## Tests

- New whole-tree uniqueness/round-trip guard + flat-token parse/build/round-trip tests.
- Updated the existing taxa/subgroups serialization tests to the flat form (old `?subgroups=` parsing still covered for back-compat).
- Full suite: **429 passing**; `tsc --noEmit` and ESLint clean.
- Not run: a live `next build`/click-through (needs R2 credentials for `app/data/`). Behaviour is covered by unit + round-trip tests, but a quick local click on corals to confirm `taxa=corals` + a populated table would be a good final check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyY1VFTPv7EHV58J9hpmAg)_