### PR TITLE
UI: refine dashboard header and summary table presentation

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -46,7 +46,7 @@ export default function RedListPage() {
     <div className="min-h-screen flex flex-col bg-zinc-50 dark:bg-zinc-950 px-4 sm:px-6 py-4 md:px-16 md:py-8">
       <main className="max-w-5xl w-full min-w-0 mx-auto flex-1">
         {/* Header: globe + two aligned rows (title | view-toggle, subtitle | search) */}
-        <div className="mb-4 md:mb-6 flex items-start gap-2">
+        <div className="mb-[0.9rem] md:mb-[1.35rem] flex items-start gap-2">
           {brand.showGlobe && (
             <FaGlobeAmericas className="shrink-0 mt-1 text-2xl sm:text-3xl md:text-[2rem] text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
           )}

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -46,14 +46,20 @@ export default function RedListPage() {
     <div className="min-h-screen flex flex-col bg-zinc-50 dark:bg-zinc-950 px-4 sm:px-6 py-4 md:px-16 md:py-8">
       <main className="max-w-5xl w-full min-w-0 mx-auto flex-1">
         {/* Header row: title + view mode toggle */}
-        <div className="mb-3 md:mb-4 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-          <h1 className="text-base sm:text-lg md:text-[1.3rem] font-bold text-zinc-900 dark:text-zinc-100 flex items-center gap-2">
+        <div className="mb-4 md:mb-6 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+          <div className="flex items-start gap-2">
             {brand.showGlobe && (
-              <FaGlobeAmericas className="shrink-0 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
+              <FaGlobeAmericas className="shrink-0 mt-1 text-2xl sm:text-3xl md:text-[2rem] text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
             )}
-            {brand.title}
-          </h1>
-          <div className="flex items-center gap-2 shrink-0">
+            <div>
+              <h1 className="text-2xl sm:text-3xl md:text-[2rem] font-bold text-zinc-900 dark:text-zinc-100">{brand.title}</h1>
+              {brand.subtitle && (
+                <p className="mt-0.5 text-lg md:text-xl text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
+              )}
+            </div>
+          </div>
+          <div className="flex flex-col items-stretch sm:items-end gap-2 shrink-0">
+            <div className="flex items-center gap-2">
             {/* View mode toggle */}
             <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-sm">
               <button
@@ -92,15 +98,9 @@ export default function RedListPage() {
               </button>
             </div>
             <ThemeToggle />
+            </div>
+            <SpeciesSearchBar />
           </div>
-        </div>
-
-        {/* Search bar + subtitle */}
-        <div className="mb-4 md:mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-          <p className="text-sm md:text-base text-zinc-600 dark:text-zinc-400">
-            Click taxa rows to filter, use charts and search to explore species.<span className="hidden sm:inline"> Cmd/Ctrl+click to multiselect.</span>
-          </p>
-          <SpeciesSearchBar />
         </div>
 
         {/* Content — single component instance stays mounted on viewMode switch */}

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -53,7 +53,7 @@ export default function RedListPage() {
           <div className="flex-1 min-w-0 grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center gap-x-3 gap-y-1.5 sm:gap-y-3 [grid-template-areas:'title'_'subtitle'_'controls'_'search'] sm:[grid-template-areas:'title_controls'_'subtitle_search']">
             <h1 className="[grid-area:title] text-2xl sm:text-3xl md:text-[2rem] font-bold text-zinc-900 dark:text-zinc-100">{brand.title}</h1>
             {brand.subtitle && (
-              <p className="[grid-area:subtitle] text-lg md:text-xl text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
+              <p className="[grid-area:subtitle] text-xl md:text-2xl text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
             )}
             <div className="[grid-area:controls] flex items-center gap-2 sm:justify-self-end">
               {/* View mode toggle */}

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -3,8 +3,8 @@
 import { useState, useEffect } from "react";
 import dynamic from "next/dynamic";
 import { FaGlobeAmericas } from "react-icons/fa";
-import { ThemeToggle } from "../components/ThemeToggle";
 import { SpeciesSearchBar } from "../components/SpeciesSearchBar";
+import { ThemeToggle } from "../components/ThemeToggle";
 import { useBrand } from "../components/BrandProvider";
 import { parseParams, type ViewMode } from "../hooks/useFilterParams";
 
@@ -45,61 +45,63 @@ export default function RedListPage() {
   return (
     <div className="min-h-screen flex flex-col bg-zinc-50 dark:bg-zinc-950 px-4 sm:px-6 py-4 md:px-16 md:py-8">
       <main className="max-w-5xl w-full min-w-0 mx-auto flex-1">
-        {/* Header row: title + view mode toggle */}
-        <div className="mb-4 md:mb-6 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-          <div className="flex items-start gap-2">
-            {brand.showGlobe && (
-              <FaGlobeAmericas className="shrink-0 mt-1 text-2xl sm:text-3xl md:text-[2rem] text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
-            )}
-            <div>
+        {/* Header: globe + two aligned rows (title | view-toggle, subtitle | search) */}
+        <div className="mb-4 md:mb-6 flex items-start gap-2">
+          {brand.showGlobe && (
+            <FaGlobeAmericas className="shrink-0 mt-1 text-2xl sm:text-3xl md:text-[2rem] text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
+          )}
+          <div className="flex-1 min-w-0">
+            {/* Row 1: title aligned with the view-mode toggle */}
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
               <h1 className="text-2xl sm:text-3xl md:text-[2rem] font-bold text-zinc-900 dark:text-zinc-100">{brand.title}</h1>
+              <div className="flex items-center gap-2 shrink-0">
+              {/* View mode toggle */}
+              <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-sm">
+                <button
+                  onClick={() => {
+                    if (viewMode === "reassessments") return;
+                    setViewMode("reassessments");
+                    setSharedTaxa(new Set());
+                    setSharedSubgroups(new Set());
+                    window.history.pushState(null, "", "/");
+                    window.dispatchEvent(new PopStateEvent("popstate"));
+                  }}
+                  className={`px-3 py-2 sm:py-1.5 font-medium transition-colors ${
+                    viewMode === "reassessments"
+                      ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                      : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                  }`}
+                >
+                  {brand.assessedTabLabel ?? "Reassessments"}
+                </button>
+                <button
+                  onClick={() => {
+                    if (viewMode === "new-assessments") return;
+                    setViewMode("new-assessments");
+                    setSharedTaxa(new Set());
+                    setSharedSubgroups(new Set());
+                    window.history.pushState(null, "", "/?view=new-assessments");
+                    window.dispatchEvent(new PopStateEvent("popstate"));
+                  }}
+                  className={`px-3 py-2 sm:py-1.5 font-medium transition-colors ${
+                    viewMode === "new-assessments"
+                      ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                      : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                  }`}
+                >
+                  {brand.unassessedTabLabel ?? "New Assessments"}
+                </button>
+              </div>
+              <ThemeToggle />
+              </div>
+            </div>
+            {/* Row 2: subtitle aligned with the search bar */}
+            <div className="mt-2 md:mt-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
               {brand.subtitle && (
-                <p className="mt-0.5 text-lg md:text-xl text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
+                <p className="text-base md:text-lg text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
               )}
+              <SpeciesSearchBar />
             </div>
-          </div>
-          <div className="flex flex-col items-stretch sm:items-end gap-2 shrink-0">
-            <div className="flex items-center gap-2">
-            {/* View mode toggle */}
-            <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-sm">
-              <button
-                onClick={() => {
-                  if (viewMode === "reassessments") return;
-                  setViewMode("reassessments");
-                  setSharedTaxa(new Set());
-                  setSharedSubgroups(new Set());
-                  window.history.pushState(null, "", "/");
-                  window.dispatchEvent(new PopStateEvent("popstate"));
-                }}
-                className={`px-3 py-2 sm:py-1.5 font-medium transition-colors ${
-                  viewMode === "reassessments"
-                    ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                    : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                }`}
-              >
-                {brand.assessedTabLabel ?? "Reassessments"}
-              </button>
-              <button
-                onClick={() => {
-                  if (viewMode === "new-assessments") return;
-                  setViewMode("new-assessments");
-                  setSharedTaxa(new Set());
-                  setSharedSubgroups(new Set());
-                  window.history.pushState(null, "", "/?view=new-assessments");
-                  window.dispatchEvent(new PopStateEvent("popstate"));
-                }}
-                className={`px-3 py-2 sm:py-1.5 font-medium transition-colors ${
-                  viewMode === "new-assessments"
-                    ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                    : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                }`}
-              >
-                {brand.unassessedTabLabel ?? "New Assessments"}
-              </button>
-            </div>
-            <ThemeToggle />
-            </div>
-            <SpeciesSearchBar />
           </div>
         </div>
 

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -47,7 +47,7 @@ export default function RedListPage() {
       <main className="max-w-5xl w-full min-w-0 mx-auto flex-1">
         {/* Header row: title + view mode toggle */}
         <div className="mb-3 md:mb-4 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-          <h1 className="text-xl sm:text-2xl md:text-[1.7rem] font-bold text-zinc-900 dark:text-zinc-100 flex items-center gap-2">
+          <h1 className="text-base sm:text-lg md:text-[1.3rem] font-bold text-zinc-900 dark:text-zinc-100 flex items-center gap-2">
             {brand.showGlobe && (
               <FaGlobeAmericas className="shrink-0 text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
             )}

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -98,7 +98,7 @@ export default function RedListPage() {
             {/* Row 2: subtitle aligned with the search bar */}
             <div className="mt-2 md:mt-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
               {brand.subtitle && (
-                <p className="text-base md:text-lg text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
+                <p className="text-lg md:text-xl text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
               )}
               <SpeciesSearchBar />
             </div>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -50,11 +50,12 @@ export default function RedListPage() {
           {brand.showGlobe && (
             <FaGlobeAmericas className="shrink-0 mt-1 text-2xl sm:text-3xl md:text-[2rem] text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
           )}
-          <div className="flex-1 min-w-0">
-            {/* Row 1: title aligned with the view-mode toggle */}
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-              <h1 className="text-2xl sm:text-3xl md:text-[2rem] font-bold text-zinc-900 dark:text-zinc-100">{brand.title}</h1>
-              <div className="flex items-center gap-2 shrink-0">
+          <div className="flex-1 min-w-0 grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center gap-x-3 gap-y-1.5 sm:gap-y-3 [grid-template-areas:'title'_'subtitle'_'controls'_'search'] sm:[grid-template-areas:'title_controls'_'subtitle_search']">
+            <h1 className="[grid-area:title] text-2xl sm:text-3xl md:text-[2rem] font-bold text-zinc-900 dark:text-zinc-100">{brand.title}</h1>
+            {brand.subtitle && (
+              <p className="[grid-area:subtitle] text-lg md:text-xl text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
+            )}
+            <div className="[grid-area:controls] flex items-center gap-2 sm:justify-self-end">
               {/* View mode toggle */}
               <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-sm">
                 <button
@@ -93,13 +94,8 @@ export default function RedListPage() {
                 </button>
               </div>
               <ThemeToggle />
-              </div>
             </div>
-            {/* Row 2: subtitle aligned with the search bar */}
-            <div className="mt-2 md:mt-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-              {brand.subtitle && (
-                <p className="text-lg md:text-xl text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
-              )}
+            <div className="[grid-area:search] sm:justify-self-end">
               <SpeciesSearchBar />
             </div>
           </div>

--- a/app/src/components/BrandProvider.tsx
+++ b/app/src/components/BrandProvider.tsx
@@ -5,7 +5,7 @@ import type { Brand } from "../config/brand";
 
 const BrandContext = createContext<Brand>({
   title: "Dash of Life",
-  subtitle: "A Dashboard for Threatened Species Conservation",
+  subtitle: "A Dashboard for Conservation of Threatened Species",
   description: "A dashboard for biodiversity data about life on Earth",
   assessedTabLabel: "Red List Assessed",
   unassessedTabLabel: "Unassessed",

--- a/app/src/components/BrandProvider.tsx
+++ b/app/src/components/BrandProvider.tsx
@@ -4,7 +4,8 @@ import { createContext, useContext } from "react";
 import type { Brand } from "../config/brand";
 
 const BrandContext = createContext<Brand>({
-  title: "Dash of Life: A Dashboard for Conservation of Threatened Species",
+  title: "Dash of Life",
+  subtitle: "A Dashboard for Conservation of Threatened Species",
   description: "A dashboard for biodiversity data about life on Earth",
   assessedTabLabel: "Red List Assessed",
   unassessedTabLabel: "Unassessed",

--- a/app/src/components/BrandProvider.tsx
+++ b/app/src/components/BrandProvider.tsx
@@ -5,7 +5,7 @@ import type { Brand } from "../config/brand";
 
 const BrandContext = createContext<Brand>({
   title: "Dash of Life",
-  subtitle: "A Dashboard for Conservation of Threatened Species",
+  subtitle: "A Dashboard for Threatened Species Conservation",
   description: "A dashboard for biodiversity data about life on Earth",
   assessedTabLabel: "Red List Assessed",
   unassessedTabLabel: "Unassessed",

--- a/app/src/components/BrandProvider.tsx
+++ b/app/src/components/BrandProvider.tsx
@@ -4,7 +4,7 @@ import { createContext, useContext } from "react";
 import type { Brand } from "../config/brand";
 
 const BrandContext = createContext<Brand>({
-  title: "Dash of Life: A Dashboard for Threatened Species Conservation",
+  title: "Dash of Life: A Dashboard for Conservation of Threatened Species",
   description: "A dashboard for biodiversity data about life on Earth",
   assessedTabLabel: "Red List Assessed",
   unassessedTabLabel: "Unassessed",

--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -186,7 +186,7 @@ export function SpeciesSearchBar() {
           onFocus={() => query.length >= 2 && setIsOpen(true)}
           onKeyDown={handleKeyDown}
           placeholder="Search for a species..."
-          className="w-full pl-10 pr-8 py-1.5 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-500"
+          className="w-full pl-10 pr-8 py-1.5 text-base rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-500"
         />
         {/* Clear button */}
         {query && (

--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -162,7 +162,7 @@ export function SpeciesSearchBar() {
   }
 
   return (
-    <div ref={containerRef} className="relative w-full sm:w-[22.5rem] md:w-[27rem]">
+    <div ref={containerRef} className="relative w-full sm:w-[20.25rem] md:w-[24.3rem]">
       <div className="relative">
         {/* Magnifying glass icon */}
         <svg

--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -162,7 +162,7 @@ export function SpeciesSearchBar() {
   }
 
   return (
-    <div ref={containerRef} className="relative w-full sm:w-[20rem]">
+    <div ref={containerRef} className="relative w-full sm:w-[22rem] md:w-[28rem]">
       <div className="relative">
         {/* Magnifying glass icon */}
         <svg
@@ -186,7 +186,7 @@ export function SpeciesSearchBar() {
           onFocus={() => query.length >= 2 && setIsOpen(true)}
           onKeyDown={handleKeyDown}
           placeholder="Search for a species..."
-          className="w-full pl-10 pr-8 py-1 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-500"
+          className="w-full pl-10 pr-8 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-500"
         />
         {/* Clear button */}
         {query && (

--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -162,7 +162,7 @@ export function SpeciesSearchBar() {
   }
 
   return (
-    <div ref={containerRef} className="relative w-full sm:w-[20.25rem] md:w-[24.3rem]">
+    <div ref={containerRef} className="relative w-full sm:w-[18.23rem] md:w-[21.87rem]">
       <div className="relative">
         {/* Magnifying glass icon */}
         <svg

--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -162,7 +162,7 @@ export function SpeciesSearchBar() {
   }
 
   return (
-    <div ref={containerRef} className="relative w-full sm:w-[15rem] md:w-[18rem]">
+    <div ref={containerRef} className="relative w-full sm:w-[22.5rem] md:w-[27rem]">
       <div className="relative">
         {/* Magnifying glass icon */}
         <svg

--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -162,7 +162,7 @@ export function SpeciesSearchBar() {
   }
 
   return (
-    <div ref={containerRef} className="relative w-full sm:w-[22rem] md:w-[28rem]">
+    <div ref={containerRef} className="relative w-full sm:w-[15rem] md:w-[18rem]">
       <div className="relative">
         {/* Magnifying glass icon */}
         <svg
@@ -186,7 +186,7 @@ export function SpeciesSearchBar() {
           onFocus={() => query.length >= 2 && setIsOpen(true)}
           onKeyDown={handleKeyDown}
           placeholder="Search for a species..."
-          className="w-full pl-10 pr-8 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-500"
+          className="w-full pl-10 pr-8 py-1.5 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-500"
         />
         {/* Clear button */}
         {query && (

--- a/app/src/components/redlist/ReviewerChart.tsx
+++ b/app/src/components/redlist/ReviewerChart.tsx
@@ -189,7 +189,7 @@ export default function AssessorChart({
             dataKey="code"
             selectedItems={selectedItems}
             onBarClick={onBarClick}
-            barColor="#fb923c"
+            barColor={viewMode === "assessors" ? "#fb923c" : "#818cf8"}
             yAxisWidth={150}
             leftMargin={-30}
             rightMargin={55}

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -111,7 +111,7 @@ const getOutdatedBarColor = (percent: number) =>
 // Sticky cell classes for the pinned taxon column
 const stickyClasses = "sticky left-0 z-10";
 // Compact cell classes for tighter table spacing
-const cellPad = "px-3 py-2 md:px-4 md:py-2.5";
+const cellPad = "px-2 sm:px-3 py-2 md:px-4 md:py-2.5";
 const colDivider = "border-l border-zinc-200 dark:border-zinc-700";
 const numericTdNoDividerClasses = `${cellPad} text-right whitespace-nowrap w-0`;
 const numericThNoDividerClasses = `${cellPad} text-right text-sm font-bold text-zinc-600 dark:text-zinc-300 whitespace-nowrap w-0`;
@@ -465,7 +465,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         )}
         {isVisible("assessed") && (
           <td className={flexTdClasses}>
-            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[230px] md:min-w-[250px]">
+            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[150px] sm:min-w-[230px] md:min-w-[250px]">
               <div className="h-4 w-[48px] sm:w-[60px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
               <div className="flex-1 min-w-[40px] h-3.5 sm:h-2.5 rounded-full bg-zinc-200 dark:bg-zinc-700" />
               <div className="h-3 w-[44px] sm:w-[52px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
@@ -474,7 +474,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         )}
         {isVisible("outdated") && (
           <td className={flexTdClasses}>
-            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[230px] md:min-w-[250px]">
+            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[150px] sm:min-w-[230px] md:min-w-[250px]">
               <div className="h-4 w-[48px] sm:w-[60px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
               <div className="flex-1 min-w-[40px] h-3.5 sm:h-2.5 rounded-full bg-zinc-200 dark:bg-zinc-700" />
               <div className="h-3 w-[44px] sm:w-[52px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
@@ -483,7 +483,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         )}
         {isVisible("gbifUnassessed") && (
           <td className={flexTdClasses}>
-            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[230px] md:min-w-[250px]">
+            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[150px] sm:min-w-[230px] md:min-w-[250px]">
               <div className="h-4 w-[48px] sm:w-[60px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
               <div className="flex-1 min-w-[40px] h-3.5 sm:h-2.5 rounded-full bg-zinc-200 dark:bg-zinc-700" />
               <div className="h-3 w-[44px] sm:w-[52px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
@@ -492,7 +492,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         )}
         {isVisible("colNe") && (
           <td className={flexTdClasses}>
-            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[230px] md:min-w-[250px]">
+            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[150px] sm:min-w-[230px] md:min-w-[250px]">
               <div className="h-4 w-[48px] sm:w-[60px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
               <div className="flex-1 min-w-[40px] h-3.5 sm:h-2.5 rounded-full bg-zinc-200 dark:bg-zinc-700" />
               <div className="h-3 w-[44px] sm:w-[52px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
@@ -612,7 +612,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     const fillColor = isAll ? "rgba(255,255,255,0.25)" : barColor;
     const fw = fontWeight || "font-medium";
     return (
-      <div className="flex items-center gap-1.5 sm:gap-3 min-w-[230px] md:min-w-[250px]">
+      <div className="flex items-center gap-1.5 sm:gap-3 min-w-[150px] sm:min-w-[230px] md:min-w-[250px]">
         {count != null && (
           <span className={`text-sm md:text-base ${fw} tabular-nums text-zinc-700 dark:text-zinc-300 w-[48px] sm:w-[60px] text-right flex-shrink-0`}>
             {count.toLocaleString()}
@@ -1764,13 +1764,13 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         all landing-only — hidden once a taxon is selected. */}
     {!loading && perTaxa.length > 0 && selectedTaxa.size === 0 && (
       <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 mt-1.5">
-        {/* Usage hint */}
-        <span className="pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
+        {/* Usage hint — hidden on mobile to save space */}
+        <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
           Click taxa rows to filter, use charts and search to explore species.<span className="hidden sm:inline"> Cmd/Ctrl+click to multiselect.</span>
         </span>
         <div className="flex items-center gap-3">
-          {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed */}
-          <span className="inline-flex items-center gap-1.5">
+          {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed (hidden on mobile) */}
+          <span className="hidden sm:inline-flex items-center gap-1.5">
             <span className="text-xs text-zinc-400 dark:text-zinc-500">Source for # Described:</span>
             <span className="inline-flex rounded-md overflow-hidden border border-zinc-300 dark:border-zinc-600 text-[10px] font-semibold" title="Switch # Described Species between IUCN Table 1a estimates and the Catalogue of Life backbone">
               {(["iucn", "col"] as const).map((src) => (
@@ -1788,7 +1788,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
               ))}
             </span>
           </span>
-          <span className="text-zinc-300 dark:text-zinc-700">|</span>
+          <span className="hidden sm:inline text-zinc-300 dark:text-zinc-700">|</span>
           {table1aMode ? (
             <button
               onClick={exitTable1a}

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -1285,8 +1285,8 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
   const renderHead = () => (
     <thead>
       <tr className="bg-zinc-50 dark:bg-zinc-800 border-b border-zinc-200 dark:border-zinc-700">
-        <th className={`${stickyClasses} bg-zinc-50 dark:bg-zinc-800 ${cellPad} text-center text-sm font-bold text-zinc-600 dark:text-zinc-300 whitespace-nowrap w-0`}>
-          <div className="flex items-center justify-center gap-1.5">
+        <th className={`${stickyClasses} bg-zinc-50 dark:bg-zinc-800 ${cellPad} ${table1aMode ? "text-left" : "text-center"} text-sm font-bold text-zinc-600 dark:text-zinc-300 whitespace-nowrap w-0`}>
+          <div className={`flex items-center gap-1.5 ${table1aMode ? "justify-start" : "justify-center"}`}>
             Taxonomic Group
             <button
               ref={menuButtonRef}

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -114,16 +114,16 @@ const stickyClasses = "sticky left-0 z-10";
 const cellPad = "px-3 py-2 md:px-4 md:py-2.5";
 const colDivider = "border-l border-zinc-200 dark:border-zinc-700";
 const numericTdNoDividerClasses = `${cellPad} text-right whitespace-nowrap w-0`;
-const numericThNoDividerClasses = `${cellPad} text-right text-xs font-medium text-zinc-500 uppercase tracking-wider whitespace-nowrap w-0`;
+const numericThNoDividerClasses = `${cellPad} text-right text-sm font-bold text-zinc-600 dark:text-zinc-300 whitespace-nowrap w-0`;
 const numericTdClasses = `${numericTdNoDividerClasses} ${colDivider}`;
 const numericThClasses = `${numericThNoDividerClasses} ${colDivider}`;
 const flexTdClasses = `${cellPad} ${colDivider} whitespace-nowrap w-0`;
-const flexThClasses = `${cellPad} ${colDivider} text-left text-xs font-medium text-zinc-500 uppercase tracking-wider whitespace-nowrap w-0`;
+const flexThClasses = `${cellPad} ${colDivider} text-left text-sm font-bold text-zinc-600 dark:text-zinc-300 whitespace-nowrap w-0`;
 // Bar-column headers (Assessed / Outdated / Unassessed / Not Evaluated) are allowed
 // to wrap: their cells already carry a bar min-width, so a long single-line header
-// (e.g. "# Outdated Assessments (10+Y)") would otherwise force the column wider than
+// (e.g. "# Outdated (>10 yrs old)") would otherwise force the column wider than
 // it needs to be and push the table into horizontal overflow.
-const centeredThClasses = `${cellPad} ${colDivider} text-center text-xs font-medium text-zinc-500 uppercase tracking-wider w-0`;
+const centeredThClasses = `${cellPad} ${colDivider} text-center text-sm font-bold text-zinc-600 dark:text-zinc-300 w-0`;
 
 // Toggleable column IDs (Taxon is always visible)
 type ColumnId = "described" | "colDescribed" | "assessed" | "outdated" | "breakdown" | "gbifUnassessed" | "colNe" | "totalGbifObs" | "meanGbifObs" | "medianGbifObs" | "gbifDistribution";
@@ -132,7 +132,7 @@ const COLUMN_LABELS: Record<ColumnId, string> = {
   described: "# Described Species",
   colDescribed: "# Described Species (CoL)",
   assessed: "# Red List Assessed",
-  outdated: "# Outdated Assessments (10+Y)",
+  outdated: "# Outdated (>10 yrs old)",
   breakdown: "Risk Category Breakdown",
   gbifUnassessed: "# Unassessed, 1+ GBIF Obs",
   colNe: "# Not Evaluated",
@@ -548,11 +548,11 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         <table className="w-full">
           <thead>
             <tr className="bg-zinc-50 dark:bg-zinc-800 border-b border-zinc-200 dark:border-zinc-700">
-              <th className={`${stickyClasses} bg-zinc-50 dark:bg-zinc-800 ${cellPad} text-left text-xs font-medium text-zinc-500 uppercase tracking-wider whitespace-nowrap w-0`}>Taxon</th>
+              <th className={`${stickyClasses} bg-zinc-50 dark:bg-zinc-800 ${cellPad} text-center text-sm font-bold text-zinc-600 dark:text-zinc-300 whitespace-nowrap w-0`}>Taxonomic Group</th>
               {isVisible("described") && <th className={numericThNoDividerClasses}># Described Species</th>}
               {isVisible("colDescribed") && <th className={numericThClasses}># Described Species (CoL)</th>}
               {isVisible("assessed") && <th className={centeredThClasses}># Red List Assessed</th>}
-              {isVisible("outdated") && <th className={centeredThClasses}># Outdated Assessments (10+Y)</th>}
+              {isVisible("outdated") && <th className={centeredThClasses}># Outdated (&gt;10 yrs old)</th>}
               {isVisible("gbifUnassessed") && <th className={centeredThClasses}># Unassessed, 1+ GBIF Obs</th>}
               {isVisible("colNe") && <th className={centeredThClasses}># Not Evaluated</th>}
               {isVisible("totalGbifObs") && <th className={numericThClasses}>Total Obs</th>}
@@ -1285,9 +1285,9 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
   const renderHead = () => (
     <thead>
       <tr className="bg-zinc-50 dark:bg-zinc-800 border-b border-zinc-200 dark:border-zinc-700">
-        <th className={`${stickyClasses} bg-zinc-50 dark:bg-zinc-800 ${cellPad} text-left text-xs font-medium text-zinc-500 uppercase tracking-wider whitespace-nowrap w-0`}>
-          <div className="flex items-center gap-1.5">
-            Taxon
+        <th className={`${stickyClasses} bg-zinc-50 dark:bg-zinc-800 ${cellPad} text-center text-sm font-bold text-zinc-600 dark:text-zinc-300 whitespace-nowrap w-0`}>
+          <div className="flex items-center justify-center gap-1.5">
+            Taxonomic Group
             <button
               ref={menuButtonRef}
               onClick={(e) => {
@@ -1335,7 +1335,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           <th className={centeredThClasses}># Red List Assessed</th>
         )}
         {isVisible("outdated") && (
-          <th className={centeredThClasses}># Outdated Assessments (10+Y)</th>
+          <th className={centeredThClasses}># Outdated (&gt;10 yrs old)</th>
         )}
         {isVisible("gbifUnassessed") && (
           <th className={centeredThClasses}># Unassessed, 1+ GBIF Obs</th>

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -281,8 +281,11 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
   }, []);
 
   useEffect(() => {
-    if (scrollRef.current && taxa.length > 0) {
-      autoScroll(scrollRef.current);
+    const el = scrollRef.current;
+    if (el && taxa.length > 0) {
+      // rAF so the scroll is applied after layout settles (otherwise it can
+      // land before column widths are known and fail to reveal Assessed).
+      requestAnimationFrame(() => autoScroll(el));
     }
   }, [taxa, autoScroll]);
 
@@ -1763,14 +1766,14 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     {/* Subtle controls: usage hint + # Described toggle + expand/table controls,
         all landing-only — hidden once a taxon is selected. */}
     {!loading && perTaxa.length > 0 && selectedTaxa.size === 0 && (
-      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 mt-1.5">
-        {/* Usage hint — hidden on mobile to save space */}
-        <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
+      <div className="hidden sm:flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 mt-1.5">
+        {/* Usage hint */}
+        <span className="pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
           Click taxa rows to filter, use charts and search to explore species.<span className="hidden sm:inline"> Cmd/Ctrl+click to multiselect.</span>
         </span>
         <div className="flex items-center gap-3">
-          {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed (hidden on mobile) */}
-          <span className="hidden sm:inline-flex items-center gap-1.5">
+          {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed */}
+          <span className="inline-flex items-center gap-1.5">
             <span className="text-xs text-zinc-400 dark:text-zinc-500">Source for # Described:</span>
             <span className="inline-flex rounded-md overflow-hidden border border-zinc-300 dark:border-zinc-600 text-[10px] font-semibold" title="Switch # Described Species between IUCN Table 1a estimates and the Catalogue of Life backbone">
               {(["iucn", "col"] as const).map((src) => (
@@ -1788,7 +1791,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
               ))}
             </span>
           </span>
-          <span className="hidden sm:inline text-zinc-300 dark:text-zinc-700">|</span>
+          <span className="text-zinc-300 dark:text-zinc-700">|</span>
           {table1aMode ? (
             <button
               onClick={exitTable1a}

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -1771,7 +1771,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         <div className="flex items-center gap-3">
           {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed */}
           <span className="inline-flex items-center gap-1.5">
-            <span className="text-xs text-zinc-400 dark:text-zinc-500"># Described:</span>
+            <span className="text-xs text-zinc-400 dark:text-zinc-500">Source for # Described:</span>
             <span className="inline-flex rounded-md overflow-hidden border border-zinc-300 dark:border-zinc-600 text-[10px] font-semibold" title="Switch # Described Species between IUCN Table 1a estimates and the Catalogue of Life backbone">
               {(["iucn", "col"] as const).map((src) => (
                 <button

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -1762,7 +1762,12 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     </div>
     {/* Subtle controls: # Described source toggle (always shown) + expand/table controls (landing only) */}
     {!loading && perTaxa.length > 0 && (
-      <div className="flex items-center justify-end gap-3 mt-1.5">
+      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 mt-1.5">
+        {/* Usage hint, kept alongside the table controls it describes */}
+        <span className="text-xs text-zinc-400 dark:text-zinc-500">
+          Click taxa rows to filter, use charts and search to explore species.<span className="hidden sm:inline"> Cmd/Ctrl+click to multiselect.</span>
+        </span>
+        <div className="flex items-center gap-3">
         {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed */}
         <span className="inline-flex items-center gap-1.5">
           <span className="text-xs text-zinc-400 dark:text-zinc-500"># Described:</span>
@@ -1828,6 +1833,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
             )}
           </>
         )}
+        </div>
       </div>
     )}
     </>

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -114,7 +114,7 @@ const stickyClasses = "sticky left-0 z-10";
 const cellPad = "px-3 py-2 md:px-4 md:py-2.5";
 const colDivider = "border-l border-zinc-200 dark:border-zinc-700";
 const numericTdNoDividerClasses = `${cellPad} text-right whitespace-nowrap w-0`;
-const numericThNoDividerClasses = `${cellPad} text-right text-sm font-bold text-zinc-600 dark:text-zinc-300 whitespace-nowrap w-0`;
+const numericThNoDividerClasses = `${cellPad} text-right text-sm font-bold text-zinc-600 dark:text-zinc-300 w-0`;
 const numericTdClasses = `${numericTdNoDividerClasses} ${colDivider}`;
 const numericThClasses = `${numericThNoDividerClasses} ${colDivider}`;
 const flexTdClasses = `${cellPad} ${colDivider} whitespace-nowrap w-0`;
@@ -465,7 +465,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         )}
         {isVisible("assessed") && (
           <td className={flexTdClasses}>
-            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[140px] md:min-w-[160px]">
+            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[170px] md:min-w-[190px]">
               <div className="h-4 w-[48px] sm:w-[60px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
               <div className="flex-1 min-w-[40px] h-3.5 sm:h-2.5 rounded-full bg-zinc-200 dark:bg-zinc-700" />
               <div className="h-3 w-[44px] sm:w-[52px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
@@ -474,7 +474,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         )}
         {isVisible("outdated") && (
           <td className={flexTdClasses}>
-            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[140px] md:min-w-[160px]">
+            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[170px] md:min-w-[190px]">
               <div className="h-4 w-[48px] sm:w-[60px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
               <div className="flex-1 min-w-[40px] h-3.5 sm:h-2.5 rounded-full bg-zinc-200 dark:bg-zinc-700" />
               <div className="h-3 w-[44px] sm:w-[52px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
@@ -483,7 +483,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         )}
         {isVisible("gbifUnassessed") && (
           <td className={flexTdClasses}>
-            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[140px] md:min-w-[160px]">
+            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[170px] md:min-w-[190px]">
               <div className="h-4 w-[48px] sm:w-[60px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
               <div className="flex-1 min-w-[40px] h-3.5 sm:h-2.5 rounded-full bg-zinc-200 dark:bg-zinc-700" />
               <div className="h-3 w-[44px] sm:w-[52px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
@@ -492,7 +492,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         )}
         {isVisible("colNe") && (
           <td className={flexTdClasses}>
-            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[140px] md:min-w-[160px]">
+            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[170px] md:min-w-[190px]">
               <div className="h-4 w-[48px] sm:w-[60px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
               <div className="flex-1 min-w-[40px] h-3.5 sm:h-2.5 rounded-full bg-zinc-200 dark:bg-zinc-700" />
               <div className="h-3 w-[44px] sm:w-[52px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
@@ -612,7 +612,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     const fillColor = isAll ? "rgba(255,255,255,0.25)" : barColor;
     const fw = fontWeight || "font-medium";
     return (
-      <div className="flex items-center gap-1.5 sm:gap-3 min-w-[140px] md:min-w-[160px]">
+      <div className="flex items-center gap-1.5 sm:gap-3 min-w-[170px] md:min-w-[190px]">
         {count != null && (
           <span className={`text-sm md:text-base ${fw} tabular-nums text-zinc-700 dark:text-zinc-300 w-[48px] sm:w-[60px] text-right flex-shrink-0`}>
             {count.toLocaleString()}
@@ -1760,79 +1760,76 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         </tbody>
       </table>
     </div>
-    {/* Subtle controls: # Described source toggle (always shown) + expand/table controls (landing only) */}
-    {!loading && perTaxa.length > 0 && (
+    {/* Subtle controls: usage hint + # Described toggle + expand/table controls,
+        all landing-only — hidden once a taxon is selected. */}
+    {!loading && perTaxa.length > 0 && selectedTaxa.size === 0 && (
       <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 mt-1.5">
-        {/* Usage hint, kept alongside the table controls it describes */}
-        <span className="text-xs text-zinc-400 dark:text-zinc-500">
+        {/* Usage hint */}
+        <span className="pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
           Click taxa rows to filter, use charts and search to explore species.<span className="hidden sm:inline"> Cmd/Ctrl+click to multiselect.</span>
         </span>
         <div className="flex items-center gap-3">
-        {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed */}
-        <span className="inline-flex items-center gap-1.5">
-          <span className="text-xs text-zinc-400 dark:text-zinc-500"># Described:</span>
-          <span className="inline-flex rounded-md overflow-hidden border border-zinc-300 dark:border-zinc-600 text-[10px] font-semibold" title="Switch # Described Species between IUCN Table 1a estimates and the Catalogue of Life backbone">
-            {(["iucn", "col"] as const).map((src) => (
-              <button
-                key={src}
-                onClick={(e) => { e.stopPropagation(); setDescribedSource(src); }}
-                className={`px-1.5 py-0.5 transition-colors ${
-                  describedSource === src
-                    ? "bg-zinc-700 text-white dark:bg-zinc-200 dark:text-zinc-900"
-                    : "text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-700"
-                }`}
-              >
-                {src === "iucn" ? "IUCN" : "CoL"}
-              </button>
-            ))}
-          </span>
-        </span>
-        {selectedTaxa.size === 0 && (
-          <>
-            <span className="text-zinc-300 dark:text-zinc-700">|</span>
-            {table1aMode ? (
-              <button
-                onClick={exitTable1a}
-                className="text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-              >
-                Exit Table 1a mode
-              </button>
-            ) : (
-              <>
+          {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed */}
+          <span className="inline-flex items-center gap-1.5">
+            <span className="text-xs text-zinc-400 dark:text-zinc-500"># Described:</span>
+            <span className="inline-flex rounded-md overflow-hidden border border-zinc-300 dark:border-zinc-600 text-[10px] font-semibold" title="Switch # Described Species between IUCN Table 1a estimates and the Catalogue of Life backbone">
+              {(["iucn", "col"] as const).map((src) => (
                 <button
-                  onClick={allExpanded ? collapseAll : expandAll}
-                  className="inline-flex items-center gap-1 text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                  key={src}
+                  onClick={(e) => { e.stopPropagation(); setDescribedSource(src); }}
+                  className={`px-1.5 py-0.5 transition-colors ${
+                    describedSource === src
+                      ? "bg-zinc-700 text-white dark:bg-zinc-200 dark:text-zinc-900"
+                      : "text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-700"
+                  }`}
                 >
-                  {allExpanded ? <FaCompressAlt size={9} /> : <FaExpandAlt size={9} />}
-                  {allExpanded ? "Collapse all" : "Expand all"}
+                  {src === "iucn" ? "IUCN" : "CoL"}
                 </button>
-                <span className="text-zinc-300 dark:text-zinc-700">|</span>
-                <span className="inline-flex items-center gap-1">
-                  <button
-                    onClick={enterTable1a}
-                    className="text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+              ))}
+            </span>
+          </span>
+          <span className="text-zinc-300 dark:text-zinc-700">|</span>
+          {table1aMode ? (
+            <button
+              onClick={exitTable1a}
+              className="text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+            >
+              Exit Table 1a mode
+            </button>
+          ) : (
+            <>
+              <button
+                onClick={allExpanded ? collapseAll : expandAll}
+                className="inline-flex items-center gap-1 text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+              >
+                {allExpanded ? <FaCompressAlt size={9} /> : <FaExpandAlt size={9} />}
+                {allExpanded ? "Collapse all" : "Expand all"}
+              </button>
+              <span className="text-zinc-300 dark:text-zinc-700">|</span>
+              <span className="inline-flex items-center gap-1">
+                <button
+                  onClick={enterTable1a}
+                  className="text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                >
+                  Table 1a mode
+                </button>
+                <span className="relative group/t1a">
+                  <a
+                    href={IUCN_SOURCE_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                    onClick={(e) => e.stopPropagation()}
                   >
-                    Table 1a mode
-                  </button>
-                  <span className="relative group/t1a">
-                    <a
-                      href={IUCN_SOURCE_URL}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <FaInfoCircle size={10} />
-                    </a>
-                    <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 text-xs text-white bg-zinc-800 dark:bg-zinc-700 rounded whitespace-nowrap opacity-0 invisible group-hover/t1a:opacity-100 group-hover/t1a:visible z-50 shadow-lg pointer-events-none">
-                      View IUCN Red List Table 1a (PDF)
-                    </span>
+                    <FaInfoCircle size={10} />
+                  </a>
+                  <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 text-xs text-white bg-zinc-800 dark:bg-zinc-700 rounded whitespace-nowrap opacity-0 invisible group-hover/t1a:opacity-100 group-hover/t1a:visible z-50 shadow-lg pointer-events-none">
+                    View IUCN Red List Table 1a (PDF)
                   </span>
                 </span>
-              </>
-            )}
-          </>
-        )}
+              </span>
+            </>
+          )}
         </div>
       </div>
     )}

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -114,7 +114,7 @@ const stickyClasses = "sticky left-0 z-10";
 const cellPad = "px-3 py-2 md:px-4 md:py-2.5";
 const colDivider = "border-l border-zinc-200 dark:border-zinc-700";
 const numericTdNoDividerClasses = `${cellPad} text-right whitespace-nowrap w-0`;
-const numericThNoDividerClasses = `${cellPad} text-right text-sm font-bold text-zinc-600 dark:text-zinc-300 w-0`;
+const numericThNoDividerClasses = `${cellPad} text-right text-sm font-bold text-zinc-600 dark:text-zinc-300 whitespace-nowrap w-0`;
 const numericTdClasses = `${numericTdNoDividerClasses} ${colDivider}`;
 const numericThClasses = `${numericThNoDividerClasses} ${colDivider}`;
 const flexTdClasses = `${cellPad} ${colDivider} whitespace-nowrap w-0`;
@@ -465,7 +465,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         )}
         {isVisible("assessed") && (
           <td className={flexTdClasses}>
-            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[170px] md:min-w-[190px]">
+            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[230px] md:min-w-[250px]">
               <div className="h-4 w-[48px] sm:w-[60px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
               <div className="flex-1 min-w-[40px] h-3.5 sm:h-2.5 rounded-full bg-zinc-200 dark:bg-zinc-700" />
               <div className="h-3 w-[44px] sm:w-[52px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
@@ -474,7 +474,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         )}
         {isVisible("outdated") && (
           <td className={flexTdClasses}>
-            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[170px] md:min-w-[190px]">
+            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[230px] md:min-w-[250px]">
               <div className="h-4 w-[48px] sm:w-[60px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
               <div className="flex-1 min-w-[40px] h-3.5 sm:h-2.5 rounded-full bg-zinc-200 dark:bg-zinc-700" />
               <div className="h-3 w-[44px] sm:w-[52px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
@@ -483,7 +483,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         )}
         {isVisible("gbifUnassessed") && (
           <td className={flexTdClasses}>
-            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[170px] md:min-w-[190px]">
+            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[230px] md:min-w-[250px]">
               <div className="h-4 w-[48px] sm:w-[60px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
               <div className="flex-1 min-w-[40px] h-3.5 sm:h-2.5 rounded-full bg-zinc-200 dark:bg-zinc-700" />
               <div className="h-3 w-[44px] sm:w-[52px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
@@ -492,7 +492,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         )}
         {isVisible("colNe") && (
           <td className={flexTdClasses}>
-            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[170px] md:min-w-[190px]">
+            <div className="flex items-center gap-1.5 sm:gap-3 min-w-[230px] md:min-w-[250px]">
               <div className="h-4 w-[48px] sm:w-[60px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
               <div className="flex-1 min-w-[40px] h-3.5 sm:h-2.5 rounded-full bg-zinc-200 dark:bg-zinc-700" />
               <div className="h-3 w-[44px] sm:w-[52px] bg-zinc-200 dark:bg-zinc-700 rounded flex-shrink-0" />
@@ -612,7 +612,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     const fillColor = isAll ? "rgba(255,255,255,0.25)" : barColor;
     const fw = fontWeight || "font-medium";
     return (
-      <div className="flex items-center gap-1.5 sm:gap-3 min-w-[170px] md:min-w-[190px]">
+      <div className="flex items-center gap-1.5 sm:gap-3 min-w-[230px] md:min-w-[250px]">
         {count != null && (
           <span className={`text-sm md:text-base ${fw} tabular-nums text-zinc-700 dark:text-zinc-300 w-[48px] sm:w-[60px] text-right flex-shrink-0`}>
             {count.toLocaleString()}

--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -13,7 +13,7 @@ export type Brand = {
 
 // "Dash of Life" is the default brand shown on every host.
 const DEFAULT_BRAND: Brand = {
-  title: "Dash of Life: A Dashboard for Threatened Species Conservation",
+  title: "Dash of Life: A Dashboard for Conservation of Threatened Species",
   tabTitle: "Dash of Life",
   description: "A dashboard for biodiversity data about life on Earth",
   assessedTabLabel: "Red List Assessed",

--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -1,5 +1,7 @@
 export type Brand = {
   title: string;
+  /** Tagline shown beneath the title; omitted brands render no subtitle. */
+  subtitle?: string;
   description: string;
   /** Browser-tab title; falls back to `title` when omitted. */
   tabTitle?: string;
@@ -13,7 +15,8 @@ export type Brand = {
 
 // "Dash of Life" is the default brand shown on every host.
 const DEFAULT_BRAND: Brand = {
-  title: "Dash of Life: A Dashboard for Conservation of Threatened Species",
+  title: "Dash of Life",
+  subtitle: "A Dashboard for Conservation of Threatened Species",
   tabTitle: "Dash of Life",
   description: "A dashboard for biodiversity data about life on Earth",
   assessedTabLabel: "Red List Assessed",

--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -16,7 +16,7 @@ export type Brand = {
 // "Dash of Life" is the default brand shown on every host.
 const DEFAULT_BRAND: Brand = {
   title: "Dash of Life",
-  subtitle: "A Dashboard for Conservation of Threatened Species",
+  subtitle: "A Dashboard for Threatened Species Conservation",
   tabTitle: "Dash of Life",
   description: "A dashboard for biodiversity data about life on Earth",
   assessedTabLabel: "Red List Assessed",

--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -16,7 +16,7 @@ export type Brand = {
 // "Dash of Life" is the default brand shown on every host.
 const DEFAULT_BRAND: Brand = {
   title: "Dash of Life",
-  subtitle: "A Dashboard for Threatened Species Conservation",
+  subtitle: "A Dashboard for Conservation of Threatened Species",
   tabTitle: "Dash of Life",
   description: "A dashboard for biodiversity data about life on Earth",
   assessedTabLabel: "Red List Assessed",


### PR DESCRIPTION
Polishes the dashboard header, the taxa summary table, and the assessors/reviewers charts for clarity and visual hierarchy.

## Header
- Split the brand into a short title (**Dash of Life**) + a **subtitle** ("A Dashboard for Conservation of Threatened Species"); added an optional `subtitle` field to the `Brand` type (the IUCN brand keeps its single-line title).
- Responsive CSS grid (template areas):
  - **Desktop** — two vertically-centred rows: title ↔ view-mode tabs, subtitle ↔ search bar.
  - **Mobile** — stacks as **title → subtitle → tabs + theme toggle → search**.
- Theme toggle sits top-right beside the view tabs; search bar width/height and the header-to-table gap tuned.

## Summary table
- Column headers: Title Case + bold + higher contrast (was muted uppercase), `text-sm`.
- Renamed **Taxon → Taxonomic Group** (centred; left-aligned in Table 1a mode); relabelled **# Outdated Assessments (10+Y) → # Outdated (>10 yrs old)**.
- Widened the Red List Assessed / Outdated bar columns to tighten the name↔number gap; `# Described Species` header stays on one line.
- **Mobile**: smaller bar min-width + tighter cell padding so `# Red List Assessed` fits; reliable auto-scroll reveals the Assessed column on load.

## Controls bar
- Usage hint + `Source for # Described` IUCN/CoL toggle + Expand all / Table 1a are **landing-only** (hidden once a taxon is selected) and **fully hidden on mobile**. Usage hint indented to align with the table's first column.

## Charts
- Assessors and reviewers charts now use **distinct bar colors** (assessors orange `#fb923c`, reviewers indigo `#818cf8`).

> Merged latest `main` (Conservation Status rename + landing-only IUCN/CoL toggle); resolved the overlapping controls-bar conflict in favour of this branch's mobile-aware layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)