### PR TITLE
Default unevaluated species to Catalogue of Life tab when no occurrence data

### DIFF
--- a/app/src/components/InatObservationsPanel.tsx
+++ b/app/src/components/InatObservationsPanel.tsx
@@ -19,6 +19,9 @@ const MAP_POINTS = 200;
 interface InatObservationsPanelProps {
   scientificName: string;
   mounted: boolean;
+  /** Called once both feeds have loaded and iNaturalist has no observations either,
+   * letting the parent fall back to another tab (e.g. Catalogue of Life). */
+  onEmpty?: () => void;
 }
 
 /**
@@ -27,7 +30,7 @@ interface InatObservationsPanelProps {
  * GBIF's iNat-dataset occurrence search keyed by a GBIF taxonKey; that returns
  * nothing here, so this panel queries iNaturalist directly by scientific name.
  */
-export default function InatObservationsPanel({ scientificName, mounted }: InatObservationsPanelProps) {
+export default function InatObservationsPanel({ scientificName, mounted, onEmpty }: InatObservationsPanelProps) {
   const [observations, setObservations] = useState<InatObservation[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [inatTaxonId, setInatTaxonId] = useState<number | null>(null);
@@ -85,8 +88,18 @@ export default function InatObservationsPanel({ scientificName, mounted }: InatO
 
   const totalPages = Math.ceil(totalCount / PAGE_SIZE);
 
+  // Both feeds loaded and neither turned up anything: no occurrence data at all.
+  const noRecords = loaded && mapLoaded && observations.length === 0 && mapObs.length === 0;
+
+  // Notify the parent when there's nothing to show, so an unevaluated species can
+  // fall back to another tab (e.g. Catalogue of Life). The parent guards against
+  // acting more than once.
+  useEffect(() => {
+    if (noRecords) onEmpty?.();
+  }, [noRecords, onEmpty]);
+
   // Once both feeds have loaded, if iNaturalist has nothing either, say so plainly.
-  if (loaded && mapLoaded && observations.length === 0 && mapObs.length === 0) {
+  if (noRecords) {
     return (
       <div className="p-6 text-sm text-zinc-500 dark:text-zinc-400">
         No GBIF match found for <span className="italic">{scientificName}</span>, and no iNaturalist

--- a/app/src/components/OccurrenceMapRow.tsx
+++ b/app/src/components/OccurrenceMapRow.tsx
@@ -512,6 +512,9 @@ interface OccurrenceMapRowProps {
    * preserved specimens ON for plants & fungi, where herbarium/fungarium
    * records are a core data source. */
   taxonGroup?: string;
+  /** Called once the occurrence data has loaded and there are no records to show,
+   * letting the parent fall back to another tab (e.g. Catalogue of Life). */
+  onEmpty?: () => void;
 }
 
 /**
@@ -531,6 +534,7 @@ export default function OccurrenceMapRow({
   assessmentYear,
   assessmentDate,
   taxonGroup,
+  onEmpty,
 }: OccurrenceMapRowProps) {
   const [occurrences, setOccurrences] = useState<OccurrenceFeature[]>([]);
   const [breakdown, setBreakdown] = useState<RecordTypeBreakdown | null>(null);
@@ -673,6 +677,15 @@ export default function OccurrenceMapRow({
       .catch(console.error)
       .finally(() => setLoadingBreakdown(false));
   }, [speciesKey, countryCode]);
+
+  // Once occurrences have loaded, tell the parent if GBIF (which includes iNat
+  // records) returned nothing — so an unevaluated species with no occurrence data
+  // can fall back to another tab (e.g. Catalogue of Life).
+  useEffect(() => {
+    if (!loadingOccurrences && totalOccurrences === 0) {
+      onEmpty?.();
+    }
+  }, [loadingOccurrences, totalOccurrences, onEmpty]);
 
   // Fetch iNat photos for a given page
   const fetchInatPhotos = useCallback((page: number, limit: number) => {

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -865,6 +865,12 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   const urlSpeciesHandledRef = useRef(false);
   // Track whether a tab change was initiated programmatically (click) vs URL navigation (popstate)
   const programmaticTabChangeRef = useRef(false);
+  // Whether the user has explicitly picked a tab for the currently open species.
+  // When the occurrence tab turns up no records for a not-evaluated species we
+  // auto-switch to Catalogue of Life — but only while the user hasn't chosen a tab.
+  const manualTabSelectionRef = useRef(false);
+  // Guards the auto-switch so it fires at most once per opened species.
+  const autoColSwitchedRef = useRef(false);
 
   // Wrap setters to sync with URL
   const setSelectedSpeciesKey = useCallback((key: number | null) => {
@@ -873,12 +879,15 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     if (key != null) {
       setActiveDetailTabRaw("gbif");
       setVisitedTabs(new Set(["gbif"]));
+      manualTabSelectionRef.current = false;
+      autoColSwitchedRef.current = false;
     }
   }, [setSpeciesParam]);
 
-  const setActiveDetailTab = useCallback((tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol") => {
+  const setActiveDetailTab = useCallback((tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol", isManual = true) => {
     setActiveDetailTabRaw(tab);
     programmaticTabChangeRef.current = true;
+    if (isManual) manualTabSelectionRef.current = true;
     setTabParam(tab);
     setVisitedTabs(prev => {
       if (prev.has(tab)) return prev;
@@ -887,6 +896,15 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       return next;
     });
   }, [setTabParam]);
+
+  // When the occurrence tab (GBIF + iNat) reports no records for a not-evaluated
+  // species, fall back to the Catalogue of Life tab — unless the user has already
+  // navigated to a tab themselves.
+  const handleOccurrenceEmpty = useCallback(() => {
+    if (manualTabSelectionRef.current || autoColSwitchedRef.current) return;
+    autoColSwitchedRef.current = true;
+    setActiveDetailTab("col", false);
+  }, [setActiveDetailTab]);
   // Sync species/tab from URL params (fires on popstate, e.g. back/forward or search bar navigation)
   // In new-assessments mode, row keys use Math.abs(id) so selectedSpeciesKey must match.
   useEffect(() => {
@@ -899,6 +917,9 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       setSelectedSpeciesKeyRaw(isNewAssessments ? Math.abs(urlSpecies) : urlSpecies);
       setActiveDetailTabRaw(urlTab ?? "gbif");
       setVisitedTabs(new Set([urlTab ?? "gbif"]));
+      // A tab pinned in the URL counts as an explicit choice, so don't auto-switch.
+      manualTabSelectionRef.current = urlTab != null && urlTab !== "gbif";
+      autoColSwitchedRef.current = false;
       urlSpeciesHandledRef.current = false; // allow auto-page-navigate for new species
     }
   }, [urlSpecies, urlTab, isNewAssessments]);
@@ -3673,12 +3694,13 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
                                 assessmentYear={assessmentYear}
                                 assessmentDate={s.assessment_date}
                                 taxonGroup={s.taxon_group}
+                                onEmpty={s.category === "NE" ? handleOccurrenceEmpty : undefined}
                               />
                             </div>
                             )
                           ) : (visitedTabs.has("gbif")) && (
                             <div style={{ display: activeDetailTab === "gbif" ? undefined : "none" }}>
-                              <InatObservationsPanel scientificName={s.scientific_name} mounted={mounted} />
+                              <InatObservationsPanel scientificName={s.scientific_name} mounted={mounted} onEmpty={s.category === "NE" ? handleOccurrenceEmpty : undefined} />
                             </div>
                           )}
                           {(assessmentYear || s.category === "NE") && (visitedTabs.has("literature")) && (


### PR DESCRIPTION
## Summary

For **not-evaluated (NE)** species, the detail panel still opens on the **GBIF + iNat** occurrence tab by default — but when that tab finds no data, it now automatically falls back to the **Catalogue of Life** tab instead of leaving the user on an empty map.

## Changes

- **`OccurrenceMapRow.tsx`** — the GBIF-keyed occurrence panel (GBIF occurrences already include iNat records). Added an `onEmpty` callback that fires once occurrences load with a total of `0`.
- **`InatObservationsPanel.tsx`** — the fallback panel for species with no GBIF backbone match. Fires `onEmpty` when both the observation grid and the map come back empty (its existing "no data" state).
- **`RedListView.tsx`** — passes `onEmpty` only for `category === "NE"` species. The handler switches to the `col` tab, guarded so it:
  - fires **at most once** per opened species (`autoColSwitchedRef`),
  - never overrides a tab the **user manually picked** or one **pinned in the URL** (`manualTabSelectionRef`).

## Behaviour notes

- The switch only triggers on a definitive empty result (`totalOccurrences === 0`), never during loading or on an API error (which leaves the count `null`), so species that do have records — or that fail to load — stay on the occurrence tab.
- Only applies to NE species, matching the request; other categories are unaffected.

## Testing

- `tsc --noEmit` clean
- ESLint clean on all three changed files
- Component test suite passes (40 tests)

Not driven in a live browser: the empty state depends on live GBIF/iNaturalist API responses plus the full dataset, so this was verified statically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Saqks8BiFAwkk453rrTssp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Saqks8BiFAwkk453rrTssp)_