### PR TITLE
PostHog: reverse-proxy events through /ingest to beat ad blockers

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -19,6 +19,6 @@ R2_ACCESS_KEY_ID=id
 R2_SECRET_ACCESS_KEY=key
 R2_DATA_BUCKET_NAME=dashboard-data
 
-# PostHog analytics (optional, public)
+# PostHog analytics (optional, public). Events are reverse-proxied through
+# /ingest (see next.config.ts) so the host is fixed there, not via env.
 NEXT_PUBLIC_POSTHOG_KEY=your-posthog-key
-NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -23,6 +23,30 @@ const COL_ARTIFACTS = [
 ];
 
 const nextConfig: NextConfig = {
+  // Proxy PostHog through our own origin so ad/tracking blockers (which match the
+  // posthog.com domain directly) can't drop analytics for the academic audience.
+  // /static + /array hit the asset host (it keeps cache-control headers the main
+  // API strips); the catch-all must come last. EU cloud destinations.
+  async rewrites() {
+    return [
+      {
+        source: "/ingest/static/:path*",
+        destination: "https://eu-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/ingest/array/:path*",
+        destination: "https://eu-assets.i.posthog.com/array/:path*",
+      },
+      {
+        source: "/ingest/:path*",
+        destination: "https://eu.i.posthog.com/:path*",
+      },
+    ];
+  },
+  // PostHog's API relies on trailing slashes; without this Next.js redirects them
+  // and breaks event capture through the proxy.
+  skipTrailingSlashRedirect: true,
+
   // #261: DuckDB-backed read routes query Parquet in R2. Keep the native addon
   // out of the bundler, and force-include the 68MB libduckdb.so it dlopens at
   // runtime (file-tracing misses dlopen deps). Scoped to the v2 routes so the

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -129,6 +129,13 @@ export default function RedListPage() {
           >
             sw984@cam.ac.uk
           </a>
+          . See our{" "}
+          <a
+            href="/privacy"
+            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
+          >
+            privacy notice
+          </a>
           .
         </p>
         <p className="text-center text-xs text-zinc-400 dark:text-zinc-500 mt-3">

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -130,13 +130,6 @@ export default function RedListPage() {
           >
             sw984@cam.ac.uk
           </a>
-          . See our{" "}
-          <Link
-            href="/privacy"
-            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
-          >
-            privacy notice
-          </Link>
           .
         </p>
         <p className="text-center text-xs text-zinc-400 dark:text-zinc-500 mt-3">
@@ -222,6 +215,14 @@ export default function RedListPage() {
             Encyclopedia of Life
           </a>
           {" "}data. Any errors in aggregation or presentation are my own. Please verify against the primary sources before use, and do get in touch if you notice any issues.
+        </p>
+        <p className="text-center text-xs text-zinc-400 dark:text-zinc-500 mt-4">
+          <Link
+            href="/privacy"
+            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
+          >
+            Privacy policy
+          </Link>
         </p>
       </footer>
     </div>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import dynamic from "next/dynamic";
+import Link from "next/link";
 import { FaGlobeAmericas } from "react-icons/fa";
 import { SpeciesSearchBar } from "../components/SpeciesSearchBar";
 import { ThemeToggle } from "../components/ThemeToggle";
@@ -130,12 +131,12 @@ export default function RedListPage() {
             sw984@cam.ac.uk
           </a>
           . See our{" "}
-          <a
+          <Link
             href="/privacy"
             className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
           >
             privacy notice
-          </a>
+          </Link>
           .
         </p>
         <p className="text-center text-xs text-zinc-400 dark:text-zinc-500 mt-3">

--- a/app/src/app/privacy/page.tsx
+++ b/app/src/app/privacy/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Privacy",
+  title: "Privacy policy",
   description:
     "How this dashboard uses anonymous, cookieless usage analytics.",
 };
@@ -18,7 +18,7 @@ export default function PrivacyPage() {
       </Link>
 
       <h1 className="mt-6 text-2xl font-semibold text-zinc-800 dark:text-zinc-100">
-        Privacy
+        Privacy policy
       </h1>
 
       <div className="mt-4 space-y-4 text-sm text-zinc-600 dark:text-zinc-400">

--- a/app/src/app/privacy/page.tsx
+++ b/app/src/app/privacy/page.tsx
@@ -1,0 +1,96 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy",
+  description:
+    "How this dashboard uses anonymous, cookieless usage analytics.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="max-w-xl mx-auto px-4 py-12">
+      <Link
+        href="/"
+        className="text-xs text-zinc-400 dark:text-zinc-500 underline hover:text-zinc-600 dark:hover:text-zinc-300"
+      >
+        ← Back to the dashboard
+      </Link>
+
+      <h1 className="mt-6 text-2xl font-semibold text-zinc-800 dark:text-zinc-100">
+        Privacy
+      </h1>
+
+      <div className="mt-4 space-y-4 text-sm text-zinc-600 dark:text-zinc-400">
+        <p>
+          This dashboard is part of a PhD research project at the University of
+          Cambridge, which is the data controller. We collect a small amount of{" "}
+          <strong>anonymous usage analytics</strong> to understand how the
+          dashboard is used and to improve it.
+        </p>
+
+        <p>
+          <strong>What we collect.</strong> Pages viewed, the referring page,
+          and general device information such as browser and screen size, via{" "}
+          <a
+            href="https://posthog.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-zinc-800 dark:hover:text-zinc-200"
+          >
+            PostHog
+          </a>{" "}
+          (hosted in the EU). This data is not linked to your identity. We do{" "}
+          <strong>not</strong> use analytics cookies or store any identifier on
+          your device, so no cookie banner is needed. We also use{" "}
+          <a
+            href="https://sentry.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-zinc-800 dark:hover:text-zinc-200"
+          >
+            Sentry
+          </a>{" "}
+          to record technical error reports so we can fix problems.
+        </p>
+
+        <p>
+          <strong>Why.</strong> We process this data under our legitimate
+          interest in maintaining and improving a public research tool. We do
+          not sell it or use it for advertising.
+        </p>
+
+        <p>
+          <strong>Your rights and more information.</strong> You have rights
+          over your personal data under UK data protection law. For details, and
+          to exercise those rights, see the University of Cambridge{" "}
+          <a
+            href="https://www.cam.ac.uk/about-this-site/privacy-policy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-zinc-800 dark:hover:text-zinc-200"
+          >
+            privacy policy
+          </a>{" "}
+          and{" "}
+          <a
+            href="https://www.information-compliance.admin.cam.ac.uk/data-protection"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-zinc-800 dark:hover:text-zinc-200"
+          >
+            data protection information
+          </a>
+          . For anything specific to this dashboard, contact{" "}
+          <a
+            href="mailto:sw984@cam.ac.uk"
+            className="underline hover:text-zinc-800 dark:hover:text-zinc-200"
+          >
+            sw984@cam.ac.uk
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/PostHogProvider.tsx
+++ b/app/src/components/PostHogProvider.tsx
@@ -13,7 +13,11 @@ if (
     // at the real EU dashboard.
     api_host: "/ingest",
     ui_host: "https://eu.posthog.com",
-    cookieless_mode: "always",
+    // In-memory persistence: the distinct_id lives only in JS for the page
+    // session — no cookie or localStorage, so no consent banner is needed. We
+    // avoid cookieless server-hash mode because it derives identity from the
+    // client IP, which our server-side /ingest proxy hides from PostHog.
+    persistence: "memory",
     disable_session_recording: true,
   });
 }

--- a/app/src/components/PostHogProvider.tsx
+++ b/app/src/components/PostHogProvider.tsx
@@ -8,7 +8,11 @@ if (
   process.env.NEXT_PUBLIC_POSTHOG_KEY
 ) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+    // First-party reverse proxy (see next.config.ts rewrites) so ad/tracking
+    // blockers can't drop events. ui_host keeps "View in PostHog" links pointing
+    // at the real EU dashboard.
+    api_host: "/ingest",
+    ui_host: "https://eu.posthog.com",
     cookieless_mode: "always",
     disable_session_recording: true,
   });


### PR DESCRIPTION
## Problem

PostHog analytics were under-reporting. On `red.cst.cam.ac.uk` the browser console showed every analytics request failing with `net::ERR_BLOCKED_BY_CLIENT`:

```
eu.i.posthog.com/e/?...                      net::ERR_BLOCKED_BY_CLIENT
eu-assets.i.posthog.com/array/.../config     net::ERR_BLOCKED_BY_CLIENT
eu.i.posthog.com/flags/?...                  net::ERR_BLOCKED_BY_CLIENT
```

`ERR_BLOCKED_BY_CLIENT` is client-side: ad/tracking blockers match the `posthog.com` domain directly. The audience (academic/research) runs blockers at a high rate, so a meaningful share of events never left the browser.

## Changes

**1. First-party reverse proxy** (`next.config.ts`) — route PostHog through our own origin per PostHog's [official Next.js proxy guide](https://posthog.com/docs/advanced/proxy/nextjs):
- `rewrites()` map `/ingest/static/*` and `/ingest/array/*` to `eu-assets.i.posthog.com` (asset host preserves cache-control headers the main API strips), with the `/ingest/:path*` catch-all last → `eu.i.posthog.com`.
- `skipTrailingSlashRedirect: true` so Next.js doesn't 308-redirect PostHog's trailing-slash API paths and break capture.
- `PostHogProvider.tsx`: `api_host: "/ingest"`, `ui_host: "https://eu.posthog.com"`.

**2. In-memory persistence instead of cookieless** (`PostHogProvider.tsx`) — with the proxy in place, events still didn't appear. Cookieless server-hash mode derives the person identity from the client IP via a server-side hash, but the `/ingest` rewrite is server-side, so PostHog only ever sees Vercel's IP — the hash fails and the event is dropped after a `200` at ingestion. Switched `cookieless_mode: "always"` → `persistence: "memory"`: the `distinct_id` lives only in JS for the page session, so events carry a valid client-side id through the proxy. Nothing is written to a cookie or localStorage, so no consent banner is required.

**3. Privacy notice** (`app/privacy/page.tsx` + footer link in `page.tsx`) — a minimal GDPR Article 13 notice: controller (University of Cambridge), what is collected (anonymous PostHog usage analytics + Sentry error reports), lawful basis (legitimate interest), no-cookies statement, rights, and contact. Links the University [privacy policy](https://www.cam.ac.uk/about-this-site/privacy-policy) and [data-protection pages](https://www.information-compliance.admin.cam.ac.uk/data-protection).

**4. Cleanup** — removed `NEXT_PUBLIC_POSTHOG_HOST` from `.env.example`; the host is now fixed in the rewrites and read by no code.

## Verification

Curl'd every PostHog endpoint through the preview's `/ingest` proxy (with the Vercel protection-bypass header), bypassing any browser blocker:

| Endpoint | Result |
|---|---|
| `GET /ingest/static/array.js` | 200, `application/javascript`, 212 KB |
| `GET /ingest/array/<key>/config` | 200, `application/json` |
| `POST /ingest/e/` | 200 → `{"status":"Ok"}` |
| `POST /ingest/flags/` | 200, `application/json` |

In-browser: in clean incognito (no extensions), the `ERR_BLOCKED_BY_CLIENT` errors are gone and `POST /ingest/e/` returns `200`. The earlier "still blocked" reports were an aggressive request-interceptor extension in one local browser matching the request shape — not something a server-side proxy can or should defeat.

## Notes / follow-ups

- The privacy-notice wording has not been legally reviewed; worth a check with the University DPO for an institutional site.
- A `proxy_smoke_test` event from the curl verification is present in the PostHog project and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)