### PR TITLE
Rebrand Dash of Life and rename view-mode tabs

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -28,7 +28,7 @@ export const viewport: Viewport = {
 export async function generateMetadata(): Promise<Metadata> {
   const brand = brandForHost((await headers()).get("host"));
   return {
-    title: brand.title,
+    title: brand.tabTitle ?? brand.title,
     description: brand.description,
   };
 }

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import dynamic from "next/dynamic";
+import { FaGlobeAmericas } from "react-icons/fa";
 import { ThemeToggle } from "../components/ThemeToggle";
 import { SpeciesSearchBar } from "../components/SpeciesSearchBar";
 import { useBrand } from "../components/BrandProvider";
@@ -46,7 +47,10 @@ export default function RedListPage() {
       <main className="max-w-5xl w-full min-w-0 mx-auto flex-1">
         {/* Header row: title + view mode toggle */}
         <div className="mb-3 md:mb-4 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-          <h1 className="text-xl sm:text-2xl md:text-3xl font-bold text-zinc-900 dark:text-zinc-100">
+          <h1 className="text-xl sm:text-2xl md:text-3xl font-bold text-zinc-900 dark:text-zinc-100 flex items-center gap-2">
+            {brand.showGlobe && (
+              <FaGlobeAmericas className="shrink-0 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
+            )}
             {brand.title}
           </h1>
           <div className="flex items-center gap-2 shrink-0">
@@ -67,7 +71,7 @@ export default function RedListPage() {
                     : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
                 }`}
               >
-                Reassessments
+                Red List Assessed
               </button>
               <button
                 onClick={() => {
@@ -84,7 +88,7 @@ export default function RedListPage() {
                     : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
                 }`}
               >
-                New Assessments
+                Unassessed
               </button>
             </div>
             <ThemeToggle />

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -71,7 +71,7 @@ export default function RedListPage() {
                     : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
                 }`}
               >
-                Red List Assessed
+                {brand.assessedTabLabel ?? "Reassessments"}
               </button>
               <button
                 onClick={() => {
@@ -88,7 +88,7 @@ export default function RedListPage() {
                     : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
                 }`}
               >
-                Unassessed
+                {brand.unassessedTabLabel ?? "New Assessments"}
               </button>
             </div>
             <ThemeToggle />

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -125,10 +125,10 @@ const centeredThClasses = `${cellPad} ${colDivider} text-center text-xs font-med
 type ColumnId = "described" | "colDescribed" | "assessed" | "outdated" | "breakdown" | "gbifUnassessed" | "colNe" | "totalGbifObs" | "meanGbifObs" | "medianGbifObs" | "gbifDistribution";
 
 const COLUMN_LABELS: Record<ColumnId, string> = {
-  described: "# Described",
-  colDescribed: "# Described (CoL)",
-  assessed: "# Assessed",
-  outdated: "# Outdated (10+Y)",
+  described: "# Described Species",
+  colDescribed: "# Described Species (CoL)",
+  assessed: "# Red List Assessed",
+  outdated: "# Outdated Assessments (10+Y)",
   breakdown: "Risk Category Breakdown",
   gbifUnassessed: "# Unassessed, 1+ GBIF Obs",
   colNe: "# Not Evaluated",
@@ -545,10 +545,10 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           <thead>
             <tr className="bg-zinc-50 dark:bg-zinc-800 border-b border-zinc-200 dark:border-zinc-700">
               <th className={`${stickyClasses} bg-zinc-50 dark:bg-zinc-800 ${cellPad} text-left text-xs font-medium text-zinc-500 uppercase tracking-wider whitespace-nowrap w-0`}>Taxon</th>
-              {isVisible("described") && <th className={numericThNoDividerClasses}># Described</th>}
-              {isVisible("colDescribed") && <th className={numericThClasses}># Described (CoL)</th>}
-              {isVisible("assessed") && <th className={centeredThClasses}># Assessed</th>}
-              {isVisible("outdated") && <th className={centeredThClasses}># Outdated (10+Y)</th>}
+              {isVisible("described") && <th className={numericThNoDividerClasses}># Described Species</th>}
+              {isVisible("colDescribed") && <th className={numericThClasses}># Described Species (CoL)</th>}
+              {isVisible("assessed") && <th className={centeredThClasses}># Red List Assessed</th>}
+              {isVisible("outdated") && <th className={centeredThClasses}># Outdated Assessments (10+Y)</th>}
               {isVisible("gbifUnassessed") && <th className={centeredThClasses}># Unassessed, 1+ GBIF Obs</th>}
               {isVisible("colNe") && <th className={centeredThClasses}># Not Evaluated</th>}
               {isVisible("totalGbifObs") && <th className={numericThClasses}>Total Obs</th>}
@@ -1305,7 +1305,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           <th className={`${numericThNoDividerClasses}`}>
             <div className="flex items-center justify-end gap-2">
               <span className="inline-flex items-center gap-1">
-                # Described
+                # Described Species
                 <span className="relative group">
                   <a
                     href={describedSource === "col" ? COL_SOURCE_URL : IUCN_SOURCE_URL}
@@ -1324,7 +1324,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
                 </span>
               </span>
               {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed */}
-              <span className="inline-flex rounded-md overflow-hidden border border-zinc-300 dark:border-zinc-600 text-[10px] font-semibold normal-case" title="Switch # Described between IUCN Table 1a estimates and the Catalogue of Life backbone">
+              <span className="inline-flex rounded-md overflow-hidden border border-zinc-300 dark:border-zinc-600 text-[10px] font-semibold normal-case" title="Switch # Described Species between IUCN Table 1a estimates and the Catalogue of Life backbone">
                 {(["iucn", "col"] as const).map((src) => (
                   <button
                     key={src}
@@ -1343,13 +1343,13 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           </th>
         )}
         {isVisible("colDescribed") && (
-          <th className={numericThClasses}># Described (CoL)</th>
+          <th className={numericThClasses}># Described Species (CoL)</th>
         )}
         {isVisible("assessed") && (
-          <th className={centeredThClasses}># Assessed</th>
+          <th className={centeredThClasses}># Red List Assessed</th>
         )}
         {isVisible("outdated") && (
-          <th className={centeredThClasses}># Outdated (10+Y)</th>
+          <th className={centeredThClasses}># Outdated Assessments (10+Y)</th>
         )}
         {isVisible("gbifUnassessed") && (
           <th className={centeredThClasses}># Unassessed, 1+ GBIF Obs</th>

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -127,7 +127,7 @@ type ColumnId = "described" | "colDescribed" | "assessed" | "outdated" | "breakd
 const COLUMN_LABELS: Record<ColumnId, string> = {
   described: "# Described Species",
   colDescribed: "# Described Species (CoL)",
-  assessed: "# Assessed (Red List)",
+  assessed: "# Red List Assessed",
   outdated: "# Outdated Assessments (10+Y)",
   breakdown: "Risk Category Breakdown",
   gbifUnassessed: "# Unassessed, 1+ GBIF Obs",
@@ -547,7 +547,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
               <th className={`${stickyClasses} bg-zinc-50 dark:bg-zinc-800 ${cellPad} text-left text-xs font-medium text-zinc-500 uppercase tracking-wider whitespace-nowrap w-0`}>Taxon</th>
               {isVisible("described") && <th className={numericThNoDividerClasses}># Described Species</th>}
               {isVisible("colDescribed") && <th className={numericThClasses}># Described Species (CoL)</th>}
-              {isVisible("assessed") && <th className={centeredThClasses}># Assessed (Red List)</th>}
+              {isVisible("assessed") && <th className={centeredThClasses}># Red List Assessed</th>}
               {isVisible("outdated") && <th className={centeredThClasses}># Outdated Assessments (10+Y)</th>}
               {isVisible("gbifUnassessed") && <th className={centeredThClasses}># Unassessed, 1+ GBIF Obs</th>}
               {isVisible("colNe") && <th className={centeredThClasses}># Not Evaluated</th>}
@@ -1346,7 +1346,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           <th className={numericThClasses}># Described Species (CoL)</th>
         )}
         {isVisible("assessed") && (
-          <th className={centeredThClasses}># Assessed (Red List)</th>
+          <th className={centeredThClasses}># Red List Assessed</th>
         )}
         {isVisible("outdated") && (
           <th className={centeredThClasses}># Outdated Assessments (10+Y)</th>

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -127,7 +127,7 @@ type ColumnId = "described" | "colDescribed" | "assessed" | "outdated" | "breakd
 const COLUMN_LABELS: Record<ColumnId, string> = {
   described: "# Described Species",
   colDescribed: "# Described Species (CoL)",
-  assessed: "# Red List Assessed",
+  assessed: "# Assessed (Red List)",
   outdated: "# Outdated Assessments (10+Y)",
   breakdown: "Risk Category Breakdown",
   gbifUnassessed: "# Unassessed, 1+ GBIF Obs",
@@ -547,7 +547,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
               <th className={`${stickyClasses} bg-zinc-50 dark:bg-zinc-800 ${cellPad} text-left text-xs font-medium text-zinc-500 uppercase tracking-wider whitespace-nowrap w-0`}>Taxon</th>
               {isVisible("described") && <th className={numericThNoDividerClasses}># Described Species</th>}
               {isVisible("colDescribed") && <th className={numericThClasses}># Described Species (CoL)</th>}
-              {isVisible("assessed") && <th className={centeredThClasses}># Red List Assessed</th>}
+              {isVisible("assessed") && <th className={centeredThClasses}># Assessed (Red List)</th>}
               {isVisible("outdated") && <th className={centeredThClasses}># Outdated Assessments (10+Y)</th>}
               {isVisible("gbifUnassessed") && <th className={centeredThClasses}># Unassessed, 1+ GBIF Obs</th>}
               {isVisible("colNe") && <th className={centeredThClasses}># Not Evaluated</th>}
@@ -1346,7 +1346,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           <th className={numericThClasses}># Described Species (CoL)</th>
         )}
         {isVisible("assessed") && (
-          <th className={centeredThClasses}># Red List Assessed</th>
+          <th className={centeredThClasses}># Assessed (Red List)</th>
         )}
         {isVisible("outdated") && (
           <th className={centeredThClasses}># Outdated Assessments (10+Y)</th>

--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -22,7 +22,7 @@ const BRANDS: Record<string, Brand> = {
     title: "Dash of Life: A Dashboard of Life on Earth",
     tabTitle: "Dash of Life",
     description: "A dashboard for biodiversity data about life on Earth",
-    assessedTabLabel: "Assessed (Red List)",
+    assessedTabLabel: "Red List Assessed",
     unassessedTabLabel: "Unassessed",
     showGlobe: true,
   },

--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -1,6 +1,8 @@
 export type Brand = {
   title: string;
   description: string;
+  /** Browser-tab title; falls back to `title` when omitted. */
+  tabTitle?: string;
   /** Show the globe icon before the title (used by the Dash of Life brand). */
   showGlobe?: boolean;
 };
@@ -14,6 +16,7 @@ const DEFAULT_BRAND: Brand = {
 const BRANDS: Record<string, Brand> = {
   "dashoflife.org": {
     title: "Dash of Life: A Dashboard of Life on Earth",
+    tabTitle: "Dash of Life",
     description: "A dashboard for biodiversity data about life on Earth",
     showGlobe: true,
   },

--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -22,7 +22,7 @@ const BRANDS: Record<string, Brand> = {
     title: "Dash of Life: A Dashboard of Life on Earth",
     tabTitle: "Dash of Life",
     description: "A dashboard for biodiversity data about life on Earth",
-    assessedTabLabel: "Red List Assessed",
+    assessedTabLabel: "Assessed (Red List)",
     unassessedTabLabel: "Unassessed",
     showGlobe: true,
   },

--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -1,18 +1,21 @@
 export type Brand = {
   title: string;
   description: string;
+  /** Show the globe icon before the title (used by the Dash of Life brand). */
+  showGlobe?: boolean;
 };
 
 const DEFAULT_BRAND: Brand = {
   title: "IUCN Red List Assessments Dashboard",
-  description: "IUCN Red List and GBIF occurrence data explorer",
+  description: "A dashboard for biodiversity data about life on Earth",
 };
 
 // Per-hostname overrides. Keys are bare hostnames (no port, no "www.").
 const BRANDS: Record<string, Brand> = {
   "dashoflife.org": {
-    title: "Dashboard of Life",
-    description: "IUCN Red List and GBIF occurrence data explorer",
+    title: "Dash of Life: A Dashboard of Life on Earth",
+    description: "A dashboard for biodiversity data about life on Earth",
+    showGlobe: true,
   },
 };
 

--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -3,6 +3,10 @@ export type Brand = {
   description: string;
   /** Browser-tab title; falls back to `title` when omitted. */
   tabTitle?: string;
+  /** Label for the "reassessments" view-mode tab; defaults to "Reassessments". */
+  assessedTabLabel?: string;
+  /** Label for the "new-assessments" view-mode tab; defaults to "New Assessments". */
+  unassessedTabLabel?: string;
   /** Show the globe icon before the title (used by the Dash of Life brand). */
   showGlobe?: boolean;
 };
@@ -18,6 +22,8 @@ const BRANDS: Record<string, Brand> = {
     title: "Dash of Life: A Dashboard of Life on Earth",
     tabTitle: "Dash of Life",
     description: "A dashboard for biodiversity data about life on Earth",
+    assessedTabLabel: "Red List Assessed",
+    unassessedTabLabel: "Unassessed",
     showGlobe: true,
   },
 };


### PR DESCRIPTION
## Summary

Branding and naming updates, with brand-specific bits gated to the `dashoflife.org` brand and clarity-only label changes applied globally.

### Dash of Life brand only (`dashoflife.org`)
- **Title**: "Dash of Life: A Dashboard of Life on Earth" (on-page `<h1>`).
- **Browser tab**: short "Dash of Life" via new optional `Brand.tabTitle` (falls back to `title` for other brands).
- **Description**: "A dashboard for biodiversity data about life on Earth".
- **Globe icon** before the title — reuses `FaGlobeAmericas` (same icon as the All Species row), gated on `Brand.showGlobe`. Emerald-tinted, `shrink-0`, `aria-hidden`.
- **View-mode tabs**: "Red List Assessed" / "Unassessed" via optional `Brand.assessedTabLabel` / `unassessedTabLabel`. The default (IUCN) brand keeps "Reassessments" / "New Assessments".

### All brands
- **Table column headers** renamed for clarity (kept global — clearer for every audience):
  - `# Described` → `# Described Species`
  - `# Described (CoL)` → `# Described Species (CoL)`
  - `# Assessed` → `# Red List Assessed`
  - `# Outdated (10+Y)` → `# Outdated Assessments (10+Y)`
  - Applied across both `<thead>` blocks, the column-picker (`COLUMN_LABELS`), and the `# Described` info tooltip. `(10+Y)` retained so "Outdated" stays defined.

## Notes

- `viewMode` values and the `?view=new-assessments` URL param are unchanged — labels only, no routing/bookmark impact.
- `# Not Evaluated` (strict IUCN NE column) left as-is; distinct from the broader "Unassessed" tab.
- `tsc --noEmit` passes; no tests reference the old labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)