### PR TITLE
Add smaller page size options (1, 2, 3, 5) to species table

### DIFF
--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3770,7 +3770,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                   }}
                   className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2 py-1 text-xs md:text-sm text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 focus:outline-none cursor-pointer"
                 >
-                  {[10, 25, 50, 100].map((n) => (
+                  {[1, 2, 3, 5, 10, 25, 50, 100].map((n) => (
                     <option key={n} value={n}>
                       {n}
                     </option>


### PR DESCRIPTION
## Summary

Adds `1`, `2`, `3`, and `5` to the "Rows" page-size selector on the Red List species table. The selector now offers `1, 2, 3, 5, 10, 25, 50, 100` (previously `10, 25, 50, 100`).

## Changes

- `app/src/components/redlist/RedListView.tsx` — extend the page-size options array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018mWttQ4kd1HZfrMgMutuuS)_