### PR TITLE
Add page-size selector to species and CITES records tables

### DIFF
--- a/app/src/components/CitesTradeSummary.tsx
+++ b/app/src/components/CitesTradeSummary.tsx
@@ -809,8 +809,11 @@ function CountryTable({
 /*  Individual shipment records table                                  */
 /* ------------------------------------------------------------------ */
 
-/** Rows shown per page in the individual-records table. */
+/** Default rows shown per page in the individual-records table. */
 const RECORDS_PAGE_SIZE = 5;
+
+/** Page-size options offered in the individual-records table. */
+const RECORDS_PAGE_SIZE_OPTIONS = [5, 10, 25, 50];
 
 /**
  * A paginated table of the individual shipment records behind the summary,
@@ -820,22 +823,42 @@ const RECORDS_PAGE_SIZE = 5;
  */
 function RecordsTable({ rows }: { rows: CompactRecord[] }) {
   const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(RECORDS_PAGE_SIZE);
   if (rows.length === 0) return null;
-  const totalPages = Math.max(1, Math.ceil(rows.length / RECORDS_PAGE_SIZE));
+  const totalPages = Math.max(1, Math.ceil(rows.length / pageSize));
   const safePage = Math.min(page, totalPages - 1);
   const pageRows = rows.slice(
-    safePage * RECORDS_PAGE_SIZE,
-    safePage * RECORDS_PAGE_SIZE + RECORDS_PAGE_SIZE
+    safePage * pageSize,
+    safePage * pageSize + pageSize
   );
 
   return (
     <div className="min-w-0">
-      <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-1.5">
-        Records{" "}
-        <span className="text-zinc-400 dark:text-zinc-500 normal-case tabular-nums">
-          ({rows.length.toLocaleString()})
-        </span>
-      </h5>
+      <div className="flex items-center justify-between gap-2 mb-1.5">
+        <h5 className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">
+          Records{" "}
+          <span className="text-zinc-400 dark:text-zinc-500 normal-case tabular-nums">
+            ({rows.length.toLocaleString()})
+          </span>
+        </h5>
+        <label className="flex items-center gap-1 text-[10px] text-zinc-400 dark:text-zinc-500">
+          <span>Rows</span>
+          <select
+            value={pageSize}
+            onChange={(e) => {
+              setPageSize(Number(e.target.value));
+              setPage(0);
+            }}
+            className="rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-1 py-0.5 text-[10px] text-zinc-600 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800 focus:outline-none cursor-pointer"
+          >
+            {RECORDS_PAGE_SIZE_OPTIONS.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
       <div className="border border-zinc-200 dark:border-zinc-800 rounded-lg overflow-x-auto">
         <table className="w-full text-[11px] whitespace-nowrap">
           <thead>
@@ -900,7 +923,7 @@ function RecordsTable({ rows }: { rows: CompactRecord[] }) {
         page={safePage}
         total={rows.length}
         onPage={setPage}
-        pageSize={RECORDS_PAGE_SIZE}
+        pageSize={pageSize}
       />
     </div>
   );

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -515,7 +515,8 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
 
   // Pagination
   const [currentPage, setCurrentPage] = useState(1);
-  const PAGE_SIZE = 10;
+  const [pageSize, setPageSize] = useState(10);
+  const PAGE_SIZE = pageSize;
 
   // ── Data fetching ────────────────────────────────────────────────────
   // Cache of fetched species per taxon ID. When "all" is fetched, it supersedes
@@ -3711,30 +3712,51 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
         </div>
 
         {/* Pagination */}
-        {totalPages > 1 && (
+        {totalFiltered > 0 && (
           <div className="flex flex-col sm:flex-row items-center justify-between px-3 md:px-4 py-3 border-t border-zinc-200 dark:border-zinc-800 gap-2">
-            <div className="text-xs md:text-sm text-zinc-500">
-              {(currentPage - 1) * PAGE_SIZE + 1}-{Math.min(currentPage * PAGE_SIZE, totalFiltered)} of {totalFiltered}
+            <div className="flex items-center gap-3">
+              <div className="text-xs md:text-sm text-zinc-500">
+                {(currentPage - 1) * PAGE_SIZE + 1}-{Math.min(currentPage * PAGE_SIZE, totalFiltered)} of {totalFiltered}
+              </div>
+              <label className="flex items-center gap-1.5 text-xs md:text-sm text-zinc-500">
+                <span>Rows</span>
+                <select
+                  value={pageSize}
+                  onChange={(e) => {
+                    setPageSize(Number(e.target.value));
+                    setCurrentPage(1);
+                  }}
+                  className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2 py-1 text-xs md:text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 focus:outline-none cursor-pointer"
+                >
+                  {[10, 25, 50, 100].map((n) => (
+                    <option key={n} value={n}>
+                      {n}
+                    </option>
+                  ))}
+                </select>
+              </label>
             </div>
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                disabled={currentPage === 1}
-                className="px-3 py-1 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-zinc-50 dark:hover:bg-zinc-800"
-              >
-                Prev
-              </button>
-              <span className="text-xs md:text-sm text-zinc-600 dark:text-zinc-400">
-                {currentPage} / {totalPages}
-              </span>
-              <button
-                onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-                disabled={currentPage === totalPages}
-                className="px-3 py-1 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-zinc-50 dark:hover:bg-zinc-800"
-              >
-                Next
-              </button>
-            </div>
+            {totalPages > 1 && (
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                  disabled={currentPage === 1}
+                  className="px-3 py-1 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                >
+                  Prev
+                </button>
+                <span className="text-xs md:text-sm text-zinc-600 dark:text-zinc-400">
+                  {currentPage} / {totalPages}
+                </span>
+                <button
+                  onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={currentPage === totalPages}
+                  className="px-3 py-1 text-sm rounded-lg border border-zinc-200 dark:border-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                >
+                  Next
+                </button>
+              </div>
+            )}
           </div>
         )}
         </>


### PR DESCRIPTION
## Summary

Adds a "Rows" page-size selector to both paginated tables so users can choose how many records to show per page.

### Species list (`RedListView.tsx`)
- Converted the fixed `PAGE_SIZE = 10` into state (default 10).
- Added a **Rows** dropdown (10 / 25 / 50 / 100) in the pagination footer; changing it resets to page 1.
- The footer now renders whenever there are records (so the selector is always reachable), while Prev/Next still only appear when there's more than one page.

### CITES records list (`CitesTradeSummary.tsx`)
- Added `pageSize` state to `RecordsTable` (default 5).
- Added a compact **Rows** dropdown (5 / 10 / 25 / 50) next to the "Records (N)" header, styled to match the small table. Changing it resets to the first page, and the existing `Pager` reflects the chosen size.

## Notes
A typecheck couldn't be run locally because `node_modules` isn't installed in this environment. The changes are self-contained React state/JSX additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Nv8JCaT4ZZu8V6TFoeN5Z)_