### PR TITLE
Add shared-filter registry to keep dashboard URL & MCP in sync

### DIFF
--- a/app/src/app/api/mcp/route.ts
+++ b/app/src/app/api/mcp/route.ts
@@ -98,7 +98,7 @@ const handler = createMcpHandler(
       "get_vocabulary",
       {
         title: "Get the valid filter vocabulary",
-        description: "Returns the valid values for browse_taxon: featured taxon groups, IUCN threat categories, status categories, IUCN regions, systems, and population trends. Call this first if unsure what values to pass.",
+        description: "Returns the valid values for browse_taxon: featured taxon groups, IUCN threat categories, status categories, IUCN regions, systems, population trends, movement patterns, growth forms, and the endemic flag. Call this first if unsure what values to pass.",
         inputSchema: {},
       },
       async () =>
@@ -110,6 +110,9 @@ const handler = createMcpHandler(
           regions: IUCN_REGION_ORDER,
           systems: SYSTEMS,
           trends: POPULATION_TRENDS,
+          movement: { note: "Free-text movement pattern; common values: Full Migrant, Altitudinal Migrant, Nomadic, Not a Migrant, Unknown." },
+          growthForms: { note: "Free-text plant/fungus growth form, e.g. Tree, Shrub, Herb, Forb, Graminoid, Geophyte, Lithophyte, Epiphyte." },
+          endemic: { note: "Pass endemic: 'yes' to keep only species endemic to a single country." },
         }),
     );
   },

--- a/app/src/app/api/mcp/route.ts
+++ b/app/src/app/api/mcp/route.ts
@@ -20,6 +20,7 @@ import { createMcpHandler } from "mcp-handler";
 import { z } from "zod";
 import { runBrowseQuery, type BrowseInput } from "@/lib/browse-query";
 import { browseInputToDashboardUrl } from "@/lib/dashboard-url";
+import { SHARED_FILTER_SCHEMA } from "@/lib/shared-filters";
 import {
   FEATURED_TAXA, THREAT_CATEGORIES, ALL_CATEGORIES,
   taxonLabel, categoryLabel, SYSTEMS, POPULATION_TRENDS,
@@ -46,17 +47,17 @@ const VERIFY_NOTE =
 const withDashboard = (input: BrowseInput, data: object) =>
   asText({ ...data, dashboard_url: browseInputToDashboardUrl(getOrigin(), input), verify_note: VERIFY_NOTE });
 
-// Shared optional-filter schema for browse_taxon.
+// Optional-filter schema for browse_taxon. The categorical filters
+// (categories, threats, systems, trends, movement, growthForms, hasMap,
+// endemic) come from the shared-filter registry — the single source of truth
+// shared with the dashboard URL, the predicate, and the dashboard-link builder,
+// so they can't drift. The fields here are the bespoke ones.
 const FILTERS = {
-  categories: z.array(z.string()).optional().describe("IUCN status codes or names: CR, EN, VU, NT, LC, DD, NE, EX, EW — or 'threatened' (=CR,EN,VU). NE = not yet evaluated."),
-  threats: z.array(z.string()).optional().describe("IUCN threat codes (prefix match, e.g. '11' = climate change) or aliases like climate-change, pollution, overfishing."),
+  ...SHARED_FILTER_SCHEMA,
   countries: z.array(z.string()).optional().describe("ISO alpha-2 codes or country names."),
   region: z.string().optional().describe("An IUCN region (expands to its countries), e.g. 'Sub-Saharan Africa'."),
   assessors: z.array(z.string()).optional().describe("Latest-assessment assessor name (substring match)."),
   reviewers: z.array(z.string()).optional().describe("Latest-assessment reviewer name (substring match)."),
-  systems: z.array(z.string()).optional(),
-  trends: z.array(z.string()).optional().describe("Population trend: Increasing, Decreasing, Stable, Unknown."),
-  hasMap: z.enum(["yes", "no"]).optional(),
   outdated: z.enum(["yes", "no"]).optional().describe("Assessment older than 10 years."),
   minObs: z.number().optional(), maxObs: z.number().optional(),
   minAssessmentYear: z.number().optional(), maxAssessmentYear: z.number().optional(),

--- a/app/src/app/api/mcp/route.ts
+++ b/app/src/app/api/mcp/route.ts
@@ -21,11 +21,7 @@ import { z } from "zod";
 import { runBrowseQuery, type BrowseInput } from "@/lib/browse-query";
 import { browseInputToDashboardUrl } from "@/lib/dashboard-url";
 import { SHARED_FILTER_SCHEMA } from "@/lib/shared-filters";
-import {
-  FEATURED_TAXA, THREAT_CATEGORIES, ALL_CATEGORIES,
-  taxonLabel, categoryLabel, SYSTEMS, POPULATION_TRENDS,
-} from "@/lib/filter-vocab";
-import { IUCN_REGION_ORDER } from "@/lib/regions";
+import { buildVocabulary } from "@/lib/browse-help";
 
 export const maxDuration = 60;
 
@@ -101,19 +97,7 @@ const handler = createMcpHandler(
         description: "Returns the valid values for browse_taxon: featured taxon groups, IUCN threat categories, status categories, IUCN regions, systems, population trends, movement patterns, growth forms, and the endemic flag. Call this first if unsure what values to pass.",
         inputSchema: {},
       },
-      async () =>
-        asText({
-          taxa: FEATURED_TAXA.map((id) => ({ id, label: taxonLabel(id) })),
-          note: "taxa also accepts any sub-group or scientific class/order/family name.",
-          threats: THREAT_CATEGORIES.map((t) => ({ code: t.code, label: t.label })),
-          categories: ALL_CATEGORIES.map((c) => ({ code: c, label: categoryLabel(c) })),
-          regions: IUCN_REGION_ORDER,
-          systems: SYSTEMS,
-          trends: POPULATION_TRENDS,
-          movement: { note: "Free-text movement pattern; common values: Full Migrant, Altitudinal Migrant, Nomadic, Not a Migrant, Unknown." },
-          growthForms: { note: "Free-text plant/fungus growth form, e.g. Tree, Shrub, Herb, Forb, Graminoid, Geophyte, Lithophyte, Epiphyte." },
-          endemic: { note: "Pass endemic: 'yes' to keep only species endemic to a single country." },
-        }),
+      async () => asText(buildVocabulary()),
     );
   },
   {},

--- a/app/src/app/browse/__tests__/browse.test.ts
+++ b/app/src/app/browse/__tests__/browse.test.ts
@@ -40,7 +40,8 @@ beforeEach(() => {
 describe("/browse", () => {
   it("returns a self-describing index when called bare (json)", async () => {
     const d = await json("?format=json");
-    expect(d.params.taxa.length).toBeGreaterThan(0);
+    expect(d.taxa.length).toBeGreaterThan(0);
+    expect(d.filters.length).toBeGreaterThan(0);
     expect(d.examples.length).toBeGreaterThan(0);
     expect(querySpecies).not.toHaveBeenCalled();
   });

--- a/app/src/app/browse/route.ts
+++ b/app/src/app/browse/route.ts
@@ -11,13 +11,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { runBrowseQuery, type BrowseInput, type BrowseResult, type BrowseSpecies } from "@/lib/browse-query";
 import { browseInputToDashboardUrl } from "@/lib/dashboard-url";
+import { readSharedInput } from "@/lib/shared-filters";
+import { buildVocabulary, type Vocabulary } from "@/lib/browse-help";
 import { CATEGORY_ORDER } from "@/config/taxa";
 import { CACHE_1H } from "@/lib/cache-headers";
-import {
-  taxonLabel, categoryLabel,
-  THREAT_CATEGORIES, FEATURED_TAXA, ALL_CATEGORIES, SYSTEMS, POPULATION_TRENDS,
-} from "@/lib/filter-vocab";
-import { IUCN_REGION_ORDER } from "@/lib/regions";
+import { categoryLabel } from "@/lib/filter-vocab";
 
 export const revalidate = 3600;
 
@@ -45,20 +43,15 @@ export async function GET(req: NextRequest) {
     const n = parseInt(v, 10);
     return Number.isNaN(n) ? undefined : n;
   };
-  const hasMapRaw = sp.get("hasMap");
   const outdatedRaw = sp.get("outdated");
   const input: BrowseInput = {
+    // Categorical filters (categories…endemic) are read from the URL by the
+    // shared registry, so /browse parses every registry filter automatically.
+    ...readSharedInput(sp),
     taxa: parseList(sp, "taxa"),
     search: (sp.get("search") ?? "").trim(),
-    categories: parseList(sp, "categories"),
-    threats: parseList(sp, "threats"),
     countries: parseList(sp, "countries"),
     region: parseList(sp, "region"),
-    systems: parseList(sp, "systems"),
-    trends: parseList(sp, "trends"),
-    movement: parseList(sp, "movement"),
-    growthForms: parseList(sp, "growthForms"),
-    hasMap: hasMapRaw === "yes" ? "yes" : hasMapRaw === "no" ? "no" : undefined,
     outdated: outdatedRaw === "yes" ? "yes" : outdatedRaw === "no" ? "no" : null,
     assessors: parseList(sp, "assessors"),
     reviewers: parseList(sp, "reviewers"),
@@ -197,37 +190,24 @@ const EXAMPLES: { url: string; desc: string }[] = [
 ];
 
 function indexData(unresolved: string[]) {
-  return {
-    description: "Server-rendered view of the Red List dashboard. Two modes: browse a taxon (taxa=…, with optional base filters) or look up a species by name (search=…, synonym-aware). Values may be codes or plain-English names. Results capped, with a total count.",
-    unresolved,
-    params: {
-      taxa: FEATURED_TAXA.map((id) => ({ id, label: taxonLabel(id) })),
-      threats: THREAT_CATEGORIES.map((t) => ({ code: t.code, label: t.label })),
-      categories: ALL_CATEGORIES.map((c) => ({ code: c, label: categoryLabel(c) })),
-      region: IUCN_REGION_ORDER,
-      systems: SYSTEMS,
-      trends: POPULATION_TRENDS,
-      hasMap: ["yes", "no"],
-      search: "free-text scientific or common name (incl. synonyms / old names)",
-      assessors: "latest-assessment assessor name (substring, e.g. Smith)",
-      reviewers: "latest-assessment reviewer name (substring)",
-      outdated: "yes | no (assessment >10 years old)",
-      minObs: "min GBIF occurrence count (e.g. 100)",
-      maxObs: "max GBIF occurrence count",
-      minAssessmentYear: "earliest assessment year (e.g. 2015)",
-      maxAssessmentYear: "latest assessment year",
-      minDescribedYear: "earliest CoL year-described (NE species)",
-      maxDescribedYear: "latest CoL year-described",
-    },
-    note: "taxa accepts any taxonomic rank — a curated group (birds, corals), a sub-group (sharks-rays, flatworms), or a scientific name (felidae, odonata). Every response includes a `stats` object (assessed/outdated/outdated_pct) for percentage questions.",
-    examples: EXAMPLES,
-  };
+  return { ...buildVocabulary(), unresolved, examples: EXAMPLES };
+}
+
+/** Render one filter's enumerable values for the HTML help (coded vocab → `code` label). */
+function vocabValuesHtml(v: Vocabulary["filters"][number]): string {
+  const vals = v.values
+    .map((x) => (typeof x === "string" ? `<code>${esc(x)}</code>` : `<code>${esc(x.code)}</code> ${esc(x.label)}`))
+    .join(", ");
+  return `<strong>${esc(v.key)}</strong>: ${vals}${v.note ? ` — ${esc(v.note)}` : ""}`;
 }
 
 function indexHtml(unresolved: string[]): string {
-  const taxaList = FEATURED_TAXA.map((id) => `<code>${esc(id)}</code> (${esc(taxonLabel(id))})`).join(", ");
-  const threatList = THREAT_CATEGORIES.map((t) => `<code>${t.code}</code> ${esc(t.label)}`).join(", ");
-  const catList = ALL_CATEGORIES.map((c) => `<code>${c}</code> ${esc(categoryLabel(c))}`).join(", ");
+  const vocab = buildVocabulary();
+  const taxaList = vocab.taxa.map((t) => `<code>${esc(t.id)}</code> (${esc(t.label)})`).join(", ");
+  const filterLines = vocab.filters.map((v) => `<p>${vocabValuesHtml(v)}</p>`).join("\n");
+  const paramLines = Object.entries(vocab.params)
+    .map(([k, desc]) => `<strong>${esc(k)}</strong>: ${esc(desc)}`)
+    .join(" ");
   const examples = EXAMPLES.map((e) => `<li><a href="${esc(e.url)}">${esc(e.url)}</a> — ${esc(e.desc)}</li>`).join("");
 
   return `${PAGE_HEAD}<h1>Red List Dashboard — Browse</h1>
@@ -237,15 +217,12 @@ ${unresolvedBlock(unresolved)}
 <li><strong>Browse a taxon</strong>: <code>?taxa=&lt;name&gt;</code> + optional filters. <code>taxa</code> works at <em>any rank</em> — a group (<code>birds</code>, <code>corals</code>), a sub-group (<code>sharks-rays</code>, <code>flatworms</code>), or a scientific name (<code>felidae</code>, <code>odonata</code>).</li>
 <li><strong>Look up a species</strong>: <code>?search=&lt;name&gt;</code> — scientific or common name, including <em>synonyms / old names</em>.</li>
 </ul>
-<p>Values can be codes <em>or</em> plain-English names. Add <code>&amp;format=json</code> for JSON. Within one filter, comma-separated values are OR; across filters they are AND. Threats match by prefix (<code>11</code> covers <code>11.1</code>, <code>11.4</code>, …).</p>
+<p>Values can be codes <em>or</em> plain-English names. Add <code>&amp;format=json</code> for JSON. Within one filter, comma-separated values are OR; across filters they are AND.</p>
 <h2>Filters (combine with <code>taxa</code>)</h2>
-<p><strong>taxa</strong>: ${taxaList} — or any sub-group / scientific name.</p>
-<p><strong>threats</strong>: ${threatList} — plus aliases like <code>climate-change</code>, <code>pollution</code>, <code>overfishing</code>.</p>
-<p><strong>categories</strong>: ${catList} — plus <code>threatened</code> (= CR, EN, VU).</p>
-<p><strong>systems</strong>: ${SYSTEMS.map((s) => `<code>${s}</code>`).join(", ")}. <strong>trends</strong>: ${POPULATION_TRENDS.map((s) => `<code>${s}</code>`).join(", ")}. <strong>hasMap</strong>: <code>yes</code>/<code>no</code>.</p>
-<p><strong>countries</strong>: ISO code or name. <strong>region</strong> (IUCN): ${IUCN_REGION_ORDER.map((r) => `<code>${esc(r)}</code>`).join(", ")}.</p>
-<p><strong>assessors</strong> / <strong>reviewers</strong>: name of the latest-assessment assessor/reviewer (substring match).</p>
-<p><strong>outdated</strong>: <code>yes</code>/<code>no</code> (assessment &gt;10 yrs old). <strong>minObs</strong>/<strong>maxObs</strong>, <strong>minAssessmentYear</strong>/<strong>maxAssessmentYear</strong>, <strong>minDescribedYear</strong>/<strong>maxDescribedYear</strong>: numeric bounds.</p>
+<p><strong>taxa</strong>: ${taxaList} — ${esc(vocab.taxaNote)}</p>
+${filterLines}
+<p><strong>region</strong> (IUCN): ${vocab.region.map((r) => `<code>${esc(r)}</code>`).join(", ")}.</p>
+<p>${paramLines}</p>
 <p>Every response leads with a total, a by-category breakdown, and an outdated count + %, so percentage questions are answered in one request.</p>
 <h2>Examples</h2><ul>${examples}</ul>
 ${PAGE_FOOT}`;

--- a/app/src/app/browse/route.ts
+++ b/app/src/app/browse/route.ts
@@ -58,7 +58,7 @@ export async function GET(req: NextRequest) {
     trends: parseList(sp, "trends"),
     movement: parseList(sp, "movement"),
     growthForms: parseList(sp, "growthForms"),
-    hasMap: hasMapRaw === "yes" ? "yes" : hasMapRaw === "no" ? "no" : null,
+    hasMap: hasMapRaw === "yes" ? "yes" : hasMapRaw === "no" ? "no" : undefined,
     outdated: outdatedRaw === "yes" ? "yes" : outdatedRaw === "no" ? "no" : null,
     assessors: parseList(sp, "assessors"),
     reviewers: parseList(sp, "reviewers"),

--- a/app/src/app/llms.txt/__tests__/llms.test.ts
+++ b/app/src/app/llms.txt/__tests__/llms.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Drift guard for /llms.txt — the discovery surface agents read first. Its
+ * categorical-filter section is generated from the shared-filter registry, so
+ * this asserts every registry filter (and the newly-added movement/growthForms/
+ * endemic) is actually advertised — no filter can be merged undocumented here.
+ */
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "../route";
+import { SHARED_FILTER_VOCAB } from "@/lib/shared-filters";
+
+const body = () => GET(new NextRequest("https://example.test/llms.txt")).text();
+
+describe("/llms.txt", () => {
+  it("advertises every shared-filter registry key", async () => {
+    const text = await body();
+    for (const v of SHARED_FILTER_VOCAB) {
+      expect(text, `llms.txt is missing filter "${v.key}"`).toContain(v.key);
+    }
+  });
+
+  it("includes the filters that previously drifted (movement, growthForms, endemic)", async () => {
+    const text = await body();
+    expect(text).toContain("movement");
+    expect(text).toContain("growthForms");
+    expect(text).toContain("endemic");
+  });
+});

--- a/app/src/app/llms.txt/route.ts
+++ b/app/src/app/llms.txt/route.ts
@@ -1,25 +1,37 @@
 /**
  * /llms.txt — a short, machine-readable guide so an agent can answer questions
- * from the dashboard via /browse. Generated from filter-vocab so it can't drift
- * from what /browse actually accepts. The base URL is taken from the request
+ * from the dashboard via /browse. The categorical filters are generated from the
+ * shared-filter registry (the same source /browse + get_vocabulary use), so this
+ * can't advertise a different filter set. The base URL is taken from the request
  * origin, so pasted example links always point at this same deployment.
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { CACHE_1H } from "@/lib/cache-headers";
-import {
-  THREAT_CATEGORIES, FEATURED_TAXA, ALL_CATEGORIES,
-  SYSTEMS, POPULATION_TRENDS, taxonLabel, categoryLabel,
-} from "@/lib/filter-vocab";
+import { FEATURED_TAXA, taxonLabel } from "@/lib/filter-vocab";
+import { SHARED_FILTER_VOCAB, type FilterVocab } from "@/lib/shared-filters";
 import { IUCN_REGION_ORDER } from "@/lib/regions";
 
 export const revalidate = 3600;
 
+/** Render one registry filter as an llms.txt parameter block. Coded vocab
+ *  (categories, threats) becomes a header + one line per code; the rest a
+ *  one-liner of values and/or a note — so every registry filter is listed. */
+function paramBlock(v: FilterVocab): string {
+  const coded = v.values.length > 0 && typeof v.values[0] !== "string";
+  if (coded) {
+    const lines = (v.values as { code: string; label: string }[])
+      .map((x) => `  - ${x.code} = ${x.label}`).join("\n");
+    return `${v.key}${v.note ? ` (${v.note})` : ""}:\n${lines}`;
+  }
+  const vals = (v.values as string[]).join(", ");
+  return `${v.key}: ${vals}${v.note ? ` (${v.note})` : ""}`;
+}
+
 export function GET(req: NextRequest) {
   const base = new URL(req.url).origin;
   const taxa = FEATURED_TAXA.map((id) => `  - ${id} (${taxonLabel(id)})`).join("\n");
-  const threats = THREAT_CATEGORIES.map((t) => `  - ${t.code} = ${t.label}`).join("\n");
-  const cats = ALL_CATEGORIES.map((c) => `  - ${c} = ${categoryLabel(c)}`).join("\n");
+  const filters = SHARED_FILTER_VOCAB.map(paramBlock).join("\n");
 
   const body = `# Red List Dashboard
 
@@ -60,16 +72,7 @@ including synonyms / old names (they resolve to the accepted species).
 taxa — any rank; featured groups:
 ${taxa}
 
-threats — IUCN threat class (sub-codes like 11.4 work; aliases: climate-change,
-pollution, invasive-species, overfishing, logging, hunting, dams):
-${threats}
-
-categories — IUCN status (aliases: threatened = CR,EN,VU; extinct = EX,EW):
-${cats}
-
-systems: ${SYSTEMS.join(", ")}
-trends:  ${POPULATION_TRENDS.join(", ")}
-hasMap:  yes | no
+${filters}
 countries: ISO alpha-2 code or name (e.g. IN or India)
 region (IUCN region — expands to its countries): ${IUCN_REGION_ORDER.join(", ")}
 assessors / reviewers: name of the latest-assessment assessor/reviewer (substring, e.g. assessors=Smith)

--- a/app/src/lib/__tests__/shared-filters.test.ts
+++ b/app/src/lib/__tests__/shared-filters.test.ts
@@ -42,11 +42,13 @@ describe("every shared filter round-trips MCP input → dashboard URL → parseP
       const qs = browseInputToDashboardQuery({ taxa: ["mammals"], [f.mcpKey]: f.sample });
 
       // 1. The MCP→dashboard-URL builder emits this filter's param.
-      expect(new URLSearchParams(qs).has(f.urlKey)).toBe(true);
+      const emitted = new URLSearchParams(qs).get(f.urlKey);
+      expect(emitted).not.toBeNull();
 
-      // 2. The dashboard parses it and re-emits it (no silent drop in buildQs/parseParams).
+      // 2. The dashboard parses it and re-emits it with the SAME value (no silent
+      //    drop OR mis-decode in buildQs/parseParams).
       const rebuilt = new URLSearchParams(buildQs(parseParams(qs)));
-      expect(rebuilt.has(f.urlKey)).toBe(true);
+      expect(rebuilt.get(f.urlKey)).toBe(emitted);
     });
   }
 });

--- a/app/src/lib/__tests__/shared-filters.test.ts
+++ b/app/src/lib/__tests__/shared-filters.test.ts
@@ -11,11 +11,16 @@
 import { describe, it, expect } from "vitest";
 import {
   SHARED_FILTERS, SHARED_FILTER_SCHEMA,
-  applySharedFilters, emitSharedParams, matchSharedFilters,
+  applySharedFilters, emitSharedParams, matchSharedFilters, readSharedInput,
 } from "@/lib/shared-filters";
 import { browseInputToDashboardQuery } from "@/lib/dashboard-url";
+import { buildVocabulary } from "@/lib/browse-help";
 import { parseParams, buildQs } from "@/hooks/useFilterParams";
 import { matchesSpeciesFilter, type SpeciesFilterCriteria } from "@/lib/species-filter";
+
+/** The URL-param value a /browse or shared link would carry for a filter's sample. */
+const urlValue = (sample: unknown): string =>
+  Array.isArray(sample) ? sample.join(",") : String(sample);
 
 describe("shared-filter registry integrity", () => {
   it("every descriptor has a matching MCP schema entry (and vice versa)", () => {
@@ -51,6 +56,46 @@ describe("every shared filter round-trips MCP input → dashboard URL → parseP
       expect(rebuilt.get(f.urlKey)).toBe(emitted);
     });
   }
+});
+
+// The /browse route builds its BrowseInput via readSharedInput, so a filter
+// added to the registry must be parsed from a pasted /browse URL with no edit
+// to the route. This fails if readParam isn't wired (the bug that left the
+// endemic filter dead on /browse even though MCP + the dashboard URL had it).
+describe("every shared filter is parsed from a /browse URL by readSharedInput", () => {
+  for (const f of SHARED_FILTERS) {
+    it(`${f.mcpKey} is read from ?${f.urlKey}=… and resolves`, () => {
+      const sp = new URLSearchParams({ [f.urlKey]: urlValue(f.sample) });
+      const parsed = readSharedInput(sp);
+
+      // 1. readSharedInput picks the value up under the MCP key.
+      expect(parsed[f.mcpKey]).toBeDefined();
+
+      // 2. ...and it resolves into a real criterion (a non-empty `interpreted` line).
+      const c: SpeciesFilterCriteria = {};
+      const { describe: lines } = applySharedFilters(parsed, c);
+      expect(lines.length).toBeGreaterThan(0);
+    });
+  }
+});
+
+// Discovery surfaces (the /browse index help + the get_vocabulary MCP tool) both
+// render buildVocabulary(), so every registry filter is advertised. This fails
+// if a filter is added but never described (the gap that hid movement/
+// growthForms/endemic from agents).
+describe("the shared vocabulary advertises every registry filter", () => {
+  it("buildVocabulary().filters covers exactly the registry filters", () => {
+    const vocabKeys = buildVocabulary().filters.map((v) => v.key).sort();
+    const registryKeys = SHARED_FILTERS.map((f) => f.mcpKey).sort();
+    expect(vocabKeys).toEqual(registryKeys);
+  });
+
+  it("each filter has a label and either enumerable values or a note", () => {
+    for (const v of buildVocabulary().filters) {
+      expect(v.label).toBeTruthy();
+      expect(v.values.length > 0 || !!v.note).toBe(true);
+    }
+  });
 });
 
 describe("registry predicate clauses", () => {

--- a/app/src/lib/__tests__/shared-filters.test.ts
+++ b/app/src/lib/__tests__/shared-filters.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Drift guard for the shared-filter registry.
+ *
+ * The whole point of the registry (@/lib/shared-filters) is that a filter
+ * declared once is wired into every surface — the MCP input schema, the
+ * server predicate, the dashboard-link builder, AND the dashboard URL state.
+ * These tests fail if any registry filter falls out of sync with one of them,
+ * so a new filter can't be merged half-wired (the bug that left `endemics`,
+ * `movement`, and `growthForms` missing from the MCP tools).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  SHARED_FILTERS, SHARED_FILTER_SCHEMA,
+  applySharedFilters, emitSharedParams, matchSharedFilters,
+} from "@/lib/shared-filters";
+import { browseInputToDashboardQuery } from "@/lib/dashboard-url";
+import { parseParams, buildQs } from "@/hooks/useFilterParams";
+import { matchesSpeciesFilter, type SpeciesFilterCriteria } from "@/lib/species-filter";
+
+describe("shared-filter registry integrity", () => {
+  it("every descriptor has a matching MCP schema entry (and vice versa)", () => {
+    const descriptorKeys = SHARED_FILTERS.map((f) => f.mcpKey).sort();
+    const schemaKeys = Object.keys(SHARED_FILTER_SCHEMA).sort();
+    expect(descriptorKeys).toEqual(schemaKeys);
+  });
+
+  it("uses unique MCP keys and dashboard URL keys", () => {
+    const mcp = SHARED_FILTERS.map((f) => f.mcpKey);
+    const url = SHARED_FILTERS.map((f) => f.urlKey);
+    expect(new Set(mcp).size).toBe(mcp.length);
+    expect(new Set(url).size).toBe(url.length);
+  });
+});
+
+// The guarantee: for every registry filter, an MCP input value flows all the way
+// to the dashboard URL AND the dashboard parses it back (round-trips through
+// buildQs). If a filter is added to the registry but its URL param isn't taught
+// to parseParams/buildQs, one of these assertions fails.
+describe("every shared filter round-trips MCP input → dashboard URL → parseParams", () => {
+  for (const f of SHARED_FILTERS) {
+    it(`${f.mcpKey} reaches the dashboard URL and survives a parse/rebuild`, () => {
+      const qs = browseInputToDashboardQuery({ taxa: ["mammals"], [f.mcpKey]: f.sample });
+
+      // 1. The MCP→dashboard-URL builder emits this filter's param.
+      expect(new URLSearchParams(qs).has(f.urlKey)).toBe(true);
+
+      // 2. The dashboard parses it and re-emits it (no silent drop in buildQs/parseParams).
+      const rebuilt = new URLSearchParams(buildQs(parseParams(qs)));
+      expect(rebuilt.has(f.urlKey)).toBe(true);
+    });
+  }
+});
+
+describe("registry predicate clauses", () => {
+  const base = {
+    category: "VU", countries: ["BR", "AR"], systems: ["Marine"],
+    population_trend: "Decreasing", movement_pattern: "Migratory",
+    threat_codes: ["11.4"], has_map: true, growth_forms: ["Tree"],
+    scientific_name: "X", common_name: null,
+  };
+
+  it("matchSharedFilters covers every categorical clause", () => {
+    // A criteria that selects the base species on every registry dimension.
+    const c: SpeciesFilterCriteria = {
+      categories: new Set(["VU"]), threats: new Set(["11"]),
+      systems: new Set(["Marine"]), populationTrends: new Set(["Decreasing"]),
+      movementPatterns: new Set(["Migratory"]), growthForms: new Set(["Tree"]),
+      hasMap: "yes",
+    };
+    expect(matchSharedFilters(base, c)).toBe(true);
+    // Flip each and confirm it now fails — proves the clause is wired.
+    expect(matchSharedFilters({ ...base, category: "EN" }, c)).toBe(false);
+    expect(matchSharedFilters({ ...base, threat_codes: ["5.4"] }, c)).toBe(false);
+    expect(matchSharedFilters({ ...base, systems: ["Freshwater"] }, c)).toBe(false);
+    expect(matchSharedFilters({ ...base, population_trend: "Stable" }, c)).toBe(false);
+    expect(matchSharedFilters({ ...base, movement_pattern: "Nomadic" }, c)).toBe(false);
+    expect(matchSharedFilters({ ...base, growth_forms: ["Shrub"] }, c)).toBe(false);
+    expect(matchSharedFilters({ ...base, has_map: false }, c)).toBe(false);
+  });
+
+  it("endemic filter keeps single-country species only", () => {
+    const c: SpeciesFilterCriteria = { endemicsOnly: true };
+    expect(matchesSpeciesFilter({ ...base, countries: ["BR"] }, c)).toBe(true);
+    expect(matchesSpeciesFilter({ ...base, countries: ["BR", "AR"] }, c)).toBe(false);
+  });
+});
+
+describe("applySharedFilters / emitSharedParams", () => {
+  it("resolves vocabulary aliases and reports unresolved tokens", () => {
+    const c: SpeciesFilterCriteria = {};
+    const { unresolved, describe } = applySharedFilters(
+      { categories: ["threatened", "not-a-category"], endemic: "yes" },
+      c,
+    );
+    expect(c.categories).toEqual(new Set(["CR", "EN", "VU"]));
+    expect(c.endemicsOnly).toBe(true);
+    expect(unresolved).toContain("categories=not-a-category");
+    expect(describe.some((d) => d.startsWith("Categories:"))).toBe(true);
+  });
+
+  it("emits dashboard params from resolved criteria", () => {
+    const c: SpeciesFilterCriteria = {};
+    applySharedFilters({ trends: ["Decreasing"], hasMap: "no", endemic: "yes" }, c);
+    const p = new URLSearchParams();
+    emitSharedParams(c, p);
+    expect(p.get("trends")).toBe("Decreasing");
+    expect(p.get("hasMap")).toBe("no");
+    expect(p.get("endemics")).toBe("1");
+  });
+});

--- a/app/src/lib/__tests__/shared-filters.test.ts
+++ b/app/src/lib/__tests__/shared-filters.test.ts
@@ -77,6 +77,12 @@ describe("every shared filter is parsed from a /browse URL by readSharedInput", 
       expect(lines.length).toBeGreaterThan(0);
     });
   }
+
+  it("reads the canonical endemics=1 dashboard form (not just the yes alias)", () => {
+    expect(readSharedInput(new URLSearchParams("endemics=1")).endemic).toBe("yes");
+    expect(readSharedInput(new URLSearchParams("endemics=yes")).endemic).toBe("yes");
+    expect(readSharedInput(new URLSearchParams("endemics=0")).endemic).toBeUndefined();
+  });
 });
 
 // Discovery surfaces (the /browse index help + the get_vocabulary MCP tool) both

--- a/app/src/lib/browse-help.ts
+++ b/app/src/lib/browse-help.ts
@@ -1,0 +1,48 @@
+/**
+ * The complete, self-describing query vocabulary for the agent/human data
+ * surface — the SINGLE source for BOTH the /browse index help and the
+ * get_vocabulary MCP tool, so the two can never advertise different filter sets.
+ *
+ * The categorical filters come straight from the shared-filter registry
+ * (SHARED_FILTER_VOCAB), so a filter added there shows up here automatically;
+ * the bespoke params (taxa, region, country, name/people search, numeric bounds)
+ * are listed alongside.
+ */
+import { taxonLabel, FEATURED_TAXA } from "@/lib/filter-vocab";
+import { IUCN_REGION_ORDER } from "@/lib/regions";
+import { SHARED_FILTER_VOCAB, type FilterVocab } from "@/lib/shared-filters";
+
+export interface Vocabulary {
+  description: string;
+  taxa: { id: string; label: string }[];
+  taxaNote: string;
+  /** Categorical filters, registry-driven (categories, threats, …, endemic). */
+  filters: FilterVocab[];
+  region: readonly string[];
+  /** Bespoke (non-registry) params, each a short usage note. */
+  params: Record<string, string>;
+}
+
+export function buildVocabulary(): Vocabulary {
+  return {
+    description:
+      "Query the Red List dashboard from a URL. Two modes: browse a taxon (taxa=…, with optional filters) or look up a species by name (search=…, synonym-aware). Within one filter, comma-separated values are OR; across filters they are AND.",
+    taxa: FEATURED_TAXA.map((id) => ({ id, label: taxonLabel(id) })),
+    taxaNote: "taxa accepts any rank — a curated group (birds, corals), a sub-group (sharks-rays), or a scientific class/order/family name (felidae, odonata).",
+    filters: SHARED_FILTER_VOCAB,
+    region: IUCN_REGION_ORDER,
+    params: {
+      countries: "ISO code or name.",
+      assessors: "latest-assessment assessor name (substring match, e.g. Smith).",
+      reviewers: "latest-assessment reviewer name (substring match).",
+      outdated: "yes | no (assessment >10 years old).",
+      search: "free-text scientific or common name (incl. synonyms / old names).",
+      minObs: "min GBIF occurrence count (e.g. 100).",
+      maxObs: "max GBIF occurrence count.",
+      minAssessmentYear: "earliest assessment year (e.g. 2015).",
+      maxAssessmentYear: "latest assessment year.",
+      minDescribedYear: "earliest CoL year-described (NE species).",
+      maxDescribedYear: "latest CoL year-described.",
+    },
+  };
+}

--- a/app/src/lib/browse-query.ts
+++ b/app/src/lib/browse-query.ts
@@ -13,31 +13,27 @@ import { querySpecies, searchSpecies, type SearchResult } from "@/lib/data/speci
 import { isOutdated } from "@/lib/data/species-store";
 import { findNode, speciesMatchesNode } from "@/lib/taxonomy-utils";
 import { matchesSpeciesFilter, type SpeciesFilterCriteria, type FilterableSpecies } from "@/lib/species-filter";
+import { applySharedFilters, type SharedFilterInput } from "@/lib/shared-filters";
 import type { RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
 import { parseAssessors } from "@/lib/parseAssessors";
 import { resolveRegions } from "@/lib/regions";
 import { CATEGORY_ORDER } from "@/config/taxa";
 import {
-  resolveTaxa, resolveThreats, resolveCategories, resolveCountries,
-  taxonLabel, categoryLabel, countryLabel, threatDisplay, THREAT_LABEL,
+  resolveTaxa, resolveCountries,
+  taxonLabel, categoryLabel, countryLabel, threatDisplay,
 } from "@/lib/filter-vocab";
 
 export const RESULT_CAP = 200;
 
-const threatLabel = (code: string) => (THREAT_LABEL[code] ? `${THREAT_LABEL[code]} (${code})` : code);
-
-export interface BrowseInput {
+// The categorical filters (categories, threats, systems, trends, movement,
+// growthForms, hasMap, endemic) come from the shared-filter registry via
+// SharedFilterInput; the fields below are the bespoke ones (taxa/search,
+// country+region, assessor/reviewer substring, and the exact numeric params).
+export interface BrowseInput extends SharedFilterInput {
   taxa?: string[];
   search?: string;
-  categories?: string[];
-  threats?: string[];
   countries?: string[];
   region?: string[];
-  systems?: string[];
-  trends?: string[];
-  movement?: string[];
-  growthForms?: string[];
-  hasMap?: "yes" | "no" | null;
   outdated?: "yes" | "no" | null;
   assessors?: string[];
   reviewers?: string[];
@@ -110,24 +106,28 @@ const setOrUndef = (a: string[]) => (a.length ? new Set(a) : undefined);
 
 export async function runBrowseQuery(input: BrowseInput): Promise<BrowseResult> {
   const taxa = resolveTaxa(arr(input.taxa));
-  const threats = resolveThreats(arr(input.threats));
-  const categories = resolveCategories(arr(input.categories));
   const countries = resolveCountries(arr(input.countries));
   const regionRaw = arr(input.region);
   const regions = resolveRegions(regionRaw);
   const assessors = arr(input.assessors);
   const reviewers = arr(input.reviewers);
-  const systems = arr(input.systems);
-  const trends = arr(input.trends);
-  const movement = arr(input.movement);
-  const growthForms = arr(input.growthForms);
   const search = (input.search ?? "").trim();
-  const { hasMap = null, outdated = null, minObs, maxObs, minAssessmentYear, maxAssessmentYear, minDescribedYear, maxDescribedYear } = input;
+  const { outdated = null, minObs, maxObs, minAssessmentYear, maxAssessmentYear, minDescribedYear, maxDescribedYear } = input;
+
+  // Categorical filters resolve into `criteria` via the shared registry; the
+  // bespoke ones (country+region, search, obs/year bounds) are added below.
+  const criteria: SpeciesFilterCriteria = {};
+  const shared = applySharedFilters(input, criteria);
+  criteria.countries = setOrUndef([...countries.codes, ...regions.codes]);
+  criteria.search = search ? search.toLowerCase() : undefined;
+  criteria.minObs = minObs;
+  criteria.maxObs = maxObs;
+  criteria.minAssessmentYear = minAssessmentYear;
+  criteria.maxAssessmentYear = maxAssessmentYear;
 
   const unresolved = [
     ...taxa.unresolved.map((v) => `taxa=${v}`),
-    ...threats.unresolved.map((v) => `threats=${v}`),
-    ...categories.unresolved.map((v) => `categories=${v}`),
+    ...shared.unresolved,
     ...countries.unresolved.map((v) => `countries=${v}`),
     ...regions.unresolved.map((v) => `region=${v}`),
   ];
@@ -136,24 +136,11 @@ export async function runBrowseQuery(input: BrowseInput): Promise<BrowseResult> 
     return { interpreted: [], unresolved, tooLarge: false, noSelector: true, total: 0, shown: 0, capped: false, breakdown: {}, stats: { assessed: 0, outdated: 0, outdated_pct: null }, species: [] };
   }
 
-  const criteria: SpeciesFilterCriteria = {
-    categories: setOrUndef(categories.codes),
-    threats: setOrUndef(threats.codes),
-    countries: setOrUndef([...countries.codes, ...regions.codes]),
-    systems: setOrUndef(systems),
-    populationTrends: setOrUndef(trends),
-    movementPatterns: setOrUndef(movement),
-    growthForms: setOrUndef(growthForms),
-    hasMap,
-    search: search ? search.toLowerCase() : undefined,
-    minObs, maxObs, minAssessmentYear, maxAssessmentYear,
-  };
-
   let matched: Row[] = [];
   let tooLarge = false;
 
   if (taxa.ids.length) {
-    const includeNE = categories.codes.includes("NE");
+    const includeNE = criteria.categories?.has("NE") ?? false;
     const results = await Promise.all(taxa.ids.map((id) => querySpecies({ taxon: id, includeNE })));
     const seen = new Set<number>();
     results.forEach((res, i) => {
@@ -200,7 +187,23 @@ export async function runBrowseQuery(input: BrowseInput): Promise<BrowseResult> 
   const outdatedCount = assessed.filter((r) => isOutdated(r.assessment_date ?? null)).length;
   const outdated_pct = assessed.length ? Math.round((outdatedCount / assessed.length) * 100) : null;
 
-  const interpreted = describeFilters({ taxa, threats, categories, countries, regionRaw, regions, systems, trends, movement, growthForms, hasMap, search, assessors, reviewers, minObs, maxObs, minAssessmentYear, maxAssessmentYear, minDescribedYear, maxDescribedYear, outdated });
+  // Human-readable active-filter summary (drives the HTML/JSON "interpreted").
+  // The categorical lines come from the shared registry; the rest are bespoke.
+  const interpreted: string[] = [];
+  if (taxa.ids.length) interpreted.push(`Taxa: ${taxa.ids.map(taxonLabel).join(", ")}`);
+  interpreted.push(...shared.describe);
+  if (countries.codes.length) interpreted.push(`Countries: ${countries.codes.map(countryLabel).join(", ")}`);
+  if (regions.codes.length) interpreted.push(`Region: ${regionRaw.filter((v) => !regions.unresolved.includes(v)).join(", ")}`);
+  if (search) interpreted.push(`Name search: "${search}"`);
+  if (assessors.length) interpreted.push(`Assessor: ${assessors.join(", ")}`);
+  if (reviewers.length) interpreted.push(`Reviewer: ${reviewers.join(", ")}`);
+  if (minObs != null) interpreted.push(`GBIF observations ≥ ${minObs.toLocaleString()}`);
+  if (maxObs != null) interpreted.push(`GBIF observations ≤ ${maxObs.toLocaleString()}`);
+  if (minAssessmentYear != null) interpreted.push(`Assessed in or after ${minAssessmentYear}`);
+  if (maxAssessmentYear != null) interpreted.push(`Assessed in or before ${maxAssessmentYear}`);
+  if (minDescribedYear != null) interpreted.push(`Described in or after ${minDescribedYear}`);
+  if (maxDescribedYear != null) interpreted.push(`Described in or before ${maxDescribedYear}`);
+  if (outdated) interpreted.push(outdated === "yes" ? "Outdated assessments (>10 yrs old)" : "Current assessments (≤10 yrs old)");
 
   return {
     interpreted, unresolved, tooLarge, noSelector: false,
@@ -221,38 +224,4 @@ export async function runBrowseQuery(input: BrowseInput): Promise<BrowseResult> 
       gbif_occurrence_count: s.gbif_occurrence_count ?? null,
     })),
   };
-}
-
-// Human-readable description of the active filters (drives the HTML/JSON "interpreted").
-function describeFilters(r: {
-  taxa: ReturnType<typeof resolveTaxa>; threats: ReturnType<typeof resolveThreats>;
-  categories: ReturnType<typeof resolveCategories>; countries: ReturnType<typeof resolveCountries>;
-  regionRaw: string[]; regions: { codes: string[]; unresolved: string[] };
-  systems: string[]; trends: string[]; movement: string[]; growthForms: string[];
-  hasMap: "yes" | "no" | null; search: string; assessors: string[]; reviewers: string[];
-  minObs?: number; maxObs?: number; minAssessmentYear?: number; maxAssessmentYear?: number;
-  minDescribedYear?: number; maxDescribedYear?: number; outdated: "yes" | "no" | null;
-}): string[] {
-  const parts: string[] = [];
-  if (r.taxa.ids.length) parts.push(`Taxa: ${r.taxa.ids.map(taxonLabel).join(", ")}`);
-  if (r.threats.codes.length) parts.push(`Threats: ${r.threats.codes.map(threatLabel).join(", ")}`);
-  if (r.categories.codes.length) parts.push(`Categories: ${r.categories.codes.map(categoryLabel).join(", ")}`);
-  if (r.countries.codes.length) parts.push(`Countries: ${r.countries.codes.map(countryLabel).join(", ")}`);
-  if (r.regions.codes.length) parts.push(`Region: ${r.regionRaw.filter((v) => !r.regions.unresolved.includes(v)).join(", ")}`);
-  if (r.systems.length) parts.push(`Systems: ${r.systems.join(", ")}`);
-  if (r.trends.length) parts.push(`Population trend: ${r.trends.join(", ")}`);
-  if (r.movement.length) parts.push(`Movement: ${r.movement.join(", ")}`);
-  if (r.growthForms.length) parts.push(`Growth forms: ${r.growthForms.join(", ")}`);
-  if (r.hasMap) parts.push(`Has range map: ${r.hasMap}`);
-  if (r.search) parts.push(`Name search: "${r.search}"`);
-  if (r.assessors.length) parts.push(`Assessor: ${r.assessors.join(", ")}`);
-  if (r.reviewers.length) parts.push(`Reviewer: ${r.reviewers.join(", ")}`);
-  if (r.minObs != null) parts.push(`GBIF observations ≥ ${r.minObs.toLocaleString()}`);
-  if (r.maxObs != null) parts.push(`GBIF observations ≤ ${r.maxObs.toLocaleString()}`);
-  if (r.minAssessmentYear != null) parts.push(`Assessed in or after ${r.minAssessmentYear}`);
-  if (r.maxAssessmentYear != null) parts.push(`Assessed in or before ${r.maxAssessmentYear}`);
-  if (r.minDescribedYear != null) parts.push(`Described in or after ${r.minDescribedYear}`);
-  if (r.maxDescribedYear != null) parts.push(`Described in or before ${r.maxDescribedYear}`);
-  if (r.outdated) parts.push(r.outdated === "yes" ? "Outdated assessments (>10 yrs old)" : "Current assessments (≤10 yrs old)");
-  return parts;
 }

--- a/app/src/lib/dashboard-url.ts
+++ b/app/src/lib/dashboard-url.ts
@@ -26,9 +26,9 @@
  *    same species set in each.
  */
 import type { BrowseInput } from "@/lib/browse-query";
-import {
-  resolveTaxa, resolveCategories, resolveThreats, resolveCountries,
-} from "@/lib/filter-vocab";
+import { applySharedFilters, emitSharedParams } from "@/lib/shared-filters";
+import type { SpeciesFilterCriteria } from "@/lib/species-filter";
+import { resolveTaxa, resolveCountries } from "@/lib/filter-vocab";
 import { resolveRegions } from "@/lib/regions";
 
 const arr = (a?: string[]) => (a ?? []).map((s) => s.trim()).filter(Boolean);
@@ -50,11 +50,12 @@ export function browseInputToDashboardQuery(input: BrowseInput): string {
   const taxaIds = resolveTaxa(arr(input.taxa)).ids;
   if (taxaIds.length) p.set("taxa", taxaIds.join(","));
 
-  const categories = resolveCategories(arr(input.categories)).codes;
-  if (categories.length) p.set("categories", categories.join(","));
-
-  const threats = resolveThreats(arr(input.threats)).codes;
-  if (threats.length) p.set("threats", threats.join(","));
+  // Categorical filters (categories, threats, systems, trends, movement,
+  // growthForms, hasMap, endemic) — resolved + emitted by the shared registry,
+  // so the URL keys here can't drift from the MCP schema or the predicate.
+  const criteria: SpeciesFilterCriteria = {};
+  applySharedFilters(input, criteria);
+  emitSharedParams(criteria, p);
 
   // Countries + region (region expands to its country set — lossless).
   const countries = new Set<string>([
@@ -62,20 +63,6 @@ export function browseInputToDashboardQuery(input: BrowseInput): string {
     ...resolveRegions(arr(input.region)).codes,
   ]);
   if (countries.size) p.set("countries", [...countries].join(","));
-
-  const systems = arr(input.systems);
-  if (systems.length) p.set("systems", systems.join(","));
-
-  const trends = arr(input.trends);
-  if (trends.length) p.set("trends", trends.join(","));
-
-  const movement = arr(input.movement);
-  if (movement.length) p.set("movement", movement.join(","));
-
-  const growthForms = arr(input.growthForms);
-  if (growthForms.length) p.set("growthForms", growthForms.join(","));
-
-  if (input.hasMap === "yes" || input.hasMap === "no") p.set("hasMap", input.hasMap);
 
   const assessors = arr(input.assessors);
   if (assessors.length) p.set("assessors", assessors.join("|"));

--- a/app/src/lib/shared-filters.ts
+++ b/app/src/lib/shared-filters.ts
@@ -1,0 +1,210 @@
+/**
+ * Registry of the *shared* species filters — the single source of truth for the
+ * filters that exist identically on all four surfaces:
+ *
+ *   1. the dashboard URL          (useFilterParams: buildQs / parseParams)
+ *   2. the MCP / /browse input    (route.ts FILTERS schema + BrowseInput)
+ *   3. the server-side predicate  (species-filter: matchesSpeciesFilter)
+ *   4. the dashboard link an agent hands back (dashboard-url + the `interpreted` text)
+ *
+ * Each filter is declared ONCE here (its MCP schema, its dashboard URL param, how
+ * it resolves into the filter criteria, how it matches a species, and how it
+ * reads in plain English). Adding a categorical filter is one entry and it is
+ * wired everywhere; a drift-guard test (shared-filters.test.ts) fails if the
+ * dashboard URL layer can't round-trip any registry filter.
+ *
+ * Scope: this covers the *categorical* filters (sets of values, plus the hasMap
+ * enum and the endemic flag). The genuinely-bespoke filters stay outside the
+ * registry because they don't share one shape across surfaces:
+ *   - taxa           — expands to display-root + sub-group tokens
+ *   - countries/region — region expands INTO the country set (one param)
+ *   - assessors/reviewers — substring match on a parsed name list (not a species attr)
+ *   - search, the exact numeric/outdated params — already 1:1 and bucket-free
+ */
+import { z } from "zod";
+import {
+  resolveCategories, resolveThreats, categoryLabel, THREAT_LABEL,
+} from "@/lib/filter-vocab";
+import type { FilterableSpecies, SpeciesFilterCriteria } from "@/lib/species-filter";
+
+// ─── MCP / browse input schema (the source of the BrowseInput shared fields) ──
+
+/**
+ * Zod shape for the shared categorical filters, spread into the MCP tool input.
+ * Declared as a literal so `SharedFilterInput` infers precise field types.
+ */
+export const SHARED_FILTER_SCHEMA = {
+  categories: z.array(z.string()).optional().describe("IUCN status codes or names: CR, EN, VU, NT, LC, DD, NE, EX, EW — or 'threatened' (=CR,EN,VU). NE = not yet evaluated."),
+  threats: z.array(z.string()).optional().describe("IUCN threat codes (prefix match, e.g. '11' = climate change) or aliases like climate-change, pollution, overfishing."),
+  systems: z.array(z.string()).optional().describe("Realm/system: Terrestrial, Freshwater, Marine."),
+  trends: z.array(z.string()).optional().describe("Population trend: Increasing, Decreasing, Stable, Unknown."),
+  movement: z.array(z.string()).optional().describe("Movement pattern, e.g. Migratory, Nomadic, Not a Migrant."),
+  growthForms: z.array(z.string()).optional().describe("Plant/fungus growth form, e.g. Tree, Shrub, Herb."),
+  hasMap: z.enum(["yes", "no"]).optional().describe("Whether the species has an IUCN range map."),
+  endemic: z.enum(["yes"]).optional().describe("Only species endemic to a single country (occurring in exactly one country)."),
+} as const;
+
+/** Precise TS type of the shared-filter fields on a BrowseInput / MCP args object. */
+export type SharedFilterInput = z.infer<z.ZodObject<typeof SHARED_FILTER_SCHEMA>>;
+
+// ─── Per-filter descriptors ───────────────────────────────────────────────
+
+/** Outcome of resolving one filter's raw input: any unresolved tokens + a
+ *  human-readable description (null when the filter resolved to nothing). */
+interface ApplyResult {
+  unresolved: string[];
+  describe: string | null;
+}
+
+interface SharedFilterDef {
+  /** Field name on the MCP / BrowseInput object (and the key in SHARED_FILTER_SCHEMA). */
+  mcpKey: keyof SharedFilterInput;
+  /** Dashboard URL param key (usually === mcpKey; differs only for `endemic`→`endemics`). */
+  urlKey: string;
+  /** Sample raw value (MCP-input shape) used by the drift-guard test. */
+  sample: unknown;
+  /** Resolve the raw input value and write the result onto `c`. Null when absent. */
+  apply(raw: unknown, c: SpeciesFilterCriteria): ApplyResult | null;
+  /** Emit the dashboard URL param from a resolved criteria object. */
+  toParam(c: SpeciesFilterCriteria, p: URLSearchParams): void;
+  /** Predicate clause: does the species pass this filter, given the criteria? */
+  match(s: FilterableSpecies, c: SpeciesFilterCriteria): boolean;
+}
+
+const toArray = (raw: unknown): string[] =>
+  Array.isArray(raw) ? raw.map((v) => String(v).trim()).filter(Boolean) : [];
+
+/**
+ * Factory for a "set of values" filter (OR within the set). Handles vocab
+ * resolution, criteria population, URL serialization, and the `interpreted`
+ * line; callers supply only the species-matching predicate.
+ */
+function setFilter(opts: {
+  mcpKey: keyof SharedFilterInput;
+  urlKey?: string;
+  /** SpeciesFilterCriteria field this writes/reads (defaults to mcpKey). */
+  criteriaKey: keyof SpeciesFilterCriteria;
+  label: string;
+  sample: string[];
+  /** Optional plain-English → code resolver (categories, threats). */
+  resolve?: (vals: string[]) => { codes: string[]; unresolved: string[] };
+  /** Render a resolved value for the `interpreted` text (defaults to identity). */
+  render?: (code: string) => string;
+  match: (s: FilterableSpecies, values: Set<string>) => boolean;
+}): SharedFilterDef {
+  const { mcpKey, criteriaKey, label, sample, resolve, render, match } = opts;
+  const urlKey = opts.urlKey ?? mcpKey;
+  const get = (c: SpeciesFilterCriteria) => c[criteriaKey] as Set<string> | undefined;
+  return {
+    mcpKey,
+    urlKey,
+    sample,
+    apply(raw, c) {
+      const vals = toArray(raw);
+      if (!vals.length) return null;
+      const { codes, unresolved } = resolve ? resolve(vals) : { codes: vals, unresolved: [] };
+      if (codes.length) (c as Record<string, unknown>)[criteriaKey] = new Set(codes);
+      return {
+        unresolved,
+        describe: codes.length ? `${label}: ${codes.map((c2) => (render ? render(c2) : c2)).join(", ")}` : null,
+      };
+    },
+    toParam(c, p) {
+      const set = get(c);
+      if (set && set.size) p.set(urlKey, [...set].join(","));
+    },
+    match(s, c) {
+      const set = get(c);
+      return !set || set.size === 0 || match(s, set);
+    },
+  };
+}
+
+const threatRender = (code: string) => (THREAT_LABEL[code] ? `${THREAT_LABEL[code]} (${code})` : code);
+
+export const SHARED_FILTERS: SharedFilterDef[] = [
+  setFilter({
+    mcpKey: "categories", criteriaKey: "categories", label: "Categories",
+    sample: ["threatened"], resolve: resolveCategories, render: categoryLabel,
+    match: (s, set) => set.has(s.category),
+  }),
+  setFilter({
+    mcpKey: "threats", criteriaKey: "threats", label: "Threats",
+    sample: ["climate-change"], resolve: resolveThreats, render: threatRender,
+    match: (s, set) =>
+      s.threat_codes?.some((tc) => [...set].some((sel) => tc === sel || tc.startsWith(sel + "."))) ?? false,
+  }),
+  setFilter({
+    mcpKey: "systems", criteriaKey: "systems", label: "Systems",
+    sample: ["Marine"],
+    match: (s, set) => s.systems?.some((sys) => set.has(sys)) ?? false,
+  }),
+  setFilter({
+    mcpKey: "trends", criteriaKey: "populationTrends", label: "Population trend",
+    sample: ["Decreasing"],
+    match: (s, set) => s.population_trend != null && set.has(s.population_trend),
+  }),
+  setFilter({
+    mcpKey: "movement", criteriaKey: "movementPatterns", label: "Movement",
+    sample: ["Migratory"],
+    match: (s, set) => s.movement_pattern != null && set.has(s.movement_pattern),
+  }),
+  setFilter({
+    mcpKey: "growthForms", criteriaKey: "growthForms", label: "Growth forms",
+    sample: ["Tree"],
+    match: (s, set) => s.growth_forms?.some((gf) => set.has(gf)) ?? false,
+  }),
+  // hasMap — enum yes/no
+  {
+    mcpKey: "hasMap", urlKey: "hasMap", sample: "yes",
+    apply(raw, c) {
+      if (raw !== "yes" && raw !== "no") return null;
+      c.hasMap = raw;
+      return { unresolved: [], describe: `Has range map: ${raw}` };
+    },
+    toParam(c, p) { if (c.hasMap) p.set("hasMap", c.hasMap); },
+    match(s, c) { return !c.hasMap || (c.hasMap === "yes" ? s.has_map : !s.has_map); },
+  },
+  // endemic — flag (single-country species). URL param is `endemics=1`.
+  {
+    mcpKey: "endemic", urlKey: "endemics", sample: "yes",
+    apply(raw, c) {
+      if (raw !== "yes" && raw !== true) return null;
+      c.endemicsOnly = true;
+      return { unresolved: [], describe: "Endemic to a single country" };
+    },
+    toParam(c, p) { if (c.endemicsOnly) p.set("endemics", "1"); },
+    match(s, c) { return !c.endemicsOnly || s.countries.length === 1; },
+  },
+];
+
+// ─── Surface drivers (used by browse-query, dashboard-url, species-filter) ────
+
+/**
+ * Resolve every shared filter from a raw input object onto `criteria`,
+ * collecting unresolved tokens (prefixed `key=value`) and `interpreted` lines.
+ */
+export function applySharedFilters(
+  input: SharedFilterInput,
+  criteria: SpeciesFilterCriteria,
+): { unresolved: string[]; describe: string[] } {
+  const unresolved: string[] = [];
+  const describe: string[] = [];
+  for (const f of SHARED_FILTERS) {
+    const res = f.apply(input[f.mcpKey], criteria);
+    if (!res) continue;
+    for (const u of res.unresolved) unresolved.push(`${f.mcpKey}=${u}`);
+    if (res.describe) describe.push(res.describe);
+  }
+  return { unresolved, describe };
+}
+
+/** Emit the dashboard URL params for the shared filters present on `criteria`. */
+export function emitSharedParams(criteria: SpeciesFilterCriteria, p: URLSearchParams): void {
+  for (const f of SHARED_FILTERS) f.toParam(criteria, p);
+}
+
+/** AND of every shared-filter clause (each is a no-op when its filter is absent). */
+export function matchSharedFilters(s: FilterableSpecies, criteria: SpeciesFilterCriteria): boolean {
+  return SHARED_FILTERS.every((f) => f.match(s, criteria));
+}

--- a/app/src/lib/shared-filters.ts
+++ b/app/src/lib/shared-filters.ts
@@ -169,7 +169,7 @@ export const SHARED_FILTERS: SharedFilterDef[] = [
   {
     mcpKey: "endemic", urlKey: "endemics", sample: "yes",
     apply(raw, c) {
-      if (raw !== "yes" && raw !== true) return null;
+      if (raw !== "yes") return null;
       c.endemicsOnly = true;
       return { unresolved: [], describe: "Endemic to a single country" };
     },

--- a/app/src/lib/shared-filters.ts
+++ b/app/src/lib/shared-filters.ts
@@ -161,7 +161,7 @@ export const SHARED_FILTERS: SharedFilterDef[] = [
     vocab: {
       label: "IUCN status category",
       values: ALL_CATEGORIES.map((c) => ({ code: c, label: categoryLabel(c) })),
-      note: "codes or names; also 'threatened' (= CR, EN, VU). NE = not yet evaluated.",
+      note: "codes or names; aliases: threatened = CR, EN, VU; extinct = EX, EW. NE = not yet evaluated.",
     },
   }),
   setFilter({
@@ -172,7 +172,7 @@ export const SHARED_FILTERS: SharedFilterDef[] = [
     vocab: {
       label: "IUCN threat",
       values: THREAT_CATEGORIES.map((t) => ({ code: t.code, label: t.label })),
-      note: "prefix match (11 covers 11.1, 11.4, …); aliases: climate-change, pollution, overfishing.",
+      note: "prefix/sub-code match (11 covers 11.1, 11.4, …); aliases: climate-change, pollution, invasive-species, overfishing, logging, hunting, dams.",
     },
   }),
   setFilter({

--- a/app/src/lib/shared-filters.ts
+++ b/app/src/lib/shared-filters.ts
@@ -24,6 +24,7 @@
 import { z } from "zod";
 import {
   resolveCategories, resolveThreats, categoryLabel, THREAT_LABEL,
+  ALL_CATEGORIES, THREAT_CATEGORIES, SYSTEMS, POPULATION_TRENDS,
 } from "@/lib/filter-vocab";
 import type { FilterableSpecies, SpeciesFilterCriteria } from "@/lib/species-filter";
 
@@ -56,6 +57,21 @@ interface ApplyResult {
   describe: string | null;
 }
 
+/** Help/vocabulary for one shared filter, surfaced by the /browse index help and
+ *  the get_vocabulary MCP tool — both derive from this, so they can't drift. */
+export interface FilterVocab {
+  /** MCP/BrowseInput key. */
+  key: string;
+  /** Dashboard URL param key (what a /browse or shared URL actually uses). */
+  urlKey: string;
+  /** Short human label. */
+  label: string;
+  /** Enumerable values — plain strings, or {code,label} for coded vocab; [] = free-text. */
+  values: readonly (string | { code: string; label: string })[];
+  /** Free-text note (aliases, "common values", endemic meaning, …). */
+  note?: string;
+}
+
 interface SharedFilterDef {
   /** Field name on the MCP / BrowseInput object (and the key in SHARED_FILTER_SCHEMA). */
   mcpKey: keyof SharedFilterInput;
@@ -65,14 +81,22 @@ interface SharedFilterDef {
   sample: unknown;
   /** Resolve the raw input value and write the result onto `c`. Null when absent. */
   apply(raw: unknown, c: SpeciesFilterCriteria): ApplyResult | null;
+  /** Read this filter's value from URL params into MCP-input shape (inverse of toParam). */
+  readParam(sp: URLSearchParams): unknown;
   /** Emit the dashboard URL param from a resolved criteria object. */
   toParam(c: SpeciesFilterCriteria, p: URLSearchParams): void;
   /** Predicate clause: does the species pass this filter, given the criteria? */
   match(s: FilterableSpecies, c: SpeciesFilterCriteria): boolean;
+  /** Help/vocabulary entry for the discovery surfaces. */
+  vocab: FilterVocab;
 }
 
 const toArray = (raw: unknown): string[] =>
   Array.isArray(raw) ? raw.map((v) => String(v).trim()).filter(Boolean) : [];
+
+/** Read a comma/multi-valued list param (matches the /browse + dashboard parsing). */
+const readList = (sp: URLSearchParams, key: string): string[] =>
+  sp.getAll(key).join(",").split(",").map((s) => s.trim()).filter(Boolean);
 
 /**
  * Factory for a "set of values" filter (OR within the set). Handles vocab
@@ -91,6 +115,8 @@ function setFilter(opts: {
   /** Render a resolved value for the `interpreted` text (defaults to identity). */
   render?: (code: string) => string;
   match: (s: FilterableSpecies, values: Set<string>) => boolean;
+  /** Discovery-surface vocabulary (label/values/note). */
+  vocab: Omit<FilterVocab, "key" | "urlKey">;
 }): SharedFilterDef {
   const { mcpKey, criteriaKey, label, sample, resolve, render, match } = opts;
   const urlKey = opts.urlKey ?? mcpKey;
@@ -109,6 +135,10 @@ function setFilter(opts: {
         describe: codes.length ? `${label}: ${codes.map((c2) => (render ? render(c2) : c2)).join(", ")}` : null,
       };
     },
+    readParam(sp) {
+      const vals = readList(sp, urlKey);
+      return vals.length ? vals : undefined;
+    },
     toParam(c, p) {
       const set = get(c);
       if (set && set.size) p.set(urlKey, [...set].join(","));
@@ -117,6 +147,7 @@ function setFilter(opts: {
       const set = get(c);
       return !set || set.size === 0 || match(s, set);
     },
+    vocab: { key: mcpKey, urlKey, ...opts.vocab },
   };
 }
 
@@ -127,32 +158,54 @@ export const SHARED_FILTERS: SharedFilterDef[] = [
     mcpKey: "categories", criteriaKey: "categories", label: "Categories",
     sample: ["threatened"], resolve: resolveCategories, render: categoryLabel,
     match: (s, set) => set.has(s.category),
+    vocab: {
+      label: "IUCN status category",
+      values: ALL_CATEGORIES.map((c) => ({ code: c, label: categoryLabel(c) })),
+      note: "codes or names; also 'threatened' (= CR, EN, VU). NE = not yet evaluated.",
+    },
   }),
   setFilter({
     mcpKey: "threats", criteriaKey: "threats", label: "Threats",
     sample: ["climate-change"], resolve: resolveThreats, render: threatRender,
     match: (s, set) =>
       s.threat_codes?.some((tc) => [...set].some((sel) => tc === sel || tc.startsWith(sel + "."))) ?? false,
+    vocab: {
+      label: "IUCN threat",
+      values: THREAT_CATEGORIES.map((t) => ({ code: t.code, label: t.label })),
+      note: "prefix match (11 covers 11.1, 11.4, …); aliases: climate-change, pollution, overfishing.",
+    },
   }),
   setFilter({
     mcpKey: "systems", criteriaKey: "systems", label: "Systems",
     sample: ["Marine"],
     match: (s, set) => s.systems?.some((sys) => set.has(sys)) ?? false,
+    vocab: { label: "Realm / system", values: SYSTEMS },
   }),
   setFilter({
     mcpKey: "trends", criteriaKey: "populationTrends", label: "Population trend",
     sample: ["Decreasing"],
     match: (s, set) => s.population_trend != null && set.has(s.population_trend),
+    vocab: { label: "Population trend", values: POPULATION_TRENDS },
   }),
   setFilter({
     mcpKey: "movement", criteriaKey: "movementPatterns", label: "Movement",
     sample: ["Migratory"],
     match: (s, set) => s.movement_pattern != null && set.has(s.movement_pattern),
+    vocab: {
+      label: "Movement pattern",
+      values: ["Full Migrant", "Altitudinal Migrant", "Nomadic", "Not a Migrant", "Unknown"],
+      note: "free text; common values shown.",
+    },
   }),
   setFilter({
     mcpKey: "growthForms", criteriaKey: "growthForms", label: "Growth forms",
     sample: ["Tree"],
     match: (s, set) => s.growth_forms?.some((gf) => set.has(gf)) ?? false,
+    vocab: {
+      label: "Plant / fungus growth form",
+      values: ["Tree", "Shrub", "Herb", "Forb", "Graminoid", "Geophyte", "Lithophyte", "Epiphyte"],
+      note: "free text; common values shown.",
+    },
   }),
   // hasMap — enum yes/no
   {
@@ -162,8 +215,13 @@ export const SHARED_FILTERS: SharedFilterDef[] = [
       c.hasMap = raw;
       return { unresolved: [], describe: `Has range map: ${raw}` };
     },
+    readParam(sp) {
+      const v = sp.get("hasMap");
+      return v === "yes" || v === "no" ? v : undefined;
+    },
     toParam(c, p) { if (c.hasMap) p.set("hasMap", c.hasMap); },
     match(s, c) { return !c.hasMap || (c.hasMap === "yes" ? s.has_map : !s.has_map); },
+    vocab: { key: "hasMap", urlKey: "hasMap", label: "Has IUCN range map", values: ["yes", "no"] },
   },
   // endemic — flag (single-country species). URL param is `endemics=1`.
   {
@@ -173,8 +231,14 @@ export const SHARED_FILTERS: SharedFilterDef[] = [
       c.endemicsOnly = true;
       return { unresolved: [], describe: "Endemic to a single country" };
     },
+    readParam(sp) {
+      const v = sp.get("endemics");
+      // Canonical dashboard form is `endemics=1`; also accept `endemics=yes`.
+      return v === "1" || v === "yes" ? "yes" : undefined;
+    },
     toParam(c, p) { if (c.endemicsOnly) p.set("endemics", "1"); },
     match(s, c) { return !c.endemicsOnly || s.countries.length === 1; },
+    vocab: { key: "endemic", urlKey: "endemics", label: "Endemic to a single country", values: ["yes"], note: "URL param is endemics=1." },
   },
 ];
 
@@ -203,6 +267,24 @@ export function applySharedFilters(
 export function emitSharedParams(criteria: SpeciesFilterCriteria, p: URLSearchParams): void {
   for (const f of SHARED_FILTERS) f.toParam(criteria, p);
 }
+
+/**
+ * Read the shared-filter portion of a BrowseInput straight from URL params
+ * (the inverse of emitSharedParams at the input layer). The /browse route uses
+ * this so every registry filter is parsed from a pasted/shared URL — adding a
+ * filter to the registry wires /browse automatically, no per-param edit.
+ */
+export function readSharedInput(sp: URLSearchParams): Partial<SharedFilterInput> {
+  const out: Record<string, unknown> = {};
+  for (const f of SHARED_FILTERS) {
+    const v = f.readParam(sp);
+    if (v !== undefined) out[f.mcpKey] = v;
+  }
+  return out as Partial<SharedFilterInput>;
+}
+
+/** Vocabulary for every shared filter, for the /browse index + get_vocabulary. */
+export const SHARED_FILTER_VOCAB: FilterVocab[] = SHARED_FILTERS.map((f) => f.vocab);
 
 /** AND of every shared-filter clause (each is a no-op when its filter is absent). */
 export function matchSharedFilters(s: FilterableSpecies, criteria: SpeciesFilterCriteria): boolean {

--- a/app/src/lib/species-filter.ts
+++ b/app/src/lib/species-filter.ts
@@ -4,6 +4,13 @@
  * Extracted from RedListView.tsx so the same base-filter logic runs both
  * client-side (the dashboard) and server-side (the /browse LLM endpoint).
  *
+ * The *categorical* clauses (categories, threats, systems, population trend,
+ * movement, growth form, hasMap, endemic) are declared once in the shared-filter
+ * registry (@/lib/shared-filters) and matched here via matchSharedFilters, so the
+ * predicate can't drift from the MCP schema or the dashboard URL. The clauses
+ * that don't share that shape stay inline below: countries (entangled with the
+ * region expansion), name search, and the GBIF-obs / assessment-year bounds.
+ *
  * Semantics (must match the dashboard exactly):
  *  - Within one filter, multiple selected values are OR (species matches ANY).
  *  - Across different filters it is AND (species must satisfy EVERY active filter).
@@ -14,6 +21,7 @@
  * and the "starred" filter are intentionally NOT included here — they depend on
  * the current date, GBIF counts, or local UI state and stay inline in RedListView.
  */
+import { matchSharedFilters } from "@/lib/shared-filters";
 
 /** Minimal structural shape this predicate needs. Both `SpeciesRow`
  *  (server data store) and `RedListSpecies` (client hook) satisfy it. */
@@ -41,6 +49,8 @@ export interface SpeciesFilterCriteria {
   movementPatterns?: Set<string>;
   growthForms?: Set<string>;
   hasMap?: "yes" | "no" | null;
+  /** Only species endemic to a single country (occurring in exactly one). */
+  endemicsOnly?: boolean;
   /** Already lowercased by the caller. */
   search?: string;
   /** GBIF occurrence count bounds (null obs counts as 0). */
@@ -54,30 +64,11 @@ export interface SpeciesFilterCriteria {
 const empty = (s?: Set<string>) => !s || s.size === 0;
 
 export function matchesSpeciesFilter(s: FilterableSpecies, f: SpeciesFilterCriteria): boolean {
-  const matchesCategory = empty(f.categories) || f.categories!.has(s.category);
+  // Categorical clauses (categories, threats, systems, trend, movement, growth
+  // form, hasMap, endemic) — declared once in the shared-filter registry.
+  if (!matchSharedFilters(s, f)) return false;
 
   const matchesCountry = empty(f.countries) || s.countries.some((c) => f.countries!.has(c));
-
-  const matchesSystem = empty(f.systems) || (s.systems?.some((sys) => f.systems!.has(sys)) ?? false);
-
-  const matchesTrend =
-    empty(f.populationTrends) ||
-    (s.population_trend != null && f.populationTrends!.has(s.population_trend));
-
-  const matchesMovement =
-    empty(f.movementPatterns) ||
-    (s.movement_pattern != null && f.movementPatterns!.has(s.movement_pattern));
-
-  const matchesThreat =
-    empty(f.threats) ||
-    (s.threat_codes?.some((tc) =>
-      Array.from(f.threats!).some((sel) => tc === sel || tc.startsWith(sel + "."))
-    ) ?? false);
-
-  const matchesMap = !f.hasMap || (f.hasMap === "yes" ? s.has_map : !s.has_map);
-
-  const matchesGrowth =
-    empty(f.growthForms) || (s.growth_forms?.some((gf) => f.growthForms!.has(gf)) ?? false);
 
   const q = f.search;
   const matchesSearch =
@@ -99,18 +90,6 @@ export function matchesSpeciesFilter(s: FilterableSpecies, f: SpeciesFilterCrite
     }
   }
 
-  return (
-    matchesCategory &&
-    matchesCountry &&
-    matchesSystem &&
-    matchesTrend &&
-    matchesMovement &&
-    matchesThreat &&
-    matchesMap &&
-    matchesGrowth &&
-    matchesSearch &&
-    matchesMinObs &&
-    matchesMaxObs &&
-    matchesYear
-  );
+  return matchesCountry && matchesSearch && matchesMinObs && matchesMaxObs && matchesYear;
 }
+


### PR DESCRIPTION
## Problem

A shared species filter had to be declared independently across many surfaces, with nothing forcing them to agree:

1. dashboard URL — `buildQs` / `parseParams` (`useFilterParams.ts`)
2. `BrowseInput` type (`browse-query.ts`)
3. the MCP `FILTERS` Zod schema (`route.ts`)
4. the predicate — `matchesSpeciesFilter` (`species-filter.ts`)
5. the MCP→dashboard-URL builder (`dashboard-url.ts`)
6. the `interpreted` summary (`browse-query.ts`)
7. the `/browse` route's own input parsing (`browse/route.ts`)
8. the discovery/help surfaces — `/browse` index help, the `get_vocabulary` MCP tool, and `/llms.txt`

Adding a filter meant touching all of them, and forgetting one drifted **silently**. This was already real: `endemics` reached the dashboard but never the MCP tools; `movement` / `growthForms` were missing from the MCP schema; the `endemic` filter was dead on `/browse` (its URL param was never parsed); and `/llms.txt` (the file agents read first) advertised a stale filter list.

## Change

New `app/src/lib/shared-filters.ts` — a single registry of the **categorical** shared filters (`categories`, `threats`, `systems`, `trends`, `movement`, `growthForms`, `hasMap`, `endemic`). Each filter is declared **once** (MCP/Zod schema, dashboard URL param, vocab resolution, species predicate, plain-English description, URL-param reader, and help/vocab metadata) and drives every surface:

- the MCP tool input schema (`route.ts` spreads `SHARED_FILTER_SCHEMA`)
- `BrowseInput`'s shared fields (via `z.infer`)
- the server predicate (`species-filter` delegates categorical clauses to `matchSharedFilters`)
- the MCP→dashboard-URL builder (`dashboard-url` calls `applySharedFilters` + `emitSharedParams`)
- the `interpreted` active-filter summary (`browse-query`)
- **`/browse` input parsing** (`browse/route.ts` spreads `readSharedInput(sp)` — adding a filter wires `/browse` with no route edit)
- **the help/discovery surfaces** — a single `buildVocabulary()` (`browse-help.ts`), built from the registry, now backs **both** the `/browse` index help and the `get_vocabulary` MCP tool (previously two duplicated hand-written lists), and **`/llms.txt`** renders its categorical-filter section from the same registry vocab.

### Effects
- **Closes the existing drift**: `endemic`, `movement`, and `growthForms` are now accepted by the MCP tools, parsed on `/browse`, and advertised by `get_vocabulary` + `/llms.txt`.
- **Drift-guard tests** (`shared-filters.test.ts`, `browse.test.ts`, `llms.test.ts`): for every registry filter, assert it (a) round-trips MCP → dashboard URL → `parseParams`/`buildQs`, (b) is parsed from a `/browse` URL by `readSharedInput`, (c) is present in `buildVocabulary()`, and (d) appears in `/llms.txt`. A filter can no longer be merged half-wired — CI fails if any surface is missed.

### ⚠️ Breaking change — `get_vocabulary` response shape
The `get_vocabulary` MCP tool's JSON shape changed: the categorical filters moved from top-level arrays (`systems`, `trends`, …) into a single `filters[]` array of `{ key, label, values, note }`, and `regions` → `region`. It is strictly **more** complete (now includes `movement`/`growthForms`/`endemic`, plus `description` and bespoke `params`), and nothing in this repo consumed the old keys — but any external agent that hard-coded the previous top-level keys would need to adapt.

### Out of scope (by design)
The genuinely-bespoke filters stay outside the registry because they don't share one shape across surfaces: `taxa` (expands to root + sub-group tokens), `countries`/`region` (region expands into the country set), `assessors`/`reviewers` (substring match on parsed names), `search`, and the exact numeric/`outdated` params. The dashboard-only UI state (`sort`, `species`, `tab`, starred, coarse bucket filters) is intentionally not shared — the MCP side uses exact `min`/`max` params instead, as before.

## Verification
- `tsc --noEmit`: clean
- `eslint`: clean
- Tests: **470 pass** across `src/lib`, `src/hooks`, and `src/app` (incl. the registry / `/browse` / `/llms.txt` drift guards).
- CI on the PR head: `test`, `typecheck`, `lint`, and Vercel preview all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSsqcW7Umy6MdtzkUdkv52)_