### PR TITLE
Fix country map name mismatches hiding data for ~40 territories

### DIFF
--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -68,11 +68,7 @@ const NAME_TO_ALPHA2: Record<string, string> = {
   "Marshall Is.": "MH",
   // Additional territories present as their own shape in the 50m TopoJSON that
   // had no entry at all before (always rendered as "No data" regardless of the
-  // underlying Red List data). Deliberately NOT included: Somaliland and
-  // N. Cyprus, which the TopoJSON also draws separately, but the Red List data
-  // has no distinct code for either (both fold into Somalia/Cyprus) — coloring
-  // them would misattribute data to a disputed territory, so they're left as
-  // "No data" pending a check with the Red List Unit.
+  // underlying Red List data).
   "American Samoa": "AS", "Anguilla": "AI", "Aruba": "AW", "Bermuda": "BM",
   "Br. Indian Ocean Ter.": "IO", "British Virgin Is.": "VG", "Cayman Is.": "KY",
   "Cook Is.": "CK", "Curaçao": "CW", "Faeroe Is.": "FO", "Fr. Polynesia": "PF",
@@ -83,6 +79,15 @@ const NAME_TO_ALPHA2: Record<string, string> = {
   "St-Barthélemy": "BL", "St-Martin": "MF", "St. Pierre and Miquelon": "PM",
   "Turks and Caicos Is.": "TC", "U.S. Virgin Is.": "VI", "Wallis and Futuna Is.": "WF",
   "Åland": "AX",
+  // Somaliland and N. Cyprus are drawn as their own shape in the TopoJSON, but
+  // IUCN's own Red List country standard (ISO 3166-1 + UN country names, per
+  // redlist.org/resources/country-codes) has no distinct code for either —
+  // both fold into Somalia/Cyprus, the same way IUCN's own species assessments
+  // do (e.g. the Gerenuk assessment's formal country field lists "Somalia",
+  // even though its range-description text separately mentions "Somaliland").
+  // Mapping them to their parent's code matches IUCN's own data model, rather
+  // than leaving a "no data" gap that reads as a bug.
+  "Somaliland": "SO", "N. Cyprus": "CY",
 };
 
 // Complete ISO 3166-1 alpha-2 to country name mapping (for display)
@@ -107,6 +112,7 @@ export const ALPHA2_TO_NAME: Record<string, string> = {
   "NF": "Norfolk Island", "NR": "Nauru", "NU": "Niue", "PF": "French Polynesia",
   "PM": "Saint Pierre and Miquelon", "PN": "Pitcairn", "PW": "Palau", "RE": "Réunion",
   "SC": "Seychelles", "SH": "Saint Helena", "SJ": "Svalbard", "SM": "San Marino",
+  "SO": "Somalia", "CY": "Cyprus",
   "ST": "São Tomé and Príncipe", "SV": "El Salvador", "SX": "Sint Maarten",
   "TC": "Turks and Caicos", "TK": "Tokelau", "TO": "Tonga", "TV": "Tuvalu",
   "UM": "U.S. Minor Outlying Islands", "VA": "Vatican City", "VC": "Saint Vincent and the Grenadines",
@@ -257,7 +263,7 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
     if (coords) {
       setCenter(coords);
       // Zoom level depends on country size - small countries zoom more
-      const smallCountries = new Set(["Singapore", "Luxembourg", "Cyprus", "Jamaica", "Trinidad and Tobago", "Brunei", "Qatar", "Kuwait", "Lebanon", "Djibouti", "eSwatini", "Lesotho", "Gambia", "Guinea-Bissau", "Slovenia", "Montenegro", "Kosovo", "Macedonia", "Andorra", "Antigua and Barb.", "Bahrain", "Barbados", "Belize", "Cabo Verde", "Comoros", "Dominica", "Grenada", "Kiribati", "Liechtenstein", "Maldives", "Malta", "Marshall Is.", "Mauritius", "Micronesia", "Monaco", "Nauru", "Palau", "Samoa", "San Marino", "São Tomé and Principe", "Seychelles", "St. Kitts and Nevis", "Saint Lucia", "St. Vin. and Gren.", "Tonga", "Tuvalu", "Vatican", "American Samoa", "Anguilla", "Aruba", "Bermuda", "British Virgin Is.", "Cayman Is.", "Curaçao", "Faeroe Is.", "Guernsey", "Hong Kong", "Isle of Man", "Jersey", "Macao", "Montserrat", "N. Mariana Is.", "Niue", "Norfolk Island", "Pitcairn Is.", "Saint Helena", "Sint Maarten", "St-Barthélemy", "St-Martin", "St. Pierre and Miquelon", "Turks and Caicos Is.", "U.S. Virgin Is.", "Wallis and Futuna Is.", "Åland"]);
+      const smallCountries = new Set(["Singapore", "Luxembourg", "Cyprus", "Jamaica", "Trinidad and Tobago", "Brunei", "Qatar", "Kuwait", "Lebanon", "Djibouti", "eSwatini", "Lesotho", "Gambia", "Guinea-Bissau", "Slovenia", "Montenegro", "Kosovo", "Macedonia", "Andorra", "Antigua and Barb.", "Bahrain", "Barbados", "Belize", "Cabo Verde", "Comoros", "Dominica", "Grenada", "Kiribati", "Liechtenstein", "Maldives", "Malta", "Marshall Is.", "Mauritius", "Micronesia", "Monaco", "Nauru", "Palau", "Samoa", "San Marino", "São Tomé and Principe", "Seychelles", "St. Kitts and Nevis", "Saint Lucia", "St. Vin. and Gren.", "Tonga", "Tuvalu", "Vatican", "American Samoa", "Anguilla", "Aruba", "Bermuda", "British Virgin Is.", "Cayman Is.", "Curaçao", "Faeroe Is.", "Guernsey", "Hong Kong", "Isle of Man", "Jersey", "Macao", "Montserrat", "N. Mariana Is.", "Niue", "Norfolk Island", "Pitcairn Is.", "Saint Helena", "Sint Maarten", "St-Barthélemy", "St-Martin", "St. Pierre and Miquelon", "Turks and Caicos Is.", "U.S. Virgin Is.", "Wallis and Futuna Is.", "Åland", "N. Cyprus"]);
       const largeCountries = new Set(["Russia", "Canada", "United States of America", "China", "Brazil", "Australia", "India", "Argentina"]);
       const zoomLevel = smallCountries.has(countryName) ? 6 : largeCountries.has(countryName) ? 2.5 : 4;
       setZoom(zoomLevel);

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -49,16 +49,40 @@ const NAME_TO_ALPHA2: Record<string, string> = {
   "United Arab Emirates": "AE", "United Kingdom": "GB", "United States of America": "US",
   "Uruguay": "UY", "Uzbekistan": "UZ", "Vanuatu": "VU", "Venezuela": "VE", "Vietnam": "VN",
   "Yemen": "YE", "Zambia": "ZM", "Zimbabwe": "ZW", "Palestine": "PS", "Kosovo": "XK",
-  "North Macedonia": "MK", "New Caledonia": "NC", "W. Sahara": "EH", "Fr. S. Antarctic Lands": "TF",
+  "Macedonia": "MK", "New Caledonia": "NC", "W. Sahara": "EH", "Fr. S. Antarctic Lands": "TF",
   "Falkland Is.": "FK",
-  // Small/micro nations not in 110m TopoJSON but useful for search
-  "Andorra": "AD", "Antigua and Barbuda": "AG", "Bahamas": "BS", "Bahrain": "BH", "Barbados": "BB",
-  "Belize": "BZ", "Cape Verde": "CV", "Comoros": "KM", "Dominica": "DM", "Grenada": "GD",
-  "Kiribati": "KI", "Liechtenstein": "LI", "Maldives": "MV", "Malta": "MT", "Marshall Islands": "MH",
+  // Small/micro nations not in the 50m TopoJSON at all — kept spelled out since
+  // there's no shape to match against; only useful for search.
+  "Andorra": "AD", "Bahamas": "BS", "Bahrain": "BH", "Barbados": "BB",
+  "Belize": "BZ", "Comoros": "KM", "Dominica": "DM", "Grenada": "GD",
+  "Kiribati": "KI", "Liechtenstein": "LI", "Maldives": "MV", "Malta": "MT",
   "Mauritius": "MU", "Micronesia": "FM", "Monaco": "MC", "Nauru": "NR", "Palau": "PW",
-  "Samoa": "WS", "San Marino": "SM", "São Tomé and Príncipe": "ST", "Seychelles": "SC",
-  "Saint Kitts and Nevis": "KN", "Saint Lucia": "LC", "Saint Vincent and the Grenadines": "VC",
-  "Tonga": "TO", "Tuvalu": "TV", "Vatican City": "VA",
+  "Samoa": "WS", "San Marino": "SM", "Seychelles": "SC", "Saint Lucia": "LC",
+  "Tonga": "TO", "Tuvalu": "TV",
+  // These ARE present in the 50m TopoJSON, just under an abbreviated/different
+  // name than the long form above — keyed here by the exact shape name so the
+  // map coloring lookup (NAME_TO_ALPHA2[geo.properties.name]) actually matches.
+  // (Long display names still shown elsewhere via ALPHA2_TO_NAME's own overrides below.)
+  "Antigua and Barb.": "AG", "Cabo Verde": "CV", "São Tomé and Principe": "ST",
+  "St. Kitts and Nevis": "KN", "St. Vin. and Gren.": "VC", "Vatican": "VA",
+  "Marshall Is.": "MH",
+  // Additional territories present as their own shape in the 50m TopoJSON that
+  // had no entry at all before (always rendered as "No data" regardless of the
+  // underlying Red List data). Deliberately NOT included: Somaliland and
+  // N. Cyprus, which the TopoJSON also draws separately, but the Red List data
+  // has no distinct code for either (both fold into Somalia/Cyprus) — coloring
+  // them would misattribute data to a disputed territory, so they're left as
+  // "No data" pending a check with the Red List Unit.
+  "American Samoa": "AS", "Anguilla": "AI", "Aruba": "AW", "Bermuda": "BM",
+  "Br. Indian Ocean Ter.": "IO", "British Virgin Is.": "VG", "Cayman Is.": "KY",
+  "Cook Is.": "CK", "Curaçao": "CW", "Faeroe Is.": "FO", "Fr. Polynesia": "PF",
+  "Guam": "GU", "Guernsey": "GG", "Heard I. and McDonald Is.": "HM", "Hong Kong": "HK",
+  "Isle of Man": "IM", "Jersey": "JE", "Macao": "MO", "Montserrat": "MS",
+  "N. Mariana Is.": "MP", "Niue": "NU", "Norfolk Island": "NF", "Pitcairn Is.": "PN",
+  "S. Geo. and the Is.": "GS", "Saint Helena": "SH", "Sint Maarten": "SX",
+  "St-Barthélemy": "BL", "St-Martin": "MF", "St. Pierre and Miquelon": "PM",
+  "Turks and Caicos Is.": "TC", "U.S. Virgin Is.": "VI", "Wallis and Futuna Is.": "WF",
+  "Åland": "AX",
 };
 
 // Complete ISO 3166-1 alpha-2 to country name mapping (for display)
@@ -78,7 +102,7 @@ export const ALPHA2_TO_NAME: Record<string, string> = {
   "HM": "Heard Island", "IM": "Isle of Man", "IO": "British Indian Ocean Territory",
   "JE": "Jersey", "KI": "Kiribati", "KM": "Comoros", "KN": "Saint Kitts and Nevis",
   "KY": "Cayman Islands", "LC": "Saint Lucia", "LI": "Liechtenstein", "MC": "Monaco",
-  "MF": "Saint Martin", "MH": "Marshall Islands", "MO": "Macao", "MP": "Northern Mariana Islands",
+  "MF": "Saint Martin", "MH": "Marshall Islands", "MK": "North Macedonia", "MO": "Macao", "MP": "Northern Mariana Islands",
   "MQ": "Martinique", "MS": "Montserrat", "MT": "Malta", "MU": "Mauritius", "MV": "Maldives",
   "NF": "Norfolk Island", "NR": "Nauru", "NU": "Niue", "PF": "French Polynesia",
   "PM": "Saint Pierre and Miquelon", "PN": "Pitcairn", "PW": "Palau", "RE": "Réunion",
@@ -233,7 +257,7 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
     if (coords) {
       setCenter(coords);
       // Zoom level depends on country size - small countries zoom more
-      const smallCountries = new Set(["Singapore", "Luxembourg", "Cyprus", "Jamaica", "Trinidad and Tobago", "Brunei", "Qatar", "Kuwait", "Lebanon", "Djibouti", "eSwatini", "Lesotho", "Gambia", "Guinea-Bissau", "Slovenia", "Montenegro", "Kosovo", "North Macedonia", "Andorra", "Antigua and Barbuda", "Bahrain", "Barbados", "Belize", "Cape Verde", "Comoros", "Dominica", "Grenada", "Kiribati", "Liechtenstein", "Maldives", "Malta", "Marshall Islands", "Mauritius", "Micronesia", "Monaco", "Nauru", "Palau", "Samoa", "San Marino", "São Tomé and Príncipe", "Seychelles", "Saint Kitts and Nevis", "Saint Lucia", "Saint Vincent and the Grenadines", "Tonga", "Tuvalu", "Vatican City"]);
+      const smallCountries = new Set(["Singapore", "Luxembourg", "Cyprus", "Jamaica", "Trinidad and Tobago", "Brunei", "Qatar", "Kuwait", "Lebanon", "Djibouti", "eSwatini", "Lesotho", "Gambia", "Guinea-Bissau", "Slovenia", "Montenegro", "Kosovo", "Macedonia", "Andorra", "Antigua and Barb.", "Bahrain", "Barbados", "Belize", "Cabo Verde", "Comoros", "Dominica", "Grenada", "Kiribati", "Liechtenstein", "Maldives", "Malta", "Marshall Is.", "Mauritius", "Micronesia", "Monaco", "Nauru", "Palau", "Samoa", "San Marino", "São Tomé and Principe", "Seychelles", "St. Kitts and Nevis", "Saint Lucia", "St. Vin. and Gren.", "Tonga", "Tuvalu", "Vatican", "American Samoa", "Anguilla", "Aruba", "Bermuda", "British Virgin Is.", "Cayman Is.", "Curaçao", "Faeroe Is.", "Guernsey", "Hong Kong", "Isle of Man", "Jersey", "Macao", "Montserrat", "N. Mariana Is.", "Niue", "Norfolk Island", "Pitcairn Is.", "Saint Helena", "Sint Maarten", "St-Barthélemy", "St-Martin", "St. Pierre and Miquelon", "Turks and Caicos Is.", "U.S. Virgin Is.", "Wallis and Futuna Is.", "Åland"]);
       const largeCountries = new Set(["Russia", "Canada", "United States of America", "China", "Brazil", "Australia", "India", "Argentina"]);
       const zoomLevel = smallCountries.has(countryName) ? 6 : largeCountries.has(countryName) ? 2.5 : 4;
       setZoom(zoomLevel);


### PR DESCRIPTION
## Summary

Follow-up to Thom's feedback about Somaliland/North Macedonia/Kosovo showing "No data" on the country map. Investigated against the live TopoJSON (`world-atlas@2/countries-50m.json`) and the real species data — it's a real bug, bigger than the 3 territories Thom noticed.

**Root cause:** `WorldMap.tsx`'s TopoJSON-name → alpha-2 lookup table was hand-built and doesn't exactly match the strings this map file actually uses for its shapes (e.g. it has `"North Macedonia"` as a key, but the shape is literally named `"Macedonia"`). When a shape's name isn't found in the table, it silently renders as "No data" regardless of whether the Red List has species there. Diffing the table against all 241 TopoJSON shape names found **~40 territories** affected this way.

**Fixed:**
- North Macedonia — hid **1,649** assessed species (the exact bug Thom flagged). Added a display override so tooltips/chips still read "North Macedonia" even though the lookup key now matches the shape's legacy TopoJSON string.
- 7 more entries existed under a full name that didn't match the shape's abbreviated string (Cabo Verde, São Tomé and Príncipe, St. Kitts and Nevis, St. Vincent and the Grenadines, Vatican City, Marshall Islands, Antigua and Barbuda) — renamed the lookup keys, kept the nice display names.
- ~30 territories had no lookup entry at all (Hong Kong, Macao, US/British Virgin Islands, Guam, American Samoa, Cayman Islands, Bermuda, Guernsey, Jersey, Isle of Man, and more) — added them.

**Somaliland and N. Cyprus — mapped to their parent country, not left blank:**
Both are drawn as their own shape in the TopoJSON, but researched IUCN's own Red List country-code standard (redlist.org/resources/country-codes) rather than guessing: it's ISO 3166-1 + UN country names, with no distinct entry for Somaliland or Northern Cyprus — both fold into Somalia/Cyprus, the same way IUCN's own species assessments do (e.g. the Gerenuk assessment's formal country field lists "Somalia" even though its range-description text separately mentions "Somaliland"). IUCN does create bespoke entries for other disputed territories when it chooses to (Palestine, Western Sahara, a generic "Disputed Territory" entry for the Paracels/Spratlys) — the absence for these two looks deliberate, not an oversight. So both shapes now resolve to their parent's alpha-2 code (with explicit display-name overrides so filter chips/tooltips still read "Somalia"/"Cyprus" either way), rather than leaving a "no data" gap that reads as a bug.

**Kosovo — not a bug, a genuine data gap:**
Checked directly against the raw data: the lookup was already correct (`"Kosovo": "XK"`), and there are genuinely **zero** assessed species tagged to Kosovo (there are 2,647 in the *Unassessed* dataset). This one isn't a dashboard bug — it's a real Red List data-granularity gap, exactly as Thom suspected.

## Test plan

- [x] Typecheck passes (`npx tsc --noEmit`), lint clean
- [x] Programmatically diffed the fixed lookup table against all 241 TopoJSON shape names — confirmed 0 unexpected gaps remain (only 3 genuinely uninhabited/no-ISO-code territories left unmapped: Ashmore and Cartier Is., Indian Ocean Ter., Siachen Glacier)
- [x] Queried the real species data (`assessed.parquet`/`unassessed.parquet` via duckdb) to confirm real, non-trivial species counts exist for each previously-hidden code (e.g. MK: 1,649, HK: 1,921, CV: 1,281, KN: 1,725, VC: 1,928, and more)
- [x] Verified in-browser (Playwright): searching for each fixed territory now successfully selects it (confirms the shape's own name now resolves through the same lookup) and shows the correct display name as a filter chip — checked North Macedonia, Cape Verde, Hong Kong, Vatican City, Marshall Islands, Saint Kitts and Nevis, Kosovo
- [x] Verified Somaliland and N. Cyprus now select/color together with Somalia/Cyprus respectively, with filter chips correctly reading "Somalia"/"Cyprus" (not the breakaway region's name) regardless of which shape was clicked
- [x] Kosovo behaves as expected: selectable (mapping was always correct), but genuinely zero assessed-species data
- [x] Confirmed `lib/countries.ts` (a separate, unrelated free-text country-name resolver used for MCP/agent dashboard links) doesn't share this bug and wasn't touched

Built and tested in an isolated git worktree off `main` since other work was in progress concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

