### PR TITLE
Add CLAUDE.md: document repo PR conventions

### DIFF
--- a/.claude/skills/verify-ui/SKILL.md
+++ b/.claude/skills/verify-ui/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: run
+name: verify-ui
 description: Launch and drive the redlist-dashboard Next.js app for manual/agent verification, including the Node 22 workaround needed for Playwright browser checks on this machine.
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,11 @@ Treat the PR body as a living summary, not a one-time snapshot. Every time a com
 
 ## Always verify UI changes in a real browser
 
-For any UI-facing change, complete an actual browser drive-through (navigate, interact, screenshot) before calling it done — don't downgrade to "typecheck/lint/tests pass, API returns the right data, that's probably enough" as a way to route around flaky tooling. If the verification tooling itself is broken, fix the tooling (see `.claude/skills/run/` for the current Node/Playwright workaround) rather than substituting a weaker check. Only skip with explicit sign-off, and say plainly that it wasn't verified visually — don't imply it was.
+For any UI-facing change, complete an actual browser drive-through (navigate, interact, screenshot) before calling it done — don't downgrade to "typecheck/lint/tests pass, API returns the right data, that's probably enough" as a way to route around flaky tooling. If the verification tooling itself is broken, fix the tooling (see `.claude/skills/verify-ui/` for the current Node/Playwright workaround) rather than substituting a weaker check. Only skip with explicit sign-off, and say plainly that it wasn't verified visually — don't imply it was.
+
+## Use a git worktree for each new piece of work
+
+Start a new git worktree (a dedicated branch checked out to its own directory) for each new, substantial feature or fix, rather than branching in place in the main checkout — this keeps unrelated in-progress work isolated and lets multiple pieces of work proceed in parallel without one clobbering another's uncommitted state. Not worth it for a one-line fix or a quick doc change — use judgment on "substantial."
 
 ## PR screenshots: R2, not the repo
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# Working conventions for this repo
+
+These apply to anyone (or any agent) opening a PR against redlist-dashboard, not just a specific assistant's preferences.
+
+## Ship multi-phase features as one PR
+
+When a feature naturally breaks into sequential phases (e.g. data pipeline → UI component → integration → wiring), open **one PR** and land each phase as its own commit, verifying it (typecheck/lint/tests + a real browser check for anything UI-facing — see below) before starting the next. Don't split phases into separate PRs.
+
+Only open a genuinely separate PR when a piece of follow-up work carries real, separate regression risk against already-working code — that's a scope decision (does this touch a different, currently-stable code path?), not a phasing-cadence one.
+
+## Keep the PR description current
+
+Treat the PR body as a living summary, not a one-time snapshot. Every time a commit changes what the PR does, what it fixes, or what's been verified, update the body's Summary/Test-plan sections to match (`gh pr edit --body ...`) — don't just leave the original description stale with fixes trailing below in comments. A reviewer should be able to read the PR body alone and get the current, complete picture.
+
+## Always verify UI changes in a real browser
+
+For any UI-facing change, complete an actual browser drive-through (navigate, interact, screenshot) before calling it done — don't downgrade to "typecheck/lint/tests pass, API returns the right data, that's probably enough" as a way to route around flaky tooling. If the verification tooling itself is broken, fix the tooling (see `.claude/skills/run/` for the current Node/Playwright workaround) rather than substituting a weaker check. Only skip with explicit sign-off, and say plainly that it wasn't verified visually — don't imply it was.
+
+## PR screenshots: R2, not the repo
+
+Don't commit screenshots to the repo (`docs/pr-screenshots/` or anywhere else) — images committed to git stay in the object history forever, even after being deleted in a later commit, so screenshot-heavy PRs become a permanent, un-reclaimable addition to repo/clone size.
+
+Instead:
+1. Resize to ~1000px wide (`sips --resampleWidth 1000 <file> --out <file>`) — legible in a PR body, meaningfully smaller than a raw viewport capture.
+2. Upload to the public Cloudflare R2 bucket **`pr-assets`** via the S3-compatible API (`@aws-sdk/client-s3`, already a dependency), using the `R2_ACCOUNT_ID`/`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` env vars (same credentials `scripts/upload-data-to-r2.ts` uses — `region: "auto"`, `endpoint: https://${accountId}.r2.cloudflarestorage.com`). Set `ContentType: "image/png"`.
+3. Key convention: `pr-<number>-<short-feature-slug>/<NN>-<description>.png` — lead with the actual PR number (durable, collision-proof, and makes cleanup trivial: "is PR 369 merged? safe to delete its folder").
+4. Embed as `https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/<key>` in the PR body (the bucket's public "Public Development URL"). GitHub proxies any public HTTPS image through Camo, so this renders identically to a GitHub-hosted image.
+5. If a screenshot needs replacing after a follow-up commit changes the UI, either overwrite the same key (`PutObjectCommand`) or `CopyObjectCommand`+`DeleteObjectCommand` to rename — nothing here is git-tracked, so there's no history to worry about.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,6 @@
 
 These apply to anyone (or any agent) opening a PR against redlist-dashboard, not just a specific assistant's preferences.
 
-## Ship multi-phase features as one PR
-
-When a feature naturally breaks into sequential phases (e.g. data pipeline → UI component → integration → wiring), open **one PR** and land each phase as its own commit, verifying it (typecheck/lint/tests + a real browser check for anything UI-facing — see below) before starting the next. Don't split phases into separate PRs.
-
-Only open a genuinely separate PR when a piece of follow-up work carries real, separate regression risk against already-working code — that's a scope decision (does this touch a different, currently-stable code path?), not a phasing-cadence one.
-
 ## Keep the PR description current
 
 Treat the PR body as a living summary, not a one-time snapshot. Every time a commit changes what the PR does, what it fixes, or what's been verified, update the body's Summary/Test-plan sections to match (`gh pr edit --body ...`) — don't just leave the original description stale with fixes trailing below in comments. A reviewer should be able to read the PR body alone and get the current, complete picture.


### PR DESCRIPTION
## Summary

Pulls the workflow conventions established across recent PRs out of a private Claude Code memory system and into a git-tracked `CLAUDE.md`, so they're visible to anyone (or any agent) working on this repo:
- Keep the PR description current as follow-up commits land, rather than leaving it stale.
- Always verify UI changes in a real browser before calling them done.
- Use a dedicated git worktree for each new, substantial piece of work.
- Host PR screenshots on Cloudflare R2 (public `pr-assets` bucket), not committed to the repo.

Also renames the existing `.claude/skills/run/` skill to `.claude/skills/verify-ui/` — the old name read as "run the tests"/"run a script" and collided with the platform's own built-in generic "run" skill; `verify-ui` matches what it actually does (launch the app + drive it in a browser for verification).

No production code changes (skill + doc only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)