### PR TITLE
Add endemics filter to the country map

### DIFF
--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -118,6 +118,7 @@ export function SpeciesSearchBar() {
         movementPatterns: new Set(),
         threats: new Set(),
         hasMap: null,
+        endemicsOnly: false,
         growthForms: new Set(),
         assessors: new Set(),
         reviewers: new Set(),

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -470,7 +470,7 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
                 return "";
               })()}
               onChange={(e) => onRegionFilter(e.target.value)}
-              className="text-xs bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md px-1.5 py-0.5 text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500 max-w-[120px] truncate"
+              className="text-[10px] bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md px-1.5 py-0.5 text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500 max-w-[96px] truncate"
             >
               <option value="">All Regions</option>
               {IUCN_REGION_ORDER.map(region => (

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -157,6 +157,10 @@ interface WorldMapProps {
   speciesLabel?: string;
   // Callback when a region is selected from the dropdown (sets country filter)
   onRegionFilter?: (region: string) => void;
+  // Whether the "endemics only" filter is active (single-country species)
+  endemicsOnly?: boolean;
+  // Callback to toggle the endemics-only filter
+  onEndemicsToggle?: () => void;
   // Optional footer content rendered inside the panel below the map
   footer?: React.ReactNode;
   // Whether to show the Species/GBIF color mode toggle (only accurate for top-level taxa)
@@ -168,7 +172,7 @@ const DEFAULT_ZOOM = 1.0;
 const MIN_ZOOM = 1.0;
 const MAX_ZOOM = 8.0;
 
-function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, footer, showGbifToggle = true }: WorldMapProps) {
+function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true }: WorldMapProps) {
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
   const [hoveredCountryCode, setHoveredCountryCode] = useState<string | null>(null);
   const [speciesStats, setSpeciesStats] = useState<CountryStats>(precomputedStats || {});
@@ -432,6 +436,20 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
               GBIF
             </button>
           </div>
+          )}
+          {onEndemicsToggle && (
+            <button
+              onClick={onEndemicsToggle}
+              title="Show only species endemic to a single country"
+              aria-pressed={endemicsOnly}
+              className={`px-1.5 py-0.5 rounded-md text-[10px] font-medium transition-colors border ${
+                endemicsOnly
+                  ? "bg-teal-500 text-white border-teal-500 shadow-sm"
+                  : "bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 border-zinc-200 dark:border-zinc-700 hover:text-zinc-700 dark:hover:text-zinc-300"
+              }`}
+            >
+              Endemics
+            </button>
           )}
           {onRegionFilter && (
             <select

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -331,6 +331,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     selectedMovementPatterns, setSelectedMovementPatterns,
     selectedThreats, setSelectedThreats,
     hasMapFilter, setHasMapFilter,
+    endemicsOnly, setEndemicsOnly,
     selectedGrowthForms, setSelectedGrowthForms,
     selectedAssessors, setSelectedAssessors,
     selectedReviewers, setSelectedReviewers,
@@ -400,6 +401,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     setSelectedThreats(new Set());
     setExpandedThreat(null);
     setHasMapFilter(null);
+    setEndemicsOnly(false);
     setSelectedGrowthForms(new Set());
     setSelectedAssessors(new Set());
     setSelectedReviewers(new Set());
@@ -409,7 +411,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     if (viewMode === "new-assessments") {
       setSelectedTaxa(prev => prev.has("all") ? new Set<string>() : prev);
     }
-  }, [viewMode, setSelectedTaxa, setSelectedSubgroups, setSelectedCategories, setSelectedYearRanges, setSelectedAssessmentYears, setSelectedDescribedYears, setSelectedCountries, setSelectedObsRanges, setSelectedSystems, setSelectedPopulationTrends, setSelectedMovementPatterns, setSelectedThreats, setHasMapFilter, setSelectedGrowthForms, setSelectedAssessors, setSelectedReviewers, setSort]);
+  }, [viewMode, setSelectedTaxa, setSelectedSubgroups, setSelectedCategories, setSelectedYearRanges, setSelectedAssessmentYears, setSelectedDescribedYears, setSelectedCountries, setSelectedObsRanges, setSelectedSystems, setSelectedPopulationTrends, setSelectedMovementPatterns, setSelectedThreats, setHasMapFilter, setEndemicsOnly, setSelectedGrowthForms, setSelectedAssessors, setSelectedReviewers, setSort]);
 
   // Taxon toggle handler (used by TaxaSummary)
   // Regular click: select only that taxon (or deselect if already sole selection)
@@ -1067,6 +1069,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
       if (hasMapFilter === "yes" && !s.has_map) return;
       if (hasMapFilter === "no" && s.has_map) return;
+      if (endemicsOnly && s.countries.length !== 1) return;
       if (selectedGrowthForms.size > 0 && !s.growth_forms?.some(gf => selectedGrowthForms.has(gf))) return;
       if (!matchesAssessorsFilter(s)) return;
       if (!matchesReviewersFilter(s)) return;
@@ -1082,7 +1085,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       percent: total > 0 ? (((counts[code] || 0) / total) * 100).toFixed(1) : "0",
       label: `${(counts[code] || 0).toLocaleString()} (${total > 0 ? (((counts[code] || 0) / total) * 100).toFixed(1) : 0}%)`,
     }));
-  }, [taxaFilteredSpecies, selectedCountries, selectedYearRanges, selectedObsRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, hasMapFilter, selectedGrowthForms, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesObsRangeFilter, matchesYearRangeFilter, selectedAssessmentYears, matchesAssessmentYearFilter]);
+  }, [taxaFilteredSpecies, selectedCountries, selectedYearRanges, selectedObsRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, hasMapFilter, endemicsOnly, selectedGrowthForms, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesObsRangeFilter, matchesYearRangeFilter, selectedAssessmentYears, matchesAssessmentYearFilter]);
 
   // Year chart: apply all filters EXCEPT year range
   const assessmentYearData = useMemo(() => {
@@ -1107,6 +1110,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
       if (hasMapFilter === "yes" && !s.has_map) return;
       if (hasMapFilter === "no" && s.has_map) return;
+      if (endemicsOnly && s.countries.length !== 1) return;
       if (selectedGrowthForms.size > 0 && !s.growth_forms?.some(gf => selectedGrowthForms.has(gf))) return;
       if (!matchesAssessorsFilter(s)) return;
       if (!matchesReviewersFilter(s)) return;
@@ -1122,7 +1126,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       ...r,
       label: `${r.count.toLocaleString()} (${total > 0 ? ((r.count / total) * 100).toFixed(1) : 0}%)`,
     }));
-  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedObsRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, hasMapFilter, selectedGrowthForms, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesObsRangeFilter]);
+  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedObsRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, hasMapFilter, endemicsOnly, selectedGrowthForms, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesObsRangeFilter]);
 
   // Assessments-by-year chart: apply all filters EXCEPT the two year-based ones.
   // The Range bucket chart and the Year chart share a single cross-filter facet
@@ -1144,6 +1148,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
       if (hasMapFilter === "yes" && !s.has_map) return;
       if (hasMapFilter === "no" && s.has_map) return;
+      if (endemicsOnly && s.countries.length !== 1) return;
       if (selectedGrowthForms.size > 0 && !s.growth_forms?.some(gf => selectedGrowthForms.has(gf))) return;
       if (!matchesAssessorsFilter(s)) return;
       if (!matchesReviewersFilter(s)) return;
@@ -1159,7 +1164,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
         count,
         label: `${count.toLocaleString()} (${total > 0 ? ((count / total) * 100).toFixed(1) : 0}%)`,
       }));
-  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedObsRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, hasMapFilter, selectedGrowthForms, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesObsRangeFilter]);
+  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedObsRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, hasMapFilter, endemicsOnly, selectedGrowthForms, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesObsRangeFilter]);
 
   const yearsTotalPages = Math.max(1, Math.ceil(assessmentYearsByYearData.length / YEARS_PAGE_SIZE));
   const paginatedAssessmentYearsData = useMemo(
@@ -1216,6 +1221,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
       if (hasMapFilter === "yes" && !s.has_map) return;
       if (hasMapFilter === "no" && s.has_map) return;
+      if (endemicsOnly && s.countries.length !== 1) return;
       if (selectedGrowthForms.size > 0 && !s.growth_forms?.some(gf => selectedGrowthForms.has(gf))) return;
       if (!matchesAssessorsFilter(s)) return;
       if (!matchesReviewersFilter(s)) return;
@@ -1232,7 +1238,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       ...r,
       label: `${r.count.toLocaleString()} (${total > 0 ? ((r.count / total) * 100).toFixed(1) : 0}%)`,
     }));
-  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedYearRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, hasMapFilter, selectedGrowthForms, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesYearRangeFilter, selectedAssessmentYears, matchesAssessmentYearFilter]);
+  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedYearRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, hasMapFilter, endemicsOnly, selectedGrowthForms, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesYearRangeFilter, selectedAssessmentYears, matchesAssessmentYearFilter]);
 
   // Year Described chart (NE / new-assessments only): per-bucket counts, cross-filtered
   // by every OTHER active filter (search, country, GBIF obs) but NOT the described-year
@@ -1273,6 +1279,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
       if (hasMapFilter === "yes" && !s.has_map) return;
       if (hasMapFilter === "no" && s.has_map) return;
+      if (endemicsOnly && s.countries.length !== 1) return;
       if (selectedGrowthForms.size > 0 && !s.growth_forms?.some(gf => selectedGrowthForms.has(gf))) return;
       if (!matchesAssessorsFilter(s)) return;
       if (!matchesReviewersFilter(s)) return;
@@ -1294,7 +1301,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       ])
     );
     return { countryCounts: counts, uniqueCountries: sorted, countryStatsForMap: statsForMap };
-  }, [taxaFilteredSpecies, selectedCategories, selectedYearRanges, selectedObsRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, hasMapFilter, selectedGrowthForms, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesObsRangeFilter, matchesYearRangeFilter, selectedAssessmentYears, matchesAssessmentYearFilter]);
+  }, [taxaFilteredSpecies, selectedCategories, selectedYearRanges, selectedObsRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, hasMapFilter, endemicsOnly, selectedGrowthForms, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesObsRangeFilter, matchesYearRangeFilter, selectedAssessmentYears, matchesAssessmentYearFilter]);
 
   // Realm counts: apply all filters EXCEPT systems (for realm button tooltips)
   const realmCounts = useMemo(() => {
@@ -1311,6 +1318,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
       if (hasMapFilter === "yes" && !s.has_map) return;
       if (hasMapFilter === "no" && s.has_map) return;
+      if (endemicsOnly && s.countries.length !== 1) return;
       if (selectedGrowthForms.size > 0 && !s.growth_forms?.some(gf => selectedGrowthForms.has(gf))) return;
       if (!matchesAssessorsFilter(s)) return;
       if (!matchesReviewersFilter(s)) return;
@@ -1319,7 +1327,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       }
     });
     return counts;
-  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedYearRanges, selectedObsRanges, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, hasMapFilter, matchesObsRangeFilter, matchesYearRangeFilter, selectedGrowthForms, selectedAssessmentYears, matchesAssessmentYearFilter]);
+  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedYearRanges, selectedObsRanges, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, hasMapFilter, endemicsOnly, matchesObsRangeFilter, matchesYearRangeFilter, selectedGrowthForms, selectedAssessmentYears, matchesAssessmentYearFilter]);
 
   // Map counts: apply all filters EXCEPT hasMap
   const mapCounts = useMemo(() => {
@@ -1337,13 +1345,14 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       if (selectedMovementPatterns.size > 0 && (!s.movement_pattern || !selectedMovementPatterns.has(s.movement_pattern))) return;
       if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
       if (selectedGrowthForms.size > 0 && !s.growth_forms?.some(gf => selectedGrowthForms.has(gf))) return;
+      if (endemicsOnly && s.countries.length !== 1) return;
       if (!matchesAssessorsFilter(s)) return;
       if (!matchesReviewersFilter(s)) return;
       if (s.has_map) hasMap++;
       else noMap++;
     });
     return { yes: hasMap, no: noMap };
-  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedYearRanges, selectedObsRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, selectedGrowthForms, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesObsRangeFilter, matchesYearRangeFilter, selectedAssessmentYears, matchesAssessmentYearFilter]);
+  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedYearRanges, selectedObsRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, selectedGrowthForms, endemicsOnly, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesObsRangeFilter, matchesYearRangeFilter, selectedAssessmentYears, matchesAssessmentYearFilter]);
 
   // Population trend counts: apply all filters EXCEPT population trend
   const populationTrendCounts = useMemo(() => {
@@ -1361,13 +1370,14 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
       if (hasMapFilter === "yes" && !s.has_map) return;
       if (hasMapFilter === "no" && s.has_map) return;
+      if (endemicsOnly && s.countries.length !== 1) return;
       if (selectedGrowthForms.size > 0 && !s.growth_forms?.some(gf => selectedGrowthForms.has(gf))) return;
       if (!matchesAssessorsFilter(s)) return;
       if (!matchesReviewersFilter(s)) return;
       counts[s.population_trend] = (counts[s.population_trend] || 0) + 1;
     });
     return counts;
-  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedYearRanges, selectedObsRanges, selectedSystems, selectedMovementPatterns, selectedThreats, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, hasMapFilter, matchesObsRangeFilter, matchesYearRangeFilter, selectedGrowthForms, selectedAssessmentYears, matchesAssessmentYearFilter]);
+  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedYearRanges, selectedObsRanges, selectedSystems, selectedMovementPatterns, selectedThreats, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, hasMapFilter, endemicsOnly, matchesObsRangeFilter, matchesYearRangeFilter, selectedGrowthForms, selectedAssessmentYears, matchesAssessmentYearFilter]);
 
   // Movement pattern counts: apply all filters EXCEPT movement pattern
   const movementPatternCounts = useMemo(() => {
@@ -1385,13 +1395,14 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
       if (hasMapFilter === "yes" && !s.has_map) return;
       if (hasMapFilter === "no" && s.has_map) return;
+      if (endemicsOnly && s.countries.length !== 1) return;
       if (selectedGrowthForms.size > 0 && !s.growth_forms?.some(gf => selectedGrowthForms.has(gf))) return;
       if (!matchesAssessorsFilter(s)) return;
       if (!matchesReviewersFilter(s)) return;
       counts[s.movement_pattern] = (counts[s.movement_pattern] || 0) + 1;
     });
     return counts;
-  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedYearRanges, selectedObsRanges, selectedSystems, selectedPopulationTrends, selectedThreats, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, hasMapFilter, matchesObsRangeFilter, matchesYearRangeFilter, selectedGrowthForms, selectedAssessmentYears, matchesAssessmentYearFilter]);
+  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedYearRanges, selectedObsRanges, selectedSystems, selectedPopulationTrends, selectedThreats, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, hasMapFilter, endemicsOnly, matchesObsRangeFilter, matchesYearRangeFilter, selectedGrowthForms, selectedAssessmentYears, matchesAssessmentYearFilter]);
 
   // Threat counts: apply all filters EXCEPT threats (count species per prefix, deduplicated)
   // Threat counts per code, plus the denominator (`threatTotal`) for percentages:
@@ -1509,6 +1520,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       const matchesMovement = selectedMovementPatterns.size === 0 || (s.movement_pattern != null && selectedMovementPatterns.has(s.movement_pattern));
       const matchesThreat = selectedThreats.size === 0 || s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")));
       const matchesMap = !hasMapFilter || (hasMapFilter === "yes" ? s.has_map : !s.has_map);
+      const matchesEndemic = !endemicsOnly || s.countries.length === 1;
       const matchesGrowth = selectedGrowthForms.size === 0 || s.growth_forms?.some(gf => selectedGrowthForms.has(gf));
       const matchesSearch =
         !searchFilter ||
@@ -1518,7 +1530,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       const matchesReviewer = matchesReviewersFilter(s);
       const pinnedKey = isNewAssessments ? Math.abs(s.id) : s.sis_taxon_id;
       const matchesStarred = !showOnlyStarred || (pinnedKey != null && pinnedSet.has(pinnedKey));
-      return matchesCategory && matchesYear && matchesDescribed && matchesObs && matchesCountry && matchesSystem && matchesTrend && matchesMovement && matchesThreat && matchesMap && matchesGrowth && matchesSearch && matchesAssessor && matchesReviewer && matchesStarred;
+      return matchesCategory && matchesYear && matchesDescribed && matchesObs && matchesCountry && matchesSystem && matchesTrend && matchesMovement && matchesThreat && matchesMap && matchesEndemic && matchesGrowth && matchesSearch && matchesAssessor && matchesReviewer && matchesStarred;
     });
 
     const sorted = [...filtered].sort((a, b) => {
@@ -1570,7 +1582,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     });
 
     return { filteredSpecies: filtered, sortedSpecies: sorted };
-  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, hasMapFilter, selectedGrowthForms, searchFilter, showOnlyStarred, pinnedSet, pinnedSpecies, sortField, sortDirection, matchesAssessorsFilter, matchesReviewersFilter, isNewAssessments, matchesObsRangeFilter, matchesYearRangeFilter, matchesAssessmentYearFilter, matchesDescribedYearFilter]);
+  }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, hasMapFilter, endemicsOnly, selectedGrowthForms, searchFilter, showOnlyStarred, pinnedSet, pinnedSpecies, sortField, sortDirection, matchesAssessorsFilter, matchesReviewersFilter, isNewAssessments, matchesObsRangeFilter, matchesYearRangeFilter, matchesAssessmentYearFilter, matchesDescribedYearFilter]);
 
   // Giant aggregates (insects, invertebrates…) are capped at 400k server-side; surface
   // a banner so the list reads as "showing N of M — drill into a sub-group for the rest".
@@ -2393,6 +2405,8 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                   selectedTaxa={selectedTaxa}
                   speciesLabel={isNewAssessments ? "# Unassessed" : undefined}
                   onRegionFilter={handleRegionFilter}
+                  endemicsOnly={endemicsOnly}
+                  onEndemicsToggle={() => setEndemicsOnly(!endemicsOnly)}
                   showGbifToggle={
                     selectedSubgroups.size === 0
                     && [...selectedTaxa].every(id => id in TAXA_BY_ID)
@@ -2409,6 +2423,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                     && selectedAssessors.size === 0
                     && selectedReviewers.size === 0
                     && hasMapFilter == null
+                    && !endemicsOnly
                     && !searchFilter
                     && !showOnlyStarred
                   }
@@ -2693,6 +2708,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                     if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
                     if (hasMapFilter === "yes" && !s.has_map) return;
                     if (hasMapFilter === "no" && s.has_map) return;
+                    if (endemicsOnly && s.countries.length !== 1) return;
                     if (!matchesAssessorsFilter(s)) return;
                     if (!matchesReviewersFilter(s)) return;
                     for (const gf of s.growth_forms) {
@@ -3019,6 +3035,15 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                 <span className="text-xs">×</span>
               </button>
             )}
+            {endemicsOnly && (
+              <button
+                onClick={() => setEndemicsOnly(false)}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
+              >
+                Endemics only
+                <span className="text-xs">×</span>
+              </button>
+            )}
             {Array.from(selectedPopulationTrends).map(trend => (
               <button
                 key={`trend-${trend}`}
@@ -3111,9 +3136,9 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                 </button>
               ));
             })()}
-            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || hasMapFilter || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
+            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || hasMapFilter || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
               <button
-                onClick={() => { clearAllFilters(); setSelectedTaxa(new Set()); setSelectedSubgroups(new Set()); setSelectedObsRanges(new Set()); setSelectedSystems(new Set()); setHasMapFilter(null); setSelectedGrowthForms(new Set()); setSelectedPopulationTrends(new Set()); setSelectedMovementPatterns(new Set()); setSelectedThreats(new Set()); setExpandedThreat(null); setSelectedAssessors(new Set()); setSelectedReviewers(new Set()); setShowOnlyStarred(false); }}
+                onClick={() => { clearAllFilters(); setSelectedTaxa(new Set()); setSelectedSubgroups(new Set()); setSelectedObsRanges(new Set()); setSelectedSystems(new Set()); setHasMapFilter(null); setEndemicsOnly(false); setSelectedGrowthForms(new Set()); setSelectedPopulationTrends(new Set()); setSelectedMovementPatterns(new Set()); setSelectedThreats(new Set()); setExpandedThreat(null); setSelectedAssessors(new Set()); setSelectedReviewers(new Set()); setShowOnlyStarred(false); }}
                 className="text-xs text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 underline"
               >
                 Clear all

--- a/app/src/hooks/__tests__/filterParams.test.ts
+++ b/app/src/hooks/__tests__/filterParams.test.ts
@@ -246,6 +246,7 @@ describe("buildQs", () => {
     movementPatterns: new Set<string>(),
     threats: new Set<string>(),
     hasMap: null as "yes" | "no" | null,
+    endemicsOnly: false,
     growthForms: new Set<string>(),
     assessors: new Set<string>(),
     reviewers: new Set<string>(),
@@ -313,6 +314,17 @@ describe("buildQs", () => {
     const qs = buildQs({ ...emptyState, search: "elephant" });
     const params = new URLSearchParams(qs);
     expect(params.get("search")).toBe("elephant");
+  });
+
+  it("round-trips the endemics-only filter", () => {
+    const qs = buildQs({ ...emptyState, endemicsOnly: true });
+    expect(new URLSearchParams(qs).get("endemics")).toBe("1");
+    expect(parseParams(qs).endemicsOnly).toBe(true);
+  });
+
+  it("omits endemics when false", () => {
+    const qs = buildQs({ ...emptyState, endemicsOnly: false });
+    expect(new URLSearchParams(qs).has("endemics")).toBe(false);
   });
 
   it("collapses a sub-group into the flat taxa token (no subgroups param)", () => {
@@ -460,6 +472,7 @@ describe("parseParams ↔ buildQs round-trip", () => {
       movementPatterns: new Set<string>(),
       threats: new Set<string>(),
       hasMap: null as "yes" | "no" | null,
+      endemicsOnly: false,
       growthForms: new Set<string>(),
       assessors: new Set<string>(),
       reviewers: new Set<string>(),
@@ -499,6 +512,7 @@ describe("parseParams ↔ buildQs round-trip", () => {
       movementPatterns: new Set<string>(),
       threats: new Set<string>(),
       hasMap: null as "yes" | "no" | null,
+      endemicsOnly: false,
       growthForms: new Set<string>(),
       assessors: new Set<string>(),
       reviewers: new Set<string>(),
@@ -535,6 +549,7 @@ describe("parseParams ↔ buildQs round-trip", () => {
       movementPatterns: new Set<string>(),
       threats: new Set<string>(),
       hasMap: null as "yes" | "no" | null,
+      endemicsOnly: false,
       growthForms: new Set<string>(),
       assessors: new Set<string>(),
       reviewers: new Set<string>(),
@@ -567,6 +582,7 @@ describe("parseParams ↔ buildQs round-trip", () => {
       movementPatterns: new Set<string>(),
       threats: new Set<string>(),
       hasMap: null as "yes" | "no" | null,
+      endemicsOnly: false,
       growthForms: new Set<string>(),
       assessors: new Set<string>(),
       reviewers: new Set<string>(),
@@ -598,6 +614,7 @@ describe("parseParams ↔ buildQs round-trip", () => {
       movementPatterns: new Set<string>(),
       threats: new Set<string>(),
       hasMap: null as "yes" | "no" | null,
+      endemicsOnly: false,
       growthForms: new Set<string>(),
       assessors: new Set<string>(),
       reviewers: new Set<string>(),

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -98,6 +98,8 @@ export function parseParams(search: string) {
       ? new Set(p.get("threats")!.split(",").filter(Boolean))
       : new Set<string>(),
     hasMap: p.get("hasMap") as "yes" | "no" | null,
+    // Endemics-only: restrict to species occurring in exactly one country.
+    endemicsOnly: p.get("endemics") === "1",
     growthForms: p.get("growthForms")
       ? new Set(p.get("growthForms")!.split(",").filter(Boolean))
       : new Set<string>(),
@@ -146,6 +148,7 @@ export function buildQs(state: {
   movementPatterns: Set<string>;
   threats: Set<string>;
   hasMap: "yes" | "no" | null;
+  endemicsOnly: boolean;
   growthForms: Set<string>;
   assessors: Set<string>;
   reviewers: Set<string>;
@@ -179,6 +182,7 @@ export function buildQs(state: {
   if (state.movementPatterns.size > 0) p.set("movement", [...state.movementPatterns].join(","));
   if (state.threats.size > 0) p.set("threats", [...state.threats].join(","));
   if (state.hasMap) p.set("hasMap", state.hasMap);
+  if (state.endemicsOnly) p.set("endemics", "1");
   if (state.growthForms.size > 0) p.set("growthForms", [...state.growthForms].join(","));
   if (state.assessors.size > 0) p.set("assessors", [...state.assessors].join("|"));
   if (state.reviewers.size > 0) p.set("reviewers", [...state.reviewers].join("|"));
@@ -413,6 +417,17 @@ export function useFilterParams() {
     [syncUrl]
   );
 
+  const setEndemicsOnly = useCallback(
+    (value: boolean) => {
+      setState(prev => {
+        const next = { ...prev, endemicsOnly: value };
+        queueMicrotask(() => syncUrl(next, false));
+        return next;
+      });
+    },
+    [syncUrl]
+  );
+
   const setSelectedAssessors = useCallback(
     (updater: Set<string> | ((prev: Set<string>) => Set<string>)) => {
       setState(prev => {
@@ -533,6 +548,7 @@ export function useFilterParams() {
         movementPatterns: new Set<string>(),
         threats: new Set<string>(),
         hasMap: null,
+        endemicsOnly: false,
         growthForms: new Set<string>(),
         assessors: new Set<string>(),
         reviewers: new Set<string>(),
@@ -565,6 +581,7 @@ export function useFilterParams() {
         movementPatterns: new Set<string>(),
         threats: new Set<string>(),
         hasMap: null,
+        endemicsOnly: false,
         growthForms: new Set<string>(),
         assessors: new Set<string>(),
         reviewers: new Set<string>(),
@@ -595,6 +612,7 @@ export function useFilterParams() {
     selectedMovementPatterns: state.movementPatterns,
     selectedThreats: state.threats,
     hasMapFilter: state.hasMap,
+    endemicsOnly: state.endemicsOnly,
     selectedGrowthForms: state.growthForms,
     selectedAssessors: state.assessors,
     selectedReviewers: state.reviewers,
@@ -618,6 +636,7 @@ export function useFilterParams() {
     setSelectedMovementPatterns,
     setSelectedThreats,
     setHasMapFilter,
+    setEndemicsOnly,
     setSelectedGrowthForms,
     setSelectedAssessors,
     setSelectedReviewers,


### PR DESCRIPTION
## What

Adds an **Endemics** toggle to the country-map (`WorldMap`) panel, next to the region dropdown. When active, the dashboard is restricted to species that are **endemic — occurring in exactly one country**.

Endemism is defined as `countries.length === 1`, since that's the only endemism signal in the data model (`RedListSpecies` exposes a `countries: string[]` array but no `is_endemic` field). Combined with a country selection it naturally reads as "species endemic to *that* country" (e.g. Madagascar + Endemics → Madagascar's endemics).

## How it's wired

Follows the existing `hasMapFilter` pattern end-to-end:

- **`useFilterParams.ts`** — new `endemicsOnly` state, URL param `?endemics=1`, `setEndemicsOnly` setter, included in both clear functions and the parse/build round-trip.
- **`RedListView.tsx`** — the `s.countries.length === 1` predicate is applied in every cross-filter aggregate (category, year, GBIF observations, **country-map stats**, realm/trend/movement/growth/map counts) and the main species list, with `endemicsOnly` added to each `useMemo` dependency array. Also adds a removable "Endemics only" chip, inclusion in "Clear all", and the GBIF color-toggle guard.
- **`WorldMap.tsx`** — new `endemicsOnly` / `onEndemicsToggle` props and the toggle button.
- Updated the other `buildQs` call sites (`SpeciesSearchBar.tsx`, test fixtures) for the widened type.

## Scope note

The control lives on the country map per the request, but it filters the entire dashboard (all charts + the list), because a map-only filter would make the map disagree with the rest of the view.

## Verification

- `tsc --noEmit`: clean for app source
- `eslint` on changed files: clean
- 167 hook/lib tests pass, including 2 new round-trip tests for the `endemics` URL param

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSsqcW7Umy6MdtzkUdkv52)_