### PR TITLE
Update Red List attribution and add commercial use disclaimer

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -146,7 +146,16 @@ export default function RedListPage() {
           >
             PhD research project
           </a>
-          {" "}at the University of Cambridge. The data is sourced from IUCN Red List (version 2025-2),{" "}
+          {" "}at the University of Cambridge. The data is sourced from{" "}
+          <a
+            href="https://www.iucnredlist.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
+          >
+            IUCN Red List
+          </a>
+          {" "}(version 2025-2),{" "}
           <a
             href="https://www.gbif.org"
             target="_blank"

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -146,16 +146,7 @@ export default function RedListPage() {
           >
             PhD research project
           </a>
-          {" "}at the University of Cambridge. The data is sourced from{" "}
-          <a
-            href="https://www.iucnredlist.org"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
-          >
-            IUCN Red List (version 2025-2)
-          </a>
-          ,{" "}
+          {" "}at the University of Cambridge. The data is sourced from IUCN Red List (version 2025-2),{" "}
           <a
             href="https://www.gbif.org"
             target="_blank"

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -146,16 +146,7 @@ export default function RedListPage() {
           >
             PhD research project
           </a>
-          {" "}at the University of Cambridge. This is a non-commercial research tool; commercial users should obtain IUCN Red List data via{" "}
-          <a
-            href="https://www.ibat-alliance.org/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
-          >
-            IBAT
-          </a>
-          . The data is sourced from{" "}
+          {" "}at the University of Cambridge. The data is sourced from{" "}
           <a
             href="https://www.iucnredlist.org"
             target="_blank"
@@ -227,7 +218,16 @@ export default function RedListPage() {
           >
             Encyclopedia of Life
           </a>
-          {" "}data. Any errors in aggregation or presentation are my own. Please verify against the primary sources before use, and do get in touch if you notice any issues.
+          {" "}data. This is a non-commercial research tool; commercial users should obtain IUCN Red List data via{" "}
+          <a
+            href="https://www.ibat-alliance.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
+          >
+            IBAT
+          </a>
+          . Any errors in aggregation or presentation are my own. Please verify against the primary sources before use, and do get in touch if you notice any issues.
         </p>
         <p className="text-center text-xs text-zinc-400 dark:text-zinc-500 mt-4">
           <Link

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -218,7 +218,7 @@ export default function RedListPage() {
           >
             Encyclopedia of Life
           </a>
-          {" "}data. This is a non-commercial research tool; commercial users should obtain IUCN Red List data via{" "}
+          {" "}data. This is a free, non-commercial research tool; commercial users should obtain IUCN Red List data via{" "}
           <a
             href="https://www.ibat-alliance.org/"
             target="_blank"

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -148,15 +148,6 @@ export default function RedListPage() {
           </a>
           {" "}at the University of Cambridge. The data is sourced from{" "}
           <a
-            href="https://www.iucnredlist.org"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
-          >
-            IUCN Red List
-          </a>
-          {" "}(version 2025-2),{" "}
-          <a
             href="https://www.gbif.org"
             target="_blank"
             rel="noopener noreferrer"
@@ -209,7 +200,7 @@ export default function RedListPage() {
           >
             Catalogue of Life
           </a>
-          {" "}and{" "}
+          ,{" "}
           <a
             href="https://eol.org"
             target="_blank"
@@ -218,7 +209,16 @@ export default function RedListPage() {
           >
             Encyclopedia of Life
           </a>
-          {" "}data. This is a free, non-commercial research tool; commercial users should obtain IUCN Red List data via{" "}
+          {" "}and{" "}
+          <a
+            href="https://www.iucnredlist.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
+          >
+            IUCN Red List
+          </a>
+          {" "}(version 2025-2) data. This is a free, non-commercial research tool; commercial users should obtain IUCN Red List data via{" "}
           <a
             href="https://www.ibat-alliance.org/"
             target="_blank"

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -146,14 +146,23 @@ export default function RedListPage() {
           >
             PhD research project
           </a>
-          {" "}at the University of Cambridge. The data is sourced from publicly available{" "}
+          {" "}at the University of Cambridge. This is a non-commercial research tool; commercial users should obtain IUCN Red List data via{" "}
+          <a
+            href="https://www.ibat-alliance.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
+          >
+            IBAT
+          </a>
+          . The data is sourced from{" "}
           <a
             href="https://www.iucnredlist.org"
             target="_blank"
             rel="noopener noreferrer"
             className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
           >
-            IUCN Red List
+            IUCN Red List (version 2025-2)
           </a>
           ,{" "}
           <a


### PR DESCRIPTION
## Summary
Updated the Red List page footer to include a commercial use disclaimer and clarify data sourcing, directing commercial users to IBAT for official IUCN Red List data access.

## Key Changes
- Added non-commercial research tool disclaimer with link to IBAT (Integrated Biodiversity Assessment Tool) for commercial users
- Updated IUCN Red List attribution to specify version 2025-2
- Restructured the attribution text to clearly separate the tool's non-commercial nature from data sourcing information

## Implementation Details
- Added a new hyperlink to IBAT (https://www.ibat-alliance.org/) with consistent styling matching existing links
- Maintained existing link styling and accessibility attributes (target="_blank", rel="noopener noreferrer")
- Clarified that this is a research tool while preserving credit to the original PhD research project at University of Cambridge

https://claude.ai/code/session_01N2iT2EFS7wodqRUNprSESG