### PR TITLE
Shorten Dash of Life title to "Dash of Life"

### DIFF
--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -19,8 +19,7 @@ const DEFAULT_BRAND: Brand = {
 // Per-hostname overrides. Keys are bare hostnames (no port, no "www.").
 const BRANDS: Record<string, Brand> = {
   "dashoflife.org": {
-    title: "Dash of Life: A Dashboard of Life on Earth",
-    tabTitle: "Dash of Life",
+    title: "Dash of Life",
     description: "A dashboard for biodiversity data about life on Earth",
     assessedTabLabel: "Red List Assessed",
     unassessedTabLabel: "Unassessed",


### PR DESCRIPTION
## Summary

- Renames the `dashoflife.org` on-page title from **"Dash of Life: A Dashboard of Life on Earth"** to just **"Dash of Life"**.
- Removes the now-redundant `tabTitle` override (the browser tab falls back to `title`, which is already "Dash of Life"). The optional `Brand.tabTitle` field and the `layout.tsx` fallback remain for future use.

## Notes
- `title` drives both the on-page `<h1>` (with the globe icon) and the browser tab.
- `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)