### PR TITLE
Show subtitle on Red List Dashboard domains

### DIFF
--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -28,6 +28,7 @@ const DEFAULT_BRAND: Brand = {
 // dedicated Red List hostnames below.
 const RED_LIST_BRAND: Brand = {
   title: "IUCN Red List Assessments Dashboard",
+  subtitle: "A Dashboard for Conservation of Threatened Species",
   description: "A dashboard for biodiversity data about life on Earth",
 };
 


### PR DESCRIPTION
## Summary

The `RED_LIST_BRAND` (used on the dedicated Red List hostnames `red.cst.cam.ac.uk` and `red-list-dashboard.vercel.app`) had no `subtitle`, so those domains rendered the title with no tagline beneath it. This adds the same subtitle the default "Dash of Life" brand uses, so the subtitle is kept on the Red List Dashboard domains too.

## Changes

- `app/src/config/brand.ts`: add `subtitle: "A Dashboard for Conservation of Threatened Species"` to `RED_LIST_BRAND`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLu2Wm47ksUvtWjnRfuciq)_