### PR TITLE
Rename Red List brand title, add globe, reorder footer sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the IUCN Red List Assessments Dashboard.
 
 ## [Unreleased]
 
+- Renamed the red.cst.cam.ac.uk brand title to "Red List Dashboard" and added
+  the globe icon before it
+- Reordered footer data sources to lead with IUCN Red List (version 2025-2)
+- Renamed the "Dash For Life" brand to "Dash for Life"
 - Added "Suggested Reviewers" tab for NE species, analogous to Suggested Assessors
 - Strip "(... Red List Authority)" affiliation labels from suggested
   assessor/reviewer candidates so each person aggregates under one row and the

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -148,6 +148,15 @@ export default function RedListPage() {
           </a>
           {" "}at the University of Cambridge. The data is sourced from{" "}
           <a
+            href="https://www.iucnredlist.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
+          >
+            IUCN Red List
+          </a>
+          {" "}(version 2025-2),{" "}
+          <a
             href="https://www.gbif.org"
             target="_blank"
             rel="noopener noreferrer"
@@ -200,7 +209,7 @@ export default function RedListPage() {
           >
             Catalogue of Life
           </a>
-          ,{" "}
+          , and{" "}
           <a
             href="https://eol.org"
             target="_blank"
@@ -209,16 +218,7 @@ export default function RedListPage() {
           >
             Encyclopedia of Life
           </a>
-          {" "}and{" "}
-          <a
-            href="https://www.iucnredlist.org"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
-          >
-            IUCN Red List
-          </a>
-          {" "}(version 2025-2) data. This is a free, non-commercial research tool; commercial users should obtain IUCN Red List data via{" "}
+          {" "}data. This is a free, non-commercial research tool; commercial users should obtain IUCN Red List data via{" "}
           <a
             href="https://www.ibat-alliance.org/"
             target="_blank"

--- a/app/src/config/brand.ts
+++ b/app/src/config/brand.ts
@@ -27,16 +27,17 @@ const DEFAULT_BRAND: Brand = {
 // The original IUCN Red List dashboard branding, kept only for the
 // dedicated Red List hostnames below.
 const RED_LIST_BRAND: Brand = {
-  title: "IUCN Red List Assessments Dashboard",
+  title: "Red List Dashboard",
   subtitle: "A Dashboard for Conservation of Threatened Species",
   description: "A dashboard for biodiversity data about life on Earth",
+  showGlobe: true,
 };
 
-// The "Dash For Life" brand, identical to the default save for its title.
+// The "Dash for Life" brand, identical to the default save for its title.
 const DASH_FOR_LIFE_BRAND: Brand = {
   ...DEFAULT_BRAND,
-  title: "Dash For Life",
-  tabTitle: "Dash For Life",
+  title: "Dash for Life",
+  tabTitle: "Dash for Life",
 };
 
 // Per-hostname overrides. Keys are bare hostnames (no port, no "www.").


### PR DESCRIPTION
## Summary

- **Title**: Renamed the `red.cst.cam.ac.uk` brand title to **"Red List Dashboard"** (dropping "IUCN" and "Assessments") and enabled `showGlobe`, so the globe icon renders before the title.
- **Footer**: Reordered the data-source list to lead with IUCN Red List — now reads: *The data is sourced from IUCN Red List (version 2025-2), GBIF, iNaturalist, OpenAlex, CITES, Species+, Catalogue of Life, and Encyclopedia of Life data.* The non-commercial/IBAT sentence is preserved.
- **Brand**: Renamed the `dashforlife.org` brand from "Dash For Life" to **"Dash for Life"** (both `title` and `tabTitle`).

## Changes

- `app/src/config/brand.ts` — `RED_LIST_BRAND` title + `showGlobe`, `DASH_FOR_LIFE_BRAND` casing
- `app/src/app/page.tsx` — footer data-source ordering
- `CHANGELOG.md` — `[Unreleased]` entries

## Notes

Changes are string/JSX-only. A full typecheck/build wasn't run because `node_modules` isn't installed in this environment (`next`, `vitest`, `@types/node` missing) — nothing new to type-check in these edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5Yif5YWrGuPUj4ZAK29m1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5Yif5YWrGuPUj4ZAK29m1)_