### PR TITLE
Fit expanded species detail to viewport on mobile; bump subtitle 1px

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -58,7 +58,7 @@ export default function RedListPage() {
               <h1 className="text-2xl sm:text-3xl md:text-[2rem] font-bold text-zinc-900 dark:text-zinc-100 truncate">{brand.title}</h1>
             </div>
             {brand.subtitle && (
-              <p className="[grid-area:subtitle] text-sm md:text-[1.375rem] text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
+              <p className="[grid-area:subtitle] text-[15px] md:text-[1.375rem] text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
             )}
             <div className="[grid-area:controls] flex items-center gap-2 sm:justify-self-end">
               {/* View mode toggle */}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -316,6 +316,22 @@ interface RedListViewProps {
 
 export default function RedListView({ viewMode = "reassessments", sharedTaxa, sharedSubgroups, onTaxaChange, onSubgroupsChange }: RedListViewProps = {}) {
   const isNewAssessments = viewMode === "new-assessments";
+
+  // The species table scrolls horizontally on narrow screens, so an expanded
+  // detail row's `<td colSpan>` is as wide as the (often off-screen) table, not
+  // the viewport. Expose the scroll container's *visible* width as a CSS var so
+  // the detail panel can size itself to fit the screen instead of overflowing.
+  const tableScrollCleanupRef = useRef<(() => void) | null>(null);
+  const tableScrollRef = useCallback((el: HTMLDivElement | null) => {
+    tableScrollCleanupRef.current?.();
+    tableScrollCleanupRef.current = null;
+    if (!el) return;
+    const update = () => el.style.setProperty("--view-width", `${el.clientWidth}px`);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    tableScrollCleanupRef.current = () => ro.disconnect();
+  }, []);
   // Filters synced with URL search params for shareable links
   const {
     selectedTaxa, setSelectedTaxa,
@@ -3199,6 +3215,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
           </div>
         )}
         <div
+          ref={tableScrollRef}
           className={`bg-white dark:bg-zinc-900 rounded-xl shadow-sm border border-zinc-200 dark:border-zinc-800 overflow-x-auto transition-opacity duration-150 ${speciesLoading && !singleSpeciesPreview ? "opacity-50 pointer-events-none" : ""}`}
           onScroll={(e) => {
             e.currentTarget.style.setProperty('--scroll-left', `${e.currentTarget.scrollLeft}px`);
@@ -3530,7 +3547,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                   {selectedSpeciesKey === speciesKey && (
                     <tr>
                       <td colSpan={isNewAssessments ? 4 : 8} className="p-0 bg-zinc-50 dark:bg-zinc-800/30" style={{ width: 0 }}>
-                        <div style={{ minWidth: '100%', maxWidth: 'calc(100vw - 2rem)', transform: 'translateX(var(--scroll-left, 0px))' }}>
+                        <div style={{ width: 'var(--view-width, 100%)', maxWidth: '100%', transform: 'translateX(var(--scroll-left, 0px))' }}>
                           {/* Tab bar */}
                           <div className="flex flex-wrap items-center border-b border-zinc-200 dark:border-zinc-700" onClick={(e) => e.stopPropagation()}>
                                 <button


### PR DESCRIPTION
## What & why

On mobile, the expanded individual-species content didn't fit the screen — only ~3.5 of the 5 iNaturalist photo columns were visible and the year graph and occurrence map were clipped on the right.

**Root cause:** the expanded detail row is rendered inside a `<td colSpan>` of the species table, which is horizontally scrollable (`overflow-x-auto`). On narrow screens the 8-column table is wider than the viewport, so the cell — and therefore the detail content — inherited the full *table* width rather than the *visible* width.

A prior attempt capped the panel with `maxWidth: calc(100vw - 2rem)`, but it also set `minWidth: 100%` (100% of the wide cell). In CSS `min-width` beats `max-width`, so the panel stayed table-width and overflowed.

**Fix:** measure the scroll container's visible width (`clientWidth`) with a `ResizeObserver` and expose it as a `--view-width` CSS variable. The detail panel now sizes itself to that width (`width: var(--view-width, 100%)`) and stays pinned to the visible area via the existing `translateX(--scroll-left)` as the table scrolls. This fits correctly across all breakpoints, not just a hard-coded mobile value.

## Also

- Bump the mobile landing subtitle from 14px (`text-sm`) to 15px (`text-[15px]`); desktop size unchanged.

## Notes

`node_modules` isn't available in the build container, so this wasn't run locally — the changes are targeted (a callback ref + observer and the panel width) and rely only on already-imported hooks and the DOM `ResizeObserver`. Worth a quick check on a real device/emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuuisrHTepTgRjqz9vRjXB)_