### PR TITLE
Surface arbitrary-taxon browsing via search + a thin taxon header

### DIFF
--- a/app/src/app/api/search/route.ts
+++ b/app/src/app/api/search/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { searchSpecies } from "@/lib/data/species-duckdb";
+import { searchSpecies, suggestTaxa } from "@/lib/data/species-duckdb";
 import { CACHE_5M } from "@/lib/cache-headers";
 
 export async function GET(request: NextRequest) {
@@ -8,12 +8,17 @@ export async function GET(request: NextRequest) {
   const limit = Math.min(Math.max(parseInt(searchParams.get("limit") || "10", 10) || 10, 1), 50);
 
   if (query.length < 2) {
-    return NextResponse.json({ results: [] }, { headers: CACHE_5M });
+    return NextResponse.json({ results: [], taxa: [] }, { headers: CACHE_5M });
   }
 
   try {
-    const results = await searchSpecies(query, limit);
-    return NextResponse.json({ results }, { headers: CACHE_5M });
+    // Species hits and higher-rank taxon suggestions scan the same warm parquets;
+    // run them together so the dropdown can pin "Browse Felidae →" above the species.
+    const [results, taxa] = await Promise.all([
+      searchSpecies(query, limit),
+      suggestTaxa(query),
+    ]);
+    return NextResponse.json({ results, taxa }, { headers: CACHE_5M });
   } catch (error) {
     console.error("Search error:", error);
     const message = error instanceof Error ? error.message : "Unknown error";

--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -153,12 +153,17 @@ export function SpeciesSearchBar() {
   );
 
   // Browse a whole higher-rank taxon (e.g. Felidae): navigate to ?taxa=<taxon> in the
-  // assessed (reassessments) view, where category/threat charts render. The
   // arbitrary-rank taxon flows through resolveWhere → querySpecies just like a
-  // curated node; no species is preselected.
+  // curated node; no species is preselected. Preserve the current view: from the
+  // new-assessments view, browsing a taxon shows its not-evaluated species (charts
+  // come from the assessed/reassessments view).
   const selectTaxon = useCallback((t: TaxonSuggestion) => {
+    const currentView: ViewMode =
+      new URLSearchParams(window.location.search).get("view") === "new-assessments"
+        ? "new-assessments"
+        : "reassessments";
     const qs = buildQs({
-      viewMode: "reassessments",
+      viewMode: currentView,
       taxa: new Set([t.taxon]),
       subgroups: new Set(),
       categories: new Set(),

--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -19,6 +19,14 @@ interface SearchResult {
   matched_synonym?: string | null;
 }
 
+// A higher-rank taxon (class/order/family) the query matched — pinned above the
+// species hits. Selecting it browses the whole taxon via ?taxa=<taxon>.
+interface TaxonSuggestion {
+  name: string;
+  rank: "class" | "order" | "family";
+  taxon: string;
+}
+
 /**
  * Module-level cache of the last selected search result.
  * RedListView reads this to construct the preview without an API call.
@@ -34,6 +42,7 @@ export function clearLastSearchResult(): void {
 export function SpeciesSearchBar() {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
+  const [taxaResults, setTaxaResults] = useState<TaxonSuggestion[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [highlightIndex, setHighlightIndex] = useState(-1);
   const [loading, setLoading] = useState(false);
@@ -51,6 +60,7 @@ export function SpeciesSearchBar() {
   useEffect(() => {
     if (query.length < 2) {
       setResults([]);
+      setTaxaResults([]);
       setIsOpen(false);
       return;
     }
@@ -69,11 +79,13 @@ export function SpeciesSearchBar() {
         if (!res.ok) throw new Error("Search failed");
         const data = await res.json();
         setResults(data.results);
+        setTaxaResults(data.taxa ?? []);
         setIsOpen(true);
         setHighlightIndex(-1);
       } catch (e) {
         if (e instanceof DOMException && e.name === "AbortError") return;
         setResults([]);
+        setTaxaResults([]);
         setIsOpen(false);
       } finally {
         setLoading(false);
@@ -134,23 +146,71 @@ export function SpeciesSearchBar() {
 
       setQuery("");
       setResults([]);
+      setTaxaResults([]);
       setIsOpen(false);
     },
     []
   );
 
+  // Browse a whole higher-rank taxon (e.g. Felidae): navigate to ?taxa=<taxon> in the
+  // assessed (reassessments) view, where category/threat charts render. The
+  // arbitrary-rank taxon flows through resolveWhere → querySpecies just like a
+  // curated node; no species is preselected.
+  const selectTaxon = useCallback((t: TaxonSuggestion) => {
+    const qs = buildQs({
+      viewMode: "reassessments",
+      taxa: new Set([t.taxon]),
+      subgroups: new Set(),
+      categories: new Set(),
+      yearRanges: new Set(),
+      assessmentYears: new Set(),
+      describedYears: new Set(),
+      countries: new Set(),
+      obsRanges: new Set(),
+      systems: new Set(),
+      populationTrends: new Set(),
+      movementPatterns: new Set(),
+      threats: new Set(),
+      hasMap: null,
+      endemicsOnly: false,
+      growthForms: new Set(),
+      assessors: new Set(),
+      reviewers: new Set(),
+      search: "",
+      sortField: null,
+      sortDirection: "desc",
+      species: null,
+      tab: null,
+    });
+    window.history.pushState(null, "", "/" + qs);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+
+    setQuery("");
+    setResults([]);
+    setTaxaResults([]);
+    setIsOpen(false);
+  }, []);
+
+  // Keyboard navigation runs over a single combined list: taxon suggestions first,
+  // then species. An index < taxaResults.length picks a taxon; the rest pick species.
+  const totalItems = taxaResults.length + results.length;
+  const activateIndex = (i: number) => {
+    if (i < taxaResults.length) selectTaxon(taxaResults[i]);
+    else selectResult(results[i - taxaResults.length]);
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (!isOpen || results.length === 0) return;
+    if (!isOpen || totalItems === 0) return;
 
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setHighlightIndex((i) => (i < results.length - 1 ? i + 1 : 0));
+      setHighlightIndex((i) => (i < totalItems - 1 ? i + 1 : 0));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
-      setHighlightIndex((i) => (i > 0 ? i - 1 : results.length - 1));
+      setHighlightIndex((i) => (i > 0 ? i - 1 : totalItems - 1));
     } else if (e.key === "Enter" && highlightIndex >= 0) {
       e.preventDefault();
-      selectResult(results[highlightIndex]);
+      activateIndex(highlightIndex);
     } else if (e.key === "Escape") {
       setIsOpen(false);
       inputRef.current?.blur();
@@ -195,6 +255,7 @@ export function SpeciesSearchBar() {
             onClick={() => {
               setQuery("");
               setResults([]);
+              setTaxaResults([]);
               setIsOpen(false);
               inputRef.current?.focus();
             }}
@@ -216,12 +277,37 @@ export function SpeciesSearchBar() {
       {/* Dropdown */}
       {isOpen && (
         <div className="absolute z-50 w-full mt-1 max-h-80 overflow-y-auto rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 shadow-lg">
-          {results.length === 0 && !loading ? (
+          {/* Higher-rank taxon suggestions, pinned above species hits */}
+          {taxaResults.map((t, i) => (
+            <button
+              key={`taxon-${t.rank}-${t.taxon}`}
+              onClick={() => selectTaxon(t)}
+              onMouseEnter={() => setHighlightIndex(i)}
+              className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 border-b border-zinc-100 dark:border-zinc-700/60 ${
+                i === highlightIndex
+                  ? "bg-zinc-100 dark:bg-zinc-700"
+                  : "hover:bg-zinc-50 dark:hover:bg-zinc-700/50"
+              }`}
+            >
+              <svg className="h-4 w-4 shrink-0 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h10M4 18h6" />
+              </svg>
+              <span className="flex-1 min-w-0 text-zinc-900 dark:text-zinc-100">
+                Browse <span className="font-medium">{t.name}</span>
+              </span>
+              <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-zinc-400 dark:text-zinc-500">
+                {t.rank}
+              </span>
+            </button>
+          ))}
+          {results.length === 0 && taxaResults.length === 0 && !loading ? (
             <div className="px-3 py-2 text-sm text-zinc-500 dark:text-zinc-400">
               No species found
             </div>
           ) : (
-            results.map((result, i) => (
+            results.map((result, ri) => {
+              const i = taxaResults.length + ri;
+              return (
               <button
                 key={`${result.id}-${result.taxon_group}`}
                 onClick={() => selectResult(result)}
@@ -261,7 +347,8 @@ export function SpeciesSearchBar() {
                   {result.category}
                 </span>
               </button>
-            ))
+              );
+            })
           )}
         </div>
       )}

--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -246,7 +246,7 @@ export function SpeciesSearchBar() {
           onChange={(e) => setQuery(e.target.value)}
           onFocus={() => query.length >= 2 && setIsOpen(true)}
           onKeyDown={handleKeyDown}
-          placeholder="Search for a species..."
+          placeholder="Search for a species or taxon..."
           className="w-full pl-10 pr-8 py-1.5 text-base rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-500"
         />
         {/* Clear button */}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2140,22 +2140,28 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       ) : (
       <div className="space-y-3">
 
-          {/* Arbitrary-taxon header — a non-curated rank (e.g. Felidae) reached via
-              search. Kept deliberately thin: name + matched rank + the matched-species
-              count (mirrors the table's totalFiltered), no landing cards / drill-down. */}
+          {/* Arbitrary-taxon header — a non-curated rank (e.g. Carnivora) reached via
+              search. Two stat cards: the taxon (name + matched rank) and the
+              matched-species count (mirrors the table's totalFiltered). No landing
+              cards / drill-down — no honest data for arbitrary ranks. */}
           {arbitraryTaxon && !isSingleSpecies && (
-            <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl px-5 py-4">
-              <div className="flex items-baseline gap-2 flex-wrap">
-                <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">{arbitraryTaxon.name}</h2>
-                {arbitraryTaxon.rank && (
-                  <span className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                    {arbitraryTaxon.rank}
-                  </span>
-                )}
+            <div className="grid grid-cols-2 gap-4 max-w-md">
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
+                <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                  {arbitraryTaxon.rank ?? "Taxon"}
+                </div>
+                <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                  {arbitraryTaxon.name}
+                </div>
               </div>
-              <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-                {totalFiltered.toLocaleString()} species
-              </p>
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
+                <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                  Species
+                </div>
+                <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                  {totalFiltered.toLocaleString()}
+                </div>
+              </div>
             </div>
           )}
 

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2060,6 +2060,25 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   const GBIF_FILTERS = "has_coordinate=true&has_geospatial_issue=false&basis_of_record=HUMAN_OBSERVATION&basis_of_record=MACHINE_OBSERVATION&basis_of_record=OCCURRENCE&basis_of_record=MATERIAL_SAMPLE&basis_of_record=OBSERVATION";
   const isNE = (s: Species) => s.category === "NE";
 
+  // A single selected taxon that isn't a curated tree node — an arbitrary rank
+  // (e.g. ?taxa=felidae) reached via search. TaxaSummary can't label it (it only
+  // knows curated nodes), so the results block shows a thin header instead. The
+  // matched rank is read off the loaded species (all matched class/order/family
+  // = the token; the first row's matching field is that rank).
+  const arbitraryTaxon = useMemo(() => {
+    if (selectedTaxa.size !== 1) return null;
+    const id = [...selectedTaxa][0];
+    if (id === "all" || findNode(id)) return null;
+    const v = id.toLowerCase();
+    let rank: "family" | "order" | "class" | null = null;
+    for (const s of species) {
+      if ((s.family ?? "").toLowerCase() === v) { rank = "family"; break; }
+      if ((s.order_name ?? "").toLowerCase() === v) { rank = "order"; break; }
+      if ((s.class_name ?? "").toLowerCase() === v) { rank = "class"; break; }
+    }
+    return { name: id.charAt(0).toUpperCase() + id.slice(1), rank };
+  }, [selectedTaxa, species]);
+
   return (
     <div className="space-y-4 min-w-0">
       {/* Always show Taxa Summary table */}
@@ -2120,6 +2139,27 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
         </div>
       ) : (
       <div className="space-y-3">
+
+          {/* Arbitrary-taxon header — a non-curated rank (e.g. Felidae) reached via
+              search. Kept deliberately thin: name + matched rank, no landing cards /
+              described-count / drill-down (no honest data for arbitrary ranks). */}
+          {arbitraryTaxon && !isSingleSpecies && (
+            <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl px-5 py-4">
+              <div className="flex items-baseline gap-2 flex-wrap">
+                <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">{arbitraryTaxon.name}</h2>
+                {arbitraryTaxon.rank && (
+                  <span className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                    {arbitraryTaxon.rank}
+                  </span>
+                )}
+              </div>
+              <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+                Not part of the curated taxonomy — showing{" "}
+                {isNewAssessments ? "species not yet evaluated" : "assessed species"} matched at{" "}
+                {arbitraryTaxon.rank ?? "rank"} level.
+              </p>
+            </div>
+          )}
 
           {/* Single species header — skeleton while loading */}
           {!isSingleSpecies && urlSpecies != null && speciesLoading && (

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2145,7 +2145,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
               matched-species count (mirrors the table's totalFiltered). No landing
               cards / drill-down — no honest data for arbitrary ranks. */}
           {arbitraryTaxon && !isSingleSpecies && (
-            <div className="grid grid-cols-2 gap-4 max-w-md">
+            <div className="grid grid-cols-2 gap-4">
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
                 <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
                   {arbitraryTaxon.rank ?? "Taxon"}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2159,7 +2159,9 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                   {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
                 </div>
                 <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                  {totalFiltered.toLocaleString()}
+                  {speciesLoading && assessedSpecies.length === 0
+                    ? <Spinner className="h-6 w-6" />
+                    : totalFiltered.toLocaleString()}
                 </div>
               </div>
             </div>

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2141,8 +2141,8 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       <div className="space-y-3">
 
           {/* Arbitrary-taxon header — a non-curated rank (e.g. Felidae) reached via
-              search. Kept deliberately thin: name + matched rank, no landing cards /
-              described-count / drill-down (no honest data for arbitrary ranks). */}
+              search. Kept deliberately thin: name + matched rank + the matched-species
+              count (mirrors the table's totalFiltered), no landing cards / drill-down. */}
           {arbitraryTaxon && !isSingleSpecies && (
             <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl px-5 py-4">
               <div className="flex items-baseline gap-2 flex-wrap">
@@ -2154,9 +2154,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                 )}
               </div>
               <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
-                Not part of the curated taxonomy — showing{" "}
-                {isNewAssessments ? "species not yet evaluated" : "assessed species"} matched at{" "}
-                {arbitraryTaxon.rank ?? "rank"} level.
+                {totalFiltered.toLocaleString()} species
               </p>
             </div>
           )}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2156,7 +2156,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
               </div>
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
                 <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                  Species
+                  {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
                 </div>
                 <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
                   {totalFiltered.toLocaleString()}

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -601,3 +601,56 @@ export async function getSpeciesUnder(taxon: string, limit = 50): Promise<{
     sample: rows.map((r) => ({ col_id: String(r.col_id), scientific_name: String(r.scientific_name) })),
   };
 }
+
+// ─── Higher-rank taxon suggestions (search-bar autocomplete) ─────────────────
+
+export interface TaxonSuggestion {
+  /** Prettified display name, e.g. "Felidae". */
+  name: string;
+  /** Rank the query matched at. */
+  rank: "class" | "order" | "family";
+  /** Lowercased token to pass as ?taxa= (what resolveWhere/querySpecies match on). */
+  taxon: string;
+}
+
+// Recognize a higher-rank taxon (class / order / family) the user is typing, so the
+// search bar can offer "Browse Felidae → " above the species hits. Restricted to the
+// three ranks resolveWhere()'s arbitrary-rank branch matches on — genus is excluded
+// because the dashboard query (querySpecies) can't filter by it, so a genus pick would
+// land on an empty view. Prefix-matches the DISTINCT rank names in the assessed ∪
+// unassessed parquets (already warm in the search hot path, name columns pre-lowercased
+// at build time), so it never full-scans species/. A rank with zero assessed and zero
+// GBIF-observed species won't surface — acceptable: those are exactly the taxa a user
+// wouldn't browse to, and the direct species/synonym search still answers by name.
+export async function suggestTaxa(query: string, limit = 3): Promise<TaxonSuggestion[]> {
+  if (query.length < 2) return [];
+  const conn = await getConn();
+  const q = query.toLowerCase();
+  const RANKS: { col: string; rank: TaxonSuggestion["rank"] }[] = [
+    { col: "family", rank: "family" },
+    { col: "order_name", rank: "order" },
+    { col: "class_name", rank: "class" },
+  ];
+  const part = (src: string, col: string, rank: string) =>
+    `SELECT DISTINCT ${col} AS name, '${rank}' AS rank FROM '${parquetUri(src)}'
+     WHERE ${col} IS NOT NULL AND ${col} LIKE $q || '%'`;
+  const parts = RANKS.flatMap(({ col, rank }) =>
+    [part("assessed.parquet", col, rank), part("unassessed.parquet", col, rank)]);
+  const lim = Math.min(Math.max(limit, 1), 10);
+  // Exact match first, then shortest (closest) name, then alphabetical. DISTINCT in the
+  // sub-selects collapses per-file dupes; the outer query dedupes across ranks by name.
+  const sql = `
+    SELECT name, any_value(rank) AS rank FROM (${parts.join(" UNION ALL ")})
+    GROUP BY name
+    ORDER BY (name = $q) DESC, length(name), name
+    LIMIT ${lim}`;
+  const rows = (await conn.runAndReadAll(sql, { q })).getRowObjects();
+  return rows.map((r) => {
+    const name = String(r.name);
+    return {
+      name: name.charAt(0).toUpperCase() + name.slice(1),
+      rank: String(r.rank) as TaxonSuggestion["rank"],
+      taxon: name,
+    };
+  });
+}


### PR DESCRIPTION
## Summary

The arbitrary-rank query (`resolveWhere` → `querySpecies`) already powers `/?taxa=felidae` end to end — assessed species with category/threat charts, plus the separate not-evaluated view — but there was no way to *reach* it except hand-editing the URL, and a non-curated taxon rendered with raw-id chrome (no label). This wires up the entry point and the presentation.

## What changed

**1. Search recognition (the entry point)**
- New `suggestTaxa()` in `species-duckdb.ts`: recognizes a class/order/family the user is typing by prefix-matching the `DISTINCT` rank names in the already-warm `assessed`/`unassessed` parquets — so it never full-scans `species/`. Genus is deliberately excluded because `querySpecies`'s arbitrary-rank branch only matches class/order/family, so a genus pick would land on an empty view.
- `/api/search` now returns `{ results, taxa }`, running the species search and taxon suggestion in parallel over the same warm parquets.
- `SpeciesSearchBar` pins **"Browse &lt;Taxon&gt;"** rows above the species hits, with keyboard nav spanning both lists. Selecting one navigates to `/?taxa=<taxon>` in the assessed view.

**2. Thin taxon header**
- `RedListView` renders a small header (name + matched rank) whenever a single selected taxon isn't a curated tree node. `TaxaSummary` can only label curated nodes, so an arbitrary taxon previously had no label. The rank is read off the loaded species (no extra fetch). Deliberately thin — no landing cards, described-species count, or drill-down, since there's no honest data for arbitrary ranks.

Everything below the header (assessed charts, not-evaluated view, species table) already worked via the existing pipeline; this makes it reachable and labeled.

## Testing
- `tsc --noEmit`: clean (app sources)
- `eslint` on all changed files: clean
- `vitest run`: 470/470 pass

The live DuckDB query couldn't be smoke-tested in this environment (no R2 creds / local parquets — consistent with the repo's note that these queries are verified manually against live data, not in CI). The new SQL mirrors the existing `searchSpecies` patterns; worth a quick manual check of `/api/search?q=felidae` and the search dropdown against real data before merge.

## Deliberately out of scope (Phase 1)
- MCP `browse_taxon` / `get_vocabulary` parity for arbitrary taxa
- A precise universe count in the suggestion/header (needs a `species/` scan or a build-time rank index)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaMvsac1NFjJiLGJ52a6Yg)_