### PR TITLE
Country view: 1/2-1/2 table/map split, click-to-lock hover, SSC groups show all

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -59,9 +59,14 @@ export default function RedListPage() {
                 // Assessments) choices — same fields clearAllFiltersAndTaxa
                 // preserves, replicated here via raw URL params since this
                 // click lives outside RedListView's useFilterParams instance.
+                // Falls back to `origin` when `layout` itself is absent — a
+                // taxon drill-down out of Country View clears `layout` but
+                // leaves `origin=country` behind (see useFilterParams.ts's
+                // originLayout), so Home still lands back on that view
+                // instead of the generic default.
                 const params = new URLSearchParams(window.location.search);
                 const kept = new URLSearchParams();
-                const layout = params.get("layout");
+                const layout = params.get("layout") || params.get("origin");
                 const view = params.get("view");
                 if (layout) kept.set("layout", layout);
                 if (view) kept.set("view", view);

--- a/app/src/components/CountryStatsList.tsx
+++ b/app/src/components/CountryStatsList.tsx
@@ -46,7 +46,7 @@ function SortHeader({
 }) {
   return (
     <th
-      className={`text-xs font-medium text-zinc-500 dark:text-zinc-400 px-1.5 py-1.5 cursor-pointer select-none hover:text-zinc-700 dark:hover:text-zinc-200 whitespace-nowrap overflow-hidden text-ellipsis ${align === "left" ? "text-left" : "text-right"} ${widthClass ?? ""}`}
+      className={`text-xs font-medium text-zinc-500 dark:text-zinc-400 px-1.5 py-0.5 cursor-pointer select-none hover:text-zinc-700 dark:hover:text-zinc-200 whitespace-nowrap overflow-hidden text-ellipsis ${align === "left" ? "text-left" : "text-right"} ${widthClass ?? ""}`}
       onClick={onClick}
       aria-sort={active ? (dir === "asc" ? "ascending" : "descending") : undefined}
     >
@@ -137,8 +137,13 @@ export default function CountryStatsList({
         {/* table-fixed + explicit column-width shares (rather than auto/content-based
             sizing) so the Country column truncates instead of wrapping long names
             ("United States of America") across multiple lines — needed now that
-            this list has to fit the map's narrower 1/3-width column. */}
-        <table className="w-full table-fixed text-sm border-collapse">
+            this list has to fit the map's narrower 1/3-width column. Rows use
+            text-xs + py-0.5 (down from text-sm/py-1) so PAGE_SIZE rows + header +
+            footer land close to the Map view's own natural height — with align-
+            items: stretch on the paired grid, taller List content used to drag
+            the whole row (map card AND table) up to match, which meant just
+            toggling Map/List visibly resized the page. */}
+        <table className="w-full table-fixed text-xs border-collapse">
           <thead className="sticky top-0 bg-zinc-50 dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800 z-10">
             <tr>
               <SortHeader label="Country" active={sortKey === "name"} dir={sortDir} align="left" widthClass={showOutdatedMode ? "w-[34%]" : "w-2/3"} onClick={() => toggleSort("name")} />
@@ -162,15 +167,15 @@ export default function CountryStatsList({
                     isSelected ? "bg-blue-50 dark:bg-blue-900/30" : "hover:bg-zinc-50 dark:hover:bg-zinc-800/50"
                   }`}
                 >
-                  <td className="px-1.5 py-1 text-zinc-700 dark:text-zinc-300 max-w-0">
+                  <td className="px-1.5 py-0.5 text-zinc-700 dark:text-zinc-300 max-w-0">
                     <span className="block truncate" title={row.name}>{row.name}</span>
                   </td>
-                  <td className="px-1.5 py-1 text-right tabular-nums text-zinc-700 dark:text-zinc-300 whitespace-nowrap">{row.species.toLocaleString()}</td>
+                  <td className="px-1.5 py-0.5 text-right tabular-nums text-zinc-700 dark:text-zinc-300 whitespace-nowrap">{row.species.toLocaleString()}</td>
                   {showOutdatedMode && (
-                    <td className="px-1.5 py-1 text-right tabular-nums text-zinc-700 dark:text-zinc-300 whitespace-nowrap">{row.outdated.toLocaleString()}</td>
+                    <td className="px-1.5 py-0.5 text-right tabular-nums text-zinc-700 dark:text-zinc-300 whitespace-nowrap">{row.outdated.toLocaleString()}</td>
                   )}
                   {showOutdatedMode && (
-                    <td className="px-1.5 py-1 text-right tabular-nums text-zinc-700 dark:text-zinc-300 whitespace-nowrap">{row.percentOutdated.toFixed(1)}%</td>
+                    <td className="px-1.5 py-0.5 text-right tabular-nums text-zinc-700 dark:text-zinc-300 whitespace-nowrap">{row.percentOutdated.toFixed(1)}%</td>
                   )}
                 </tr>
               );
@@ -186,7 +191,7 @@ export default function CountryStatsList({
         </table>
       </div>
       {sorted.length > 0 && (
-        <div className="flex items-center justify-between px-2 py-1 border-t border-zinc-200 dark:border-zinc-800 text-xs text-zinc-500 dark:text-zinc-400 shrink-0">
+        <div className="flex items-center justify-between px-2 py-0.5 border-t border-zinc-200 dark:border-zinc-800 text-xs text-zinc-500 dark:text-zinc-400 shrink-0">
           <span>
             {clampedPage * PAGE_SIZE + 1}–{Math.min((clampedPage + 1) * PAGE_SIZE, sorted.length)} of {sorted.length}
           </span>

--- a/app/src/components/CountryStatsList.tsx
+++ b/app/src/components/CountryStatsList.tsx
@@ -7,6 +7,29 @@ import { iucnRegionCountries } from "@/lib/regions";
 type SortKey = "name" | "species" | "outdated" | "percentOutdated";
 type SortDir = "asc" | "desc";
 
+// Per-column min/max filter — kept as strings (not numbers) so a field can sit
+// empty (no bound) or mid-edit without fighting a parsed/reformatted value.
+interface RangeFilter {
+  min: string;
+  max: string;
+}
+const EMPTY_RANGE: RangeFilter = { min: "", max: "" };
+
+// Blank bound = unbounded on that side; a non-numeric bound (still being
+// typed, e.g. "-" or "") doesn't filter anything out rather than hiding
+// every row while the input is mid-edit.
+function inRange(value: number, filter: RangeFilter): boolean {
+  if (filter.min !== "") {
+    const min = Number(filter.min);
+    if (!Number.isNaN(min) && value < min) return false;
+  }
+  if (filter.max !== "") {
+    const max = Number(filter.max);
+    if (!Number.isNaN(max) && value > max) return false;
+  }
+  return true;
+}
+
 interface CountryStatsListProps {
   stats: CountryStats;
   selectedCountries: Set<string>;
@@ -56,6 +79,43 @@ function SortHeader({
   );
 }
 
+// Min/max inputs for one numeric column, in their own header row below the
+// sort headers. stopPropagation on click/keydown so typing a filter (or just
+// clicking into the field) doesn't trigger the row-level onClick a click on
+// the table would otherwise bubble into elsewhere in this component.
+function RangeFilterCell({
+  value,
+  onChange,
+}: {
+  value: RangeFilter;
+  onChange: (next: RangeFilter) => void;
+}) {
+  return (
+    <th className="px-1 py-0.5 font-normal">
+      <div className="flex items-center justify-end gap-0.5" onClick={(e) => e.stopPropagation()}>
+        <input
+          type="number"
+          inputMode="decimal"
+          value={value.min}
+          onChange={(e) => onChange({ ...value, min: e.target.value })}
+          placeholder="min"
+          aria-label="Minimum"
+          className="w-0 min-w-0 flex-1 text-[10px] px-1 py-0.5 rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300 placeholder-zinc-400 focus:outline-none focus:ring-1 focus:ring-blue-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+        />
+        <input
+          type="number"
+          inputMode="decimal"
+          value={value.max}
+          onChange={(e) => onChange({ ...value, max: e.target.value })}
+          placeholder="max"
+          aria-label="Maximum"
+          className="w-0 min-w-0 flex-1 text-[10px] px-1 py-0.5 rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300 placeholder-zinc-400 focus:outline-none focus:ring-1 focus:ring-blue-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+        />
+      </div>
+    </th>
+  );
+}
+
 /**
  * Sortable table alternative to WorldMap's choropleth — same data (CountryStats),
  * same onCountrySelect click-through behavior, for users who'd rather scan/sort a
@@ -79,6 +139,13 @@ export default function CountryStatsList({
   const sortDir = controlledSortDir ?? localSortDir;
   const [page, setPage] = useState(0);
 
+  // Per-column min/max — local only (not URL-synced like sort), same as the
+  // map's own search/zoom state; narrowing the list this way is a scratch
+  // exploration, not something worth making a shareable link out of.
+  const [speciesFilter, setSpeciesFilter] = useState<RangeFilter>(EMPTY_RANGE);
+  const [outdatedFilter, setOutdatedFilter] = useState<RangeFilter>(EMPTY_RANGE);
+  const [percentOutdatedFilter, setPercentOutdatedFilter] = useState<RangeFilter>(EMPTY_RANGE);
+
   const regionCodes = useMemo(
     () => (regionFilter ? new Set(iucnRegionCountries(regionFilter)) : null),
     [regionFilter]
@@ -96,19 +163,27 @@ export default function CountryStatsList({
       }));
   }, [stats, regionCodes]);
 
+  const filteredRows = useMemo(() => {
+    return rows.filter((r) =>
+      inRange(r.species, speciesFilter) &&
+      (!showOutdatedMode || (inRange(r.outdated, outdatedFilter) && inRange(r.percentOutdated, percentOutdatedFilter)))
+    );
+  }, [rows, speciesFilter, outdatedFilter, percentOutdatedFilter, showOutdatedMode]);
+
   const sorted = useMemo(() => {
     const dir = sortDir === "asc" ? 1 : -1;
-    return [...rows].sort((a, b) =>
+    return [...filteredRows].sort((a, b) =>
       sortKey === "name" ? dir * a.name.localeCompare(b.name) : dir * (a[sortKey] - b[sortKey])
     );
-  }, [rows, sortKey, sortDir]);
+  }, [filteredRows, sortKey, sortDir]);
 
-  // Back to page 1 whenever the sort or the underlying row set changes —
-  // otherwise switching sort/region could strand the view on a now-empty page.
-  // Adjusted during render (React's documented alternative to an effect that
-  // just resets state) via a second piece of state, not a ref — this project's
-  // lint rules disallow mutating a ref during render.
-  const resetKey = `${sortKey}|${sortDir}|${regionFilter ?? ""}|${rows.length}`;
+  // Back to page 1 whenever the sort, filters, or the underlying row set
+  // changes — otherwise switching sort/region/filters could strand the view
+  // on a now-empty page. Adjusted during render (React's documented
+  // alternative to an effect that just resets state) via a second piece of
+  // state, not a ref — this project's lint rules disallow mutating a ref
+  // during render.
+  const resetKey = `${sortKey}|${sortDir}|${regionFilter ?? ""}|${filteredRows.length}|${speciesFilter.min}|${speciesFilter.max}|${outdatedFilter.min}|${outdatedFilter.max}|${percentOutdatedFilter.min}|${percentOutdatedFilter.max}`;
   const [prevResetKey, setPrevResetKey] = useState(resetKey);
   if (prevResetKey !== resetKey) {
     setPrevResetKey(resetKey);
@@ -154,6 +229,12 @@ export default function CountryStatsList({
               {showOutdatedMode && (
                 <SortHeader label="% Outdated" active={sortKey === "percentOutdated"} dir={sortDir} widthClass="w-[22%]" onClick={() => toggleSort("percentOutdated")} />
               )}
+            </tr>
+            <tr className="border-t border-zinc-200 dark:border-zinc-800">
+              <th className="px-1.5 py-0.5" />
+              <RangeFilterCell value={speciesFilter} onChange={setSpeciesFilter} />
+              {showOutdatedMode && <RangeFilterCell value={outdatedFilter} onChange={setOutdatedFilter} />}
+              {showOutdatedMode && <RangeFilterCell value={percentOutdatedFilter} onChange={setPercentOutdatedFilter} />}
             </tr>
           </thead>
           <tbody>

--- a/app/src/components/CountryStatsList.tsx
+++ b/app/src/components/CountryStatsList.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { FaFilter } from "react-icons/fa";
 import { ALPHA2_TO_NAME, type CountryStats } from "./WorldMap";
 import { iucnRegionCountries } from "@/lib/regions";
 
 type SortKey = "name" | "species" | "outdated" | "percentOutdated";
 type SortDir = "asc" | "desc";
+type FilterKey = "species" | "outdated" | "percentOutdated";
 
 // Per-column min/max filter — kept as strings (not numbers) so a field can sit
 // empty (no bound) or mid-edit without fighting a parsed/reformatted value.
@@ -59,6 +62,7 @@ function SortHeader({
   align = "right",
   widthClass,
   onClick,
+  filterButton,
 }: {
   label: string;
   active: boolean;
@@ -66,6 +70,7 @@ function SortHeader({
   align?: "left" | "right";
   widthClass?: string;
   onClick: () => void;
+  filterButton?: React.ReactNode;
 }) {
   return (
     <th
@@ -75,44 +80,44 @@ function SortHeader({
     >
       {label}
       <span className="inline-block w-3 text-zinc-400">{active ? (dir === "asc" ? "▲" : "▼") : ""}</span>
+      {filterButton}
     </th>
   );
 }
 
-// Min/max inputs for one numeric column, in their own header row below the
-// sort headers. stopPropagation on click/keydown so typing a filter (or just
-// clicking into the field) doesn't trigger the row-level onClick a click on
-// the table would otherwise bubble into elsewhere in this component.
-function RangeFilterCell({
-  value,
-  onChange,
+// Filter icon for one numeric column — the convention most data-grid libraries
+// use (AG Grid, Material-UI DataGrid, Ant Design's Table) for keeping a
+// column's own controls out of a permanent row: an icon in the header that's
+// tinted when a filter's actually active, opening a small min/max popover on
+// click instead of taking up space at rest. stopPropagation so clicking it
+// doesn't also trigger the header's onClick (sort).
+function FilterIconButton({
+  active,
+  isOpen,
+  onClick,
 }: {
-  value: RangeFilter;
-  onChange: (next: RangeFilter) => void;
+  active: boolean;
+  isOpen: boolean;
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }) {
   return (
-    <th className="px-1 py-0.5 font-normal">
-      <div className="flex items-center justify-end gap-0.5" onClick={(e) => e.stopPropagation()}>
-        <input
-          type="number"
-          inputMode="decimal"
-          value={value.min}
-          onChange={(e) => onChange({ ...value, min: e.target.value })}
-          placeholder="min"
-          aria-label="Minimum"
-          className="w-0 min-w-0 flex-1 text-[10px] px-1 py-0.5 rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300 placeholder-zinc-400 focus:outline-none focus:ring-1 focus:ring-blue-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-        />
-        <input
-          type="number"
-          inputMode="decimal"
-          value={value.max}
-          onChange={(e) => onChange({ ...value, max: e.target.value })}
-          placeholder="max"
-          aria-label="Maximum"
-          className="w-0 min-w-0 flex-1 text-[10px] px-1 py-0.5 rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300 placeholder-zinc-400 focus:outline-none focus:ring-1 focus:ring-blue-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-        />
-      </div>
-    </th>
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick(e);
+      }}
+      className={`ml-1 p-0.5 rounded align-middle transition-colors ${
+        active
+          ? "text-blue-600 dark:text-blue-400"
+          : isOpen
+          ? "text-zinc-600 dark:text-zinc-300"
+          : "text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+      }`}
+      title="Filter"
+      aria-label="Filter this column"
+    >
+      <FaFilter size={9} />
+    </button>
   );
 }
 
@@ -145,6 +150,43 @@ export default function CountryStatsList({
   const [speciesFilter, setSpeciesFilter] = useState<RangeFilter>(EMPTY_RANGE);
   const [outdatedFilter, setOutdatedFilter] = useState<RangeFilter>(EMPTY_RANGE);
   const [percentOutdatedFilter, setPercentOutdatedFilter] = useState<RangeFilter>(EMPTY_RANGE);
+
+  // Which column's filter popover is open (at most one at a time) + where to
+  // portal it — computed from the clicked icon's own bounding rect, same
+  // "fixed + getBoundingClientRect" pattern TaxaSummary's column-toggle menu
+  // uses, so it escapes this table's own overflow-auto/table-fixed clipping.
+  const [openFilterKey, setOpenFilterKey] = useState<FilterKey | null>(null);
+  const [filterMenuPos, setFilterMenuPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const filterMenuRef = useRef<HTMLDivElement>(null);
+
+  const filterConfigs: Record<FilterKey, { value: RangeFilter; onChange: (next: RangeFilter) => void }> = {
+    species: { value: speciesFilter, onChange: setSpeciesFilter },
+    outdated: { value: outdatedFilter, onChange: setOutdatedFilter },
+    percentOutdated: { value: percentOutdatedFilter, onChange: setPercentOutdatedFilter },
+  };
+
+  function toggleFilterMenu(key: FilterKey, e: React.MouseEvent<HTMLButtonElement>) {
+    if (openFilterKey === key) {
+      setOpenFilterKey(null);
+      return;
+    }
+    const rect = e.currentTarget.getBoundingClientRect();
+    setFilterMenuPos({ top: rect.bottom + 4, left: Math.max(4, rect.right - 150) });
+    setOpenFilterKey(key);
+  }
+
+  // Close the filter popover on outside click — same pattern as TaxaSummary's
+  // column-toggle menu / WorldMap's search dropdown.
+  useEffect(() => {
+    if (!openFilterKey) return;
+    const handler = (e: MouseEvent) => {
+      if (filterMenuRef.current && !filterMenuRef.current.contains(e.target as Node)) {
+        setOpenFilterKey(null);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [openFilterKey]);
 
   const regionCodes = useMemo(
     () => (regionFilter ? new Set(iucnRegionCountries(regionFilter)) : null),
@@ -206,6 +248,8 @@ export default function CountryStatsList({
     }
   }
 
+  const openFilterConfig = openFilterKey ? filterConfigs[openFilterKey] : null;
+
   return (
     <div className="flex-1 min-h-0 flex flex-col rounded-lg border border-zinc-200 dark:border-zinc-800">
       <div className="flex-1 min-h-0 overflow-auto">
@@ -217,24 +261,60 @@ export default function CountryStatsList({
             footer land close to the Map view's own natural height — with align-
             items: stretch on the paired grid, taller List content used to drag
             the whole row (map card AND table) up to match, which meant just
-            toggling Map/List visibly resized the page. */}
+            toggling Map/List visibly resized the page. Min/max filters live
+            behind each numeric header's filter icon (see FilterIconButton)
+            rather than a permanent row, for the same reason — a row of inputs
+            here would have blown that height budget again. */}
         <table className="w-full table-fixed text-xs border-collapse">
           <thead className="sticky top-0 bg-zinc-50 dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800 z-10">
             <tr>
               <SortHeader label="Country" active={sortKey === "name"} dir={sortDir} align="left" widthClass={showOutdatedMode ? "w-[34%]" : "w-2/3"} onClick={() => toggleSort("name")} />
-              <SortHeader label={speciesLabel} active={sortKey === "species"} dir={sortDir} widthClass={showOutdatedMode ? "w-[22%]" : "w-1/3"} onClick={() => toggleSort("species")} />
+              <SortHeader
+                label={speciesLabel}
+                active={sortKey === "species"}
+                dir={sortDir}
+                widthClass={showOutdatedMode ? "w-[22%]" : "w-1/3"}
+                onClick={() => toggleSort("species")}
+                filterButton={
+                  <FilterIconButton
+                    active={speciesFilter.min !== "" || speciesFilter.max !== ""}
+                    isOpen={openFilterKey === "species"}
+                    onClick={(e) => toggleFilterMenu("species", e)}
+                  />
+                }
+              />
               {showOutdatedMode && (
-                <SortHeader label="# Outdated" active={sortKey === "outdated"} dir={sortDir} widthClass="w-[22%]" onClick={() => toggleSort("outdated")} />
+                <SortHeader
+                  label="# Outdated"
+                  active={sortKey === "outdated"}
+                  dir={sortDir}
+                  widthClass="w-[22%]"
+                  onClick={() => toggleSort("outdated")}
+                  filterButton={
+                    <FilterIconButton
+                      active={outdatedFilter.min !== "" || outdatedFilter.max !== ""}
+                      isOpen={openFilterKey === "outdated"}
+                      onClick={(e) => toggleFilterMenu("outdated", e)}
+                    />
+                  }
+                />
               )}
               {showOutdatedMode && (
-                <SortHeader label="% Outdated" active={sortKey === "percentOutdated"} dir={sortDir} widthClass="w-[22%]" onClick={() => toggleSort("percentOutdated")} />
+                <SortHeader
+                  label="% Outdated"
+                  active={sortKey === "percentOutdated"}
+                  dir={sortDir}
+                  widthClass="w-[22%]"
+                  onClick={() => toggleSort("percentOutdated")}
+                  filterButton={
+                    <FilterIconButton
+                      active={percentOutdatedFilter.min !== "" || percentOutdatedFilter.max !== ""}
+                      isOpen={openFilterKey === "percentOutdated"}
+                      onClick={(e) => toggleFilterMenu("percentOutdated", e)}
+                    />
+                  }
+                />
               )}
-            </tr>
-            <tr className="border-t border-zinc-200 dark:border-zinc-800">
-              <th className="px-1.5 py-0.5" />
-              <RangeFilterCell value={speciesFilter} onChange={setSpeciesFilter} />
-              {showOutdatedMode && <RangeFilterCell value={outdatedFilter} onChange={setOutdatedFilter} />}
-              {showOutdatedMode && <RangeFilterCell value={percentOutdatedFilter} onChange={setPercentOutdatedFilter} />}
             </tr>
           </thead>
           <tbody>
@@ -294,6 +374,35 @@ export default function CountryStatsList({
             </button>
           </div>
         </div>
+      )}
+      {openFilterKey && openFilterConfig && typeof document !== "undefined" && createPortal(
+        <div
+          ref={filterMenuRef}
+          className="fixed z-[9999] flex items-center gap-1 p-1.5 rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 shadow-lg"
+          style={{ top: filterMenuPos.top, left: filterMenuPos.left }}
+        >
+          <input
+            type="number"
+            inputMode="decimal"
+            value={openFilterConfig.value.min}
+            onChange={(e) => openFilterConfig.onChange({ ...openFilterConfig.value, min: e.target.value })}
+            placeholder="min"
+            aria-label="Minimum"
+            autoFocus
+            className="w-16 text-xs px-1.5 py-1 rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300 placeholder-zinc-400 focus:outline-none focus:ring-1 focus:ring-blue-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+          />
+          <span className="text-zinc-400 dark:text-zinc-500">–</span>
+          <input
+            type="number"
+            inputMode="decimal"
+            value={openFilterConfig.value.max}
+            onChange={(e) => openFilterConfig.onChange({ ...openFilterConfig.value, max: e.target.value })}
+            placeholder="max"
+            aria-label="Maximum"
+            className="w-16 text-xs px-1.5 py-1 rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-700 dark:text-zinc-300 placeholder-zinc-400 focus:outline-none focus:ring-1 focus:ring-blue-500 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+          />
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -257,18 +257,6 @@ interface WorldMapProps {
   // Called with the hovered country's code on mouseenter, and null on
   // mouseleave, only while selectOnHover is true.
   onCountryHover?: (countryCode: string | null) => void;
-  // When true, renders the current selection as individually-removable name
-  // chips floated over the top-left of the map (each ✕ toggles just that one
-  // country off via onCountrySelect) — Country View's own "which countries
-  // am I looking at" display, living on the map instead of atop the table it
-  // drives (a label atop the table there made the zoomed table jump position
-  // every time a country got locked/cleared). Default false — the other
-  // WorldMap usages keep their existing atop-table chip instead.
-  showSelectionChips?: boolean;
-  // Clears every selected country at once — the "Clear all" shown alongside
-  // the chips once there's more than one. Only rendered/called when both
-  // this and showSelectionChips are set.
-  onClearAllCountries?: () => void;
 }
 
 const DEFAULT_CENTER: [number, number] = [10, 10];
@@ -276,7 +264,7 @@ const DEFAULT_ZOOM = 1.0;
 const MIN_ZOOM = 1.0;
 const MAX_ZOOM = 8.0;
 
-function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover, showSelectionChips = false, onClearAllCountries }: WorldMapProps) {
+function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover }: WorldMapProps) {
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
   const [hoveredCountryCode, setHoveredCountryCode] = useState<string | null>(null);
   const [speciesStats, setSpeciesStats] = useState<CountryStats>(precomputedStats || {});
@@ -603,58 +591,6 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
           )}
         </div>
       </div>
-
-      {/* Selection chips — floated (absolute) over the top-left of the map
-          area rather than sitting in normal flow, so adding/removing a
-          country never changes the map's own rendered size (it used to push
-          the choropleth down/shrink it every time the selection changed).
-          One chip per selected country (not collapsed into a region name,
-          unlike the atop-table "France ×" chip elsewhere), each individually
-          removable, plus a "Clear all" for dropping the whole selection at
-          once — pointer-events-none on the wrapper so empty space between
-          chips doesn't block map clicks, re-enabled per chip/button. Before
-          anything's locked, hovering shows its own preview chip (dashed,
-          non-removable — there's nothing to remove yet, moving the mouse
-          away already clears it) so the table's live hover-preview has the
-          same visual anchor a locked selection does. */}
-      {showSelectionChips && (selectedCountries.size > 0 || (selectOnHover && hoveredCountryCode)) && (
-        <div className="absolute top-11 left-3 right-3 z-20 flex flex-wrap items-center gap-1 pointer-events-none">
-          {selectedCountries.size > 0 ? (
-            <>
-              {[...selectedCountries]
-                .map(code => ({ code, name: ALPHA2_TO_NAME[code] ?? code }))
-                .sort((a, b) => a.name.localeCompare(b.name))
-                .map(({ code, name }) => (
-                  <span
-                    key={code}
-                    className="pointer-events-auto inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 shadow-sm text-xs text-zinc-700 dark:text-zinc-300 max-w-full"
-                  >
-                    <span className="truncate">{name}</span>
-                    <button
-                      onClick={(e) => onCountrySelect(code, name, e)}
-                      className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                      title={`Remove ${name}`}
-                    >
-                      ✕
-                    </button>
-                  </span>
-                ))}
-              {selectedCountries.size > 1 && onClearAllCountries && (
-                <button
-                  onClick={onClearAllCountries}
-                  className="pointer-events-auto text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors"
-                >
-                  Clear all
-                </button>
-              )}
-            </>
-          ) : (
-            <span className="pointer-events-none inline-flex items-center pl-2 pr-2 py-0.5 rounded-full bg-white/90 dark:bg-zinc-800/90 border border-dashed border-zinc-300 dark:border-zinc-600 text-xs text-zinc-500 dark:text-zinc-400 max-w-full">
-              <span className="truncate">{hoveredCountry}</span>
-            </span>
-          )}
-        </div>
-      )}
 
       {/* Hover tooltip (map view only) */}
       {viewMode === "map" && hoveredCountry && (

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -553,16 +553,20 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
             )}
           </div>
           {/* Color mode: Species and % Outdated are always accurate; GBIF only when
-              no extra filters are active (its counts aren't filterable per-country) */}
-          <select
-            value={colorMode}
-            onChange={(e) => setColorMode(e.target.value as ColorMode)}
-            className="text-[10px] bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md px-1.5 py-0.5 text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
-          >
-            <option value="species">{speciesLabel}</option>
-            {showOutdatedMode && <option value="outdated">% Outdated</option>}
-            {showGbifToggle && <option value="occurrences"># GBIF Obs</option>}
-          </select>
+              no extra filters are active (its counts aren't filterable per-country).
+              Only meaningful for the choropleth itself — hidden in List view, which
+              shows every column directly rather than color-coding by just one. */}
+          {viewMode === "map" && (
+            <select
+              value={colorMode}
+              onChange={(e) => setColorMode(e.target.value as ColorMode)}
+              className="text-[10px] bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md px-1.5 py-0.5 text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            >
+              <option value="species">{speciesLabel}</option>
+              {showOutdatedMode && <option value="outdated">% Outdated</option>}
+              {showGbifToggle && <option value="occurrences"># GBIF Obs</option>}
+            </select>
+          )}
           {onEndemicsToggle && (
             <button
               onClick={onEndemicsToggle}

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -612,34 +612,46 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
           unlike the atop-table "France ×" chip elsewhere), each individually
           removable, plus a "Clear all" for dropping the whole selection at
           once — pointer-events-none on the wrapper so empty space between
-          chips doesn't block map clicks, re-enabled per chip/button. */}
-      {showSelectionChips && selectedCountries.size > 0 && (
+          chips doesn't block map clicks, re-enabled per chip/button. Before
+          anything's locked, hovering shows its own preview chip (dashed,
+          non-removable — there's nothing to remove yet, moving the mouse
+          away already clears it) so the table's live hover-preview has the
+          same visual anchor a locked selection does. */}
+      {showSelectionChips && (selectedCountries.size > 0 || (selectOnHover && hoveredCountryCode)) && (
         <div className="absolute top-11 left-3 right-3 z-20 flex flex-wrap items-center gap-1 pointer-events-none">
-          {[...selectedCountries]
-            .map(code => ({ code, name: ALPHA2_TO_NAME[code] ?? code }))
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map(({ code, name }) => (
-              <span
-                key={code}
-                className="pointer-events-auto inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 shadow-sm text-xs text-zinc-700 dark:text-zinc-300 max-w-full"
-              >
-                <span className="truncate">{name}</span>
+          {selectedCountries.size > 0 ? (
+            <>
+              {[...selectedCountries]
+                .map(code => ({ code, name: ALPHA2_TO_NAME[code] ?? code }))
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map(({ code, name }) => (
+                  <span
+                    key={code}
+                    className="pointer-events-auto inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 shadow-sm text-xs text-zinc-700 dark:text-zinc-300 max-w-full"
+                  >
+                    <span className="truncate">{name}</span>
+                    <button
+                      onClick={(e) => onCountrySelect(code, name, e)}
+                      className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                      title={`Remove ${name}`}
+                    >
+                      ✕
+                    </button>
+                  </span>
+                ))}
+              {selectedCountries.size > 1 && onClearAllCountries && (
                 <button
-                  onClick={(e) => onCountrySelect(code, name, e)}
-                  className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                  title={`Remove ${name}`}
+                  onClick={onClearAllCountries}
+                  className="pointer-events-auto text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors"
                 >
-                  ✕
+                  Clear all
                 </button>
-              </span>
-            ))}
-          {selectedCountries.size > 1 && onClearAllCountries && (
-            <button
-              onClick={onClearAllCountries}
-              className="pointer-events-auto text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors"
-            >
-              Clear all
-            </button>
+              )}
+            </>
+          ) : (
+            <span className="pointer-events-none inline-flex items-center pl-2 pr-2 py-0.5 rounded-full bg-white/90 dark:bg-zinc-800/90 border border-dashed border-zinc-300 dark:border-zinc-600 text-xs text-zinc-500 dark:text-zinc-400 max-w-full">
+              <span className="truncate">{hoveredCountry}</span>
+            </span>
           )}
         </div>
       )}

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -245,6 +245,13 @@ interface WorldMapProps {
   mapSortKey?: MapSortKey;
   mapSortDirection?: "asc" | "desc";
   onMapSortChange?: (key: MapSortKey, direction: "asc" | "desc") => void;
+  // When true, hovering a country also drives onCountrySelect (in addition to
+  // the tooltip), so e.g. the country-view landing page's table updates as
+  // you scan the map rather than requiring a click. Default false — the
+  // other WorldMap usages (Charts row 2's country filter, the CITES map)
+  // still expect click-to-select, since hover already drives their tooltip
+  // and select-on-hover there would fight with normal mouse movement.
+  selectOnHover?: boolean;
 }
 
 const DEFAULT_CENTER: [number, number] = [10, 10];
@@ -252,7 +259,7 @@ const DEFAULT_ZOOM = 1.0;
 const MIN_ZOOM = 1.0;
 const MAX_ZOOM = 8.0;
 
-function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange }: WorldMapProps) {
+function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false }: WorldMapProps) {
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
   const [hoveredCountryCode, setHoveredCountryCode] = useState<string | null>(null);
   const [speciesStats, setSpeciesStats] = useState<CountryStats>(precomputedStats || {});
@@ -708,9 +715,12 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
                     <Geography
                       key={geo.rsmKey}
                       geography={geo}
-                      onMouseEnter={() => {
+                      onMouseEnter={(event) => {
                         setHoveredCountry(countryName);
                         setHoveredCountryCode(alpha2);
+                        if (selectOnHover && alpha2) {
+                          onCountrySelect(alpha2, countryName, event);
+                        }
                       }}
                       onMouseLeave={() => {
                         setHoveredCountry(null);

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -257,16 +257,19 @@ interface WorldMapProps {
   // Called with the hovered country's code on mouseenter, and null on
   // mouseleave, only while selectOnHover is true.
   onCountryHover?: (countryCode: string | null) => void;
-  // When true, reserves a blank min-h-[34px] strip right below the toolbar
-  // row — matching height (and margin) to the selection-chip row Country
-  // View's paired table reserves above itself, so both sides of that grid
-  // have the same "extra" natural height and neither needs align-items:
-  // stretch to inflate it to match the other. Without this, only the
-  // table's column grew, and since the choropleth renders at a fixed
-  // projection scale (its content doesn't grow to fill extra height), the
-  // map's card stretching to match left a visible gap under the map.
-  // Default false — the other WorldMap usages have no paired chip row.
-  showTopSpacer?: boolean;
+  // When set, reserves a blank strip of exactly this many px right below
+  // the toolbar row — matching (via the caller's own ResizeObserver
+  // measurement, not a fixed guess) the real height of the selection-chip
+  // row Country View's paired table reserves above itself, so both sides
+  // of that grid always have the same "extra" natural height and neither
+  // needs align-items: stretch to inflate it to match the other — a fixed
+  // guess only covers the common 1-line-of-chips case; once chips wrap to
+  // a second line the table's column grows past it, and since the
+  // choropleth renders at a fixed projection scale (its content doesn't
+  // grow to fill extra height), stretching the map's card to match left a
+  // visible gap under the map. Omitted for the other WorldMap usages,
+  // which have no paired chip row.
+  topSpacerHeight?: number;
 }
 
 const DEFAULT_CENTER: [number, number] = [10, 10];
@@ -274,7 +277,7 @@ const DEFAULT_ZOOM = 1.0;
 const MIN_ZOOM = 1.0;
 const MAX_ZOOM = 8.0;
 
-function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover, showTopSpacer = false }: WorldMapProps) {
+function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover, topSpacerHeight }: WorldMapProps) {
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
   const [hoveredCountryCode, setHoveredCountryCode] = useState<string | null>(null);
   const [speciesStats, setSpeciesStats] = useState<CountryStats>(precomputedStats || {});
@@ -606,7 +609,7 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
         </div>
       </div>
 
-      {showTopSpacer && <div className="min-h-[34px] mb-1.5" />}
+      {topSpacerHeight != null && <div className="mb-1.5" style={{ height: topSpacerHeight }} />}
 
       {/* Hover tooltip (map view only) */}
       {viewMode === "map" && hoveredCountry && (

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -257,6 +257,16 @@ interface WorldMapProps {
   // Called with the hovered country's code on mouseenter, and null on
   // mouseleave, only while selectOnHover is true.
   onCountryHover?: (countryCode: string | null) => void;
+  // When true, reserves a blank min-h-[34px] strip right below the toolbar
+  // row — matching height (and margin) to the selection-chip row Country
+  // View's paired table reserves above itself, so both sides of that grid
+  // have the same "extra" natural height and neither needs align-items:
+  // stretch to inflate it to match the other. Without this, only the
+  // table's column grew, and since the choropleth renders at a fixed
+  // projection scale (its content doesn't grow to fill extra height), the
+  // map's card stretching to match left a visible gap under the map.
+  // Default false — the other WorldMap usages have no paired chip row.
+  showTopSpacer?: boolean;
 }
 
 const DEFAULT_CENTER: [number, number] = [10, 10];
@@ -264,7 +274,7 @@ const DEFAULT_ZOOM = 1.0;
 const MIN_ZOOM = 1.0;
 const MAX_ZOOM = 8.0;
 
-function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover }: WorldMapProps) {
+function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover, showTopSpacer = false }: WorldMapProps) {
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
   const [hoveredCountryCode, setHoveredCountryCode] = useState<string | null>(null);
   const [speciesStats, setSpeciesStats] = useState<CountryStats>(precomputedStats || {});
@@ -595,6 +605,8 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
           )}
         </div>
       </div>
+
+      {showTopSpacer && <div className="min-h-[34px] mb-1.5" />}
 
       {/* Hover tooltip (map view only) */}
       {viewMode === "map" && hoveredCountry && (

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -258,13 +258,17 @@ interface WorldMapProps {
   // mouseleave, only while selectOnHover is true.
   onCountryHover?: (countryCode: string | null) => void;
   // When true, renders the current selection as individually-removable name
-  // chips top-left below the toolbar row (each ✕ toggles just that one
+  // chips floated over the top-left of the map (each ✕ toggles just that one
   // country off via onCountrySelect) — Country View's own "which countries
   // am I looking at" display, living on the map instead of atop the table it
   // drives (a label atop the table there made the zoomed table jump position
   // every time a country got locked/cleared). Default false — the other
   // WorldMap usages keep their existing atop-table chip instead.
   showSelectionChips?: boolean;
+  // Clears every selected country at once — the "Clear all" shown alongside
+  // the chips once there's more than one. Only rendered/called when both
+  // this and showSelectionChips are set.
+  onClearAllCountries?: () => void;
 }
 
 const DEFAULT_CENTER: [number, number] = [10, 10];
@@ -272,7 +276,7 @@ const DEFAULT_ZOOM = 1.0;
 const MIN_ZOOM = 1.0;
 const MAX_ZOOM = 8.0;
 
-function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover, showSelectionChips = false }: WorldMapProps) {
+function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover, showSelectionChips = false, onClearAllCountries }: WorldMapProps) {
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
   const [hoveredCountryCode, setHoveredCountryCode] = useState<string | null>(null);
   const [speciesStats, setSpeciesStats] = useState<CountryStats>(precomputedStats || {});
@@ -600,19 +604,24 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
         </div>
       </div>
 
-      {/* Selection chips — top-left, just below the toolbar row. One per
-          selected country (not collapsed into a region name, unlike the
-          atop-table "France ×" chip elsewhere) so each can be removed
-          individually without clearing the whole selection. */}
+      {/* Selection chips — floated (absolute) over the top-left of the map
+          area rather than sitting in normal flow, so adding/removing a
+          country never changes the map's own rendered size (it used to push
+          the choropleth down/shrink it every time the selection changed).
+          One chip per selected country (not collapsed into a region name,
+          unlike the atop-table "France ×" chip elsewhere), each individually
+          removable, plus a "Clear all" for dropping the whole selection at
+          once — pointer-events-none on the wrapper so empty space between
+          chips doesn't block map clicks, re-enabled per chip/button. */}
       {showSelectionChips && selectedCountries.size > 0 && (
-        <div className="flex flex-wrap items-center gap-1 mb-1.5">
+        <div className="absolute top-11 left-3 right-3 z-20 flex flex-wrap items-center gap-1 pointer-events-none">
           {[...selectedCountries]
             .map(code => ({ code, name: ALPHA2_TO_NAME[code] ?? code }))
             .sort((a, b) => a.name.localeCompare(b.name))
             .map(({ code, name }) => (
               <span
                 key={code}
-                className="inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-800 text-xs text-zinc-700 dark:text-zinc-300 max-w-full"
+                className="pointer-events-auto inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 shadow-sm text-xs text-zinc-700 dark:text-zinc-300 max-w-full"
               >
                 <span className="truncate">{name}</span>
                 <button
@@ -624,6 +633,14 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
                 </button>
               </span>
             ))}
+          {selectedCountries.size > 1 && onClearAllCountries && (
+            <button
+              onClick={onClearAllCountries}
+              className="pointer-events-auto text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors"
+            >
+              Clear all
+            </button>
+          )}
         </div>
       )}
 

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -257,13 +257,6 @@ interface WorldMapProps {
   // Called with the hovered country's code on mouseenter, and null on
   // mouseleave, only while selectOnHover is true.
   onCountryHover?: (countryCode: string | null) => void;
-  // When provided, shows the current selection (one country's name, a
-  // matching region's name, or a comma-joined list) top-left below the
-  // toolbar row, with a ✕ that calls this to clear it — the country-view
-  // landing page's own "which country am I looking at" label, now living on
-  // the map instead of atop the table it drives. Omitted (and thus hidden)
-  // for the other WorldMap usages, which have no such label.
-  onClearSelection?: () => void;
 }
 
 const DEFAULT_CENTER: [number, number] = [10, 10];
@@ -271,7 +264,7 @@ const DEFAULT_ZOOM = 1.0;
 const MIN_ZOOM = 1.0;
 const MAX_ZOOM = 8.0;
 
-function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover, onClearSelection }: WorldMapProps) {
+function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover }: WorldMapProps) {
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
   const [hoveredCountryCode, setHoveredCountryCode] = useState<string | null>(null);
   const [speciesStats, setSpeciesStats] = useState<CountryStats>(precomputedStats || {});
@@ -499,19 +492,6 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
   const hoveredTotalStats = hoveredCountryCode ? precomputedStatsTotal?.[hoveredCountryCode] : null;
   const hoveredOccurrenceStats = hoveredCountryCode && occurrenceStats ? occurrenceStats[hoveredCountryCode] : null;
 
-  // Selection label — one country's name, a matching region's name, or a
-  // comma-joined list for an arbitrary multi-select. Same logic as
-  // TaxaSummary's own countryScopeLabel (the "France ×" chip it still shows
-  // for the non-map-paired country filter elsewhere), just computed here too
-  // now that Country View's version of this label lives on the map itself.
-  const scopeCodes = [...selectedCountries];
-  const scopeLabel = scopeCodes.length === 0 ? "" :
-    scopeCodes.length === 1 ? (ALPHA2_TO_NAME[scopeCodes[0]] ?? scopeCodes[0]) :
-    matchingRegion(selectedCountries) ?? scopeCodes
-      .map((c) => ALPHA2_TO_NAME[c] ?? c)
-      .sort()
-      .join(", ");
-
   return (
     <div className="relative bg-white dark:bg-zinc-900 rounded-xl shadow-sm border border-zinc-200 dark:border-zinc-800 p-3 h-full flex flex-col">
       {/* Header with controls */}
@@ -611,23 +591,6 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
           )}
         </div>
       </div>
-
-      {/* Selection label — top-left, just below the toolbar row. Only when a
-          clear handler's given (Country View's own map instance) and a
-          selection is actually locked in (see selectOnHover/onCountrySelect
-          in RedListView — a plain hover-preview doesn't reach here). */}
-      {onClearSelection && scopeLabel && (
-        <div className="flex items-center gap-1.5 mb-1.5 min-w-0 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-          <span className="truncate" title={scopeLabel}>{scopeLabel}</span>
-          <button
-            onClick={onClearSelection}
-            className="text-sm font-normal text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors shrink-0"
-            title="Clear selected country"
-          >
-            ✕
-          </button>
-        </div>
-      )}
 
       {/* Hover tooltip (map view only) */}
       {viewMode === "map" && hoveredCountry && (
@@ -768,9 +731,11 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
                       onMouseLeave={() => {
                         setHoveredCountry(null);
                         setHoveredCountryCode(null);
-                        if (selectOnHover) {
-                          onCountryHover?.(null);
-                        }
+                        // Unconditional (not gated on selectOnHover, unlike
+                        // onMouseEnter above) — self-heals a stale preview
+                        // left over from before a country got locked in, so
+                        // it can't resurface later if the lock is cleared.
+                        onCountryHover?.(null);
                       }}
                       onClick={(event) => {
                         if (alpha2) {

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -257,6 +257,14 @@ interface WorldMapProps {
   // Called with the hovered country's code on mouseenter, and null on
   // mouseleave, only while selectOnHover is true.
   onCountryHover?: (countryCode: string | null) => void;
+  // When true, renders the current selection as individually-removable name
+  // chips top-left below the toolbar row (each ✕ toggles just that one
+  // country off via onCountrySelect) — Country View's own "which countries
+  // am I looking at" display, living on the map instead of atop the table it
+  // drives (a label atop the table there made the zoomed table jump position
+  // every time a country got locked/cleared). Default false — the other
+  // WorldMap usages keep their existing atop-table chip instead.
+  showSelectionChips?: boolean;
 }
 
 const DEFAULT_CENTER: [number, number] = [10, 10];
@@ -264,7 +272,7 @@ const DEFAULT_ZOOM = 1.0;
 const MIN_ZOOM = 1.0;
 const MAX_ZOOM = 8.0;
 
-function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover }: WorldMapProps) {
+function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover, showSelectionChips = false }: WorldMapProps) {
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
   const [hoveredCountryCode, setHoveredCountryCode] = useState<string | null>(null);
   const [speciesStats, setSpeciesStats] = useState<CountryStats>(precomputedStats || {});
@@ -591,6 +599,33 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
           )}
         </div>
       </div>
+
+      {/* Selection chips — top-left, just below the toolbar row. One per
+          selected country (not collapsed into a region name, unlike the
+          atop-table "France ×" chip elsewhere) so each can be removed
+          individually without clearing the whole selection. */}
+      {showSelectionChips && selectedCountries.size > 0 && (
+        <div className="flex flex-wrap items-center gap-1 mb-1.5">
+          {[...selectedCountries]
+            .map(code => ({ code, name: ALPHA2_TO_NAME[code] ?? code }))
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map(({ code, name }) => (
+              <span
+                key={code}
+                className="inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-800 text-xs text-zinc-700 dark:text-zinc-300 max-w-full"
+              >
+                <span className="truncate">{name}</span>
+                <button
+                  onClick={(e) => onCountrySelect(code, name, e)}
+                  className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                  title={`Remove ${name}`}
+                >
+                  ✕
+                </button>
+              </span>
+            ))}
+        </div>
+      )}
 
       {/* Hover tooltip (map view only) */}
       {viewMode === "map" && hoveredCountry && (

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -245,13 +245,25 @@ interface WorldMapProps {
   mapSortKey?: MapSortKey;
   mapSortDirection?: "asc" | "desc";
   onMapSortChange?: (key: MapSortKey, direction: "asc" | "desc") => void;
-  // When true, hovering a country also drives onCountrySelect (in addition to
-  // the tooltip), so e.g. the country-view landing page's table updates as
-  // you scan the map rather than requiring a click. Default false — the
-  // other WorldMap usages (Charts row 2's country filter, the CITES map)
-  // still expect click-to-select, since hover already drives their tooltip
-  // and select-on-hover there would fight with normal mouse movement.
+  // When true, hovering a country calls onCountryHover (in addition to the
+  // tooltip), so e.g. the country-view landing page's table can preview a
+  // country as you scan the map rather than requiring a click. Deliberately
+  // separate from onCountrySelect/onClick — hover previews, it doesn't
+  // select, so the caller can keep its real (locked-in) selection state
+  // untouched by mouse movement. Default false — the other WorldMap usages
+  // (Charts row 2's country filter, the CITES map) still expect click-to-
+  // select only.
   selectOnHover?: boolean;
+  // Called with the hovered country's code on mouseenter, and null on
+  // mouseleave, only while selectOnHover is true.
+  onCountryHover?: (countryCode: string | null) => void;
+  // When provided, shows the current selection (one country's name, a
+  // matching region's name, or a comma-joined list) top-left below the
+  // toolbar row, with a ✕ that calls this to clear it — the country-view
+  // landing page's own "which country am I looking at" label, now living on
+  // the map instead of atop the table it drives. Omitted (and thus hidden)
+  // for the other WorldMap usages, which have no such label.
+  onClearSelection?: () => void;
 }
 
 const DEFAULT_CENTER: [number, number] = [10, 10];
@@ -259,7 +271,7 @@ const DEFAULT_ZOOM = 1.0;
 const MIN_ZOOM = 1.0;
 const MAX_ZOOM = 8.0;
 
-function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false }: WorldMapProps) {
+function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover, onClearSelection }: WorldMapProps) {
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
   const [hoveredCountryCode, setHoveredCountryCode] = useState<string | null>(null);
   const [speciesStats, setSpeciesStats] = useState<CountryStats>(precomputedStats || {});
@@ -486,6 +498,20 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
   const hoveredSpeciesStats = hoveredCountryCode ? speciesStats[hoveredCountryCode] : null;
   const hoveredTotalStats = hoveredCountryCode ? precomputedStatsTotal?.[hoveredCountryCode] : null;
   const hoveredOccurrenceStats = hoveredCountryCode && occurrenceStats ? occurrenceStats[hoveredCountryCode] : null;
+
+  // Selection label — one country's name, a matching region's name, or a
+  // comma-joined list for an arbitrary multi-select. Same logic as
+  // TaxaSummary's own countryScopeLabel (the "France ×" chip it still shows
+  // for the non-map-paired country filter elsewhere), just computed here too
+  // now that Country View's version of this label lives on the map itself.
+  const scopeCodes = [...selectedCountries];
+  const scopeLabel = scopeCodes.length === 0 ? "" :
+    scopeCodes.length === 1 ? (ALPHA2_TO_NAME[scopeCodes[0]] ?? scopeCodes[0]) :
+    matchingRegion(selectedCountries) ?? scopeCodes
+      .map((c) => ALPHA2_TO_NAME[c] ?? c)
+      .sort()
+      .join(", ");
+
   return (
     <div className="relative bg-white dark:bg-zinc-900 rounded-xl shadow-sm border border-zinc-200 dark:border-zinc-800 p-3 h-full flex flex-col">
       {/* Header with controls */}
@@ -585,6 +611,23 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
           )}
         </div>
       </div>
+
+      {/* Selection label — top-left, just below the toolbar row. Only when a
+          clear handler's given (Country View's own map instance) and a
+          selection is actually locked in (see selectOnHover/onCountrySelect
+          in RedListView — a plain hover-preview doesn't reach here). */}
+      {onClearSelection && scopeLabel && (
+        <div className="flex items-center gap-1.5 mb-1.5 min-w-0 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+          <span className="truncate" title={scopeLabel}>{scopeLabel}</span>
+          <button
+            onClick={onClearSelection}
+            className="text-sm font-normal text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors shrink-0"
+            title="Clear selected country"
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       {/* Hover tooltip (map view only) */}
       {viewMode === "map" && hoveredCountry && (
@@ -715,16 +758,19 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
                     <Geography
                       key={geo.rsmKey}
                       geography={geo}
-                      onMouseEnter={(event) => {
+                      onMouseEnter={() => {
                         setHoveredCountry(countryName);
                         setHoveredCountryCode(alpha2);
                         if (selectOnHover && alpha2) {
-                          onCountrySelect(alpha2, countryName, event);
+                          onCountryHover?.(alpha2);
                         }
                       }}
                       onMouseLeave={() => {
                         setHoveredCountry(null);
                         setHoveredCountryCode(null);
+                        if (selectOnHover) {
+                          onCountryHover?.(null);
+                        }
                       }}
                       onClick={(event) => {
                         if (alpha2) {

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2222,10 +2222,12 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   // special-case region vs. multi-select here.
   const countryScope = selectedCountries.size > 0 ? [...selectedCountries] : null;
 
-  // Country view's own map/list click — same plain-click-replaces/ctrl-click-
-  // toggles gesture as handleCountrySelect (the normal browsing view's country
-  // filter), just routed through enterCountryDrilldown so the country change
-  // stays atomic with clearing taxa/subgroups (see its own comment).
+  // Country view's own map/list select — fires on hover, not just click (see
+  // WorldMap's selectOnHover), so the table updates as you scan the map. Same
+  // plain-select-replaces/ctrl-click-toggles gesture as handleCountrySelect
+  // (the normal browsing view's country filter), just routed through
+  // enterCountryDrilldown so the country change stays atomic with clearing
+  // taxa/subgroups (see its own comment).
   const handleCountryDrilldown = useCallback(
     (code: string, _name: string, event: React.MouseEvent) => {
       const isMultiSelect = event.metaKey || event.ctrlKey;
@@ -2280,6 +2282,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     <WorldMap
       selectedCountries={selectedCountries}
       onCountrySelect={handleCountryDrilldown}
+      selectOnHover
       precomputedStats={countryLandingStats ?? {}}
       selectedTaxa={selectedTaxa}
       speciesLabel={isNewAssessments ? "# Unassessed" : undefined}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -337,6 +337,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   const {
     layoutMode, setLayoutMode,
     navigateToTaxonSubgroup,
+    exitCountryModeForTaxon,
     returnToLayoutMode,
     enterCountryDrilldown,
     returnToCountryList,
@@ -453,15 +454,20 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   const handleToggleTaxon = useCallback((taxonId: string, event: React.MouseEvent) => {
     const isMulti = event.metaKey || event.ctrlKey;
 
-    // Clicking any taxon row while browsing a country-scoped bare summary
-    // table (Country view, one country selected, no taxon picked yet — see
-    // TaxaSummary's countryMode rendering) exits to the full charts+species-
-    // table view, still scoped to that country (selectedCountries untouched).
-    // Safe to fire alongside the setSelectedTaxa call below without the
-    // fromPopstateRef trick enterCountryDrilldown needs: this is always an
-    // empty->non-empty taxa transition, which RedListView's own "reset filters
-    // on taxa change" effect already no-ops on (see its `prev.size === 0`
-    // guard), so selectedCountries survives untouched either way.
+    // Clicking a specific taxon row while browsing a country-scoped bare
+    // summary table (Country view, one country selected, no taxon picked yet
+    // — see TaxaSummary's countryMode rendering) exits to the full charts+
+    // species-table view, still scoped to that country (selectedCountries
+    // untouched). Atomic (one history push) via exitCountryModeForTaxon, so
+    // a single "back" press cleanly restores the Country View landing page
+    // instead of layoutMode and taxa unwinding as separate history entries.
+    // The "all" row and multi-select (ctrl/cmd-click) cases fall through to
+    // the general path below instead — rarer, and "all" isn't a real taxon
+    // drill-down (see its own branch just below).
+    if (layoutMode === "country" && taxonId !== "all" && !isMulti) {
+      exitCountryModeForTaxon(taxonId);
+      return;
+    }
     if (layoutMode === "country") setLayoutMode(null);
 
     // "all" row behavior:
@@ -509,7 +515,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       setSelectedSubgroups(new Set());
       return new Set([taxonId]);
     });
-  }, [setSelectedTaxa, setSelectedSubgroups, selectedTaxa, selectedSubgroups, isNewAssessments, searchFilter, urlSpecies, clearAllFilters, layoutMode, setLayoutMode]);
+  }, [setSelectedTaxa, setSelectedSubgroups, selectedTaxa, selectedSubgroups, isNewAssessments, searchFilter, urlSpecies, clearAllFilters, layoutMode, setLayoutMode, exitCountryModeForTaxon]);
 
   // Reset all other filters when taxa selection changes
   const prevTaxaRef = useRef(selectedTaxa);
@@ -2246,6 +2252,12 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   const handleCountryDrilldown = useCallback(
     (code: string, _name: string, event: React.MouseEvent) => {
       const isMultiSelect = event.metaKey || event.ctrlKey;
+      // A real click always supersedes any leftover hover preview — without
+      // this, clearing a locked selection back to empty (self-toggle-off)
+      // would leave the table reading a stale hoverPreviewCountry from
+      // before the lock, since countryScope falls back to it whenever
+      // selectedCountries is empty (see its definition above).
+      setHoverPreviewCountry(null);
       enterCountryDrilldown(prev => {
         if (prev.size === 0 && !isMultiSelect) {
           return new Set([code]);
@@ -2297,7 +2309,6 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       onCountrySelect={handleCountryDrilldown}
       selectOnHover={selectedCountries.size === 0}
       onCountryHover={setHoverPreviewCountry}
-      onClearSelection={returnToCountryList}
       precomputedStats={countryLandingStats ?? {}}
       selectedTaxa={selectedTaxa}
       speciesLabel={isNewAssessments ? "# Unassessed" : undefined}
@@ -2325,7 +2336,8 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
         onLayoutModeChange={setLayoutMode}
         countryModeContent={countryModeContent}
         countryScope={countryScope}
-        onClearCountryScope={() => setSelectedCountries(new Set())}
+        onExitCountryScope={() => { returnToCountryList(); setHoverPreviewCountry(null); }}
+        onClearCountryScope={() => { setSelectedCountries(new Set()); setHoverPreviewCountry(null); }}
         onToggleSubgroup={(sgId) => {
           // Clicking a view root ancestor → clear subgroups to show its children.
           // If the currently-selected subgroup is an SSC group, we got here by

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -336,6 +336,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   // Filters synced with URL search params for shareable links
   const {
     layoutMode, setLayoutMode,
+    originLayout,
     navigateToTaxonSubgroup,
     exitCountryModeForTaxon,
     returnToLayoutMode,
@@ -475,6 +476,20 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     // Disabled in new-assessments mode (NE dataset too large for "all")
     if (taxonId === "all") {
       if (selectedTaxa.size > 0 || selectedSubgroups.size > 0) {
+        if (originLayout === "country") {
+          // Came from Country View's landing page via a taxon drill-down
+          // (exitCountryModeForTaxon) — return there instead of the generic
+          // default view. See originLayout's own doc in useFilterParams.ts.
+          // fromPopstateRef first: this taxa non-empty→empty transition is
+          // part of one atomic, fully-specified navigation (countries stays
+          // as-is), not a generic "taxon deselected" — without the ref, the
+          // "reset filters on taxa change" effect below would immediately
+          // clear the very countries this navigation means to keep (see its
+          // own comment on enterCountryDrilldown for the same escape hatch).
+          fromPopstateRef.current = true;
+          returnToLayoutMode("country");
+          return;
+        }
         // Return to landing page
         setSelectedSubgroups(new Set());
         setSelectedTaxa(new Set());
@@ -514,7 +529,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       setSelectedSubgroups(new Set());
       return new Set([taxonId]);
     });
-  }, [setSelectedTaxa, setSelectedSubgroups, selectedTaxa, selectedSubgroups, isNewAssessments, searchFilter, urlSpecies, clearAllFilters, layoutMode, setLayoutMode, exitCountryModeForTaxon]);
+  }, [setSelectedTaxa, setSelectedSubgroups, selectedTaxa, selectedSubgroups, isNewAssessments, searchFilter, urlSpecies, clearAllFilters, layoutMode, setLayoutMode, exitCountryModeForTaxon, originLayout, returnToLayoutMode, fromPopstateRef]);
 
   // Reset all other filters when taxa selection changes
   const prevTaxaRef = useRef(selectedTaxa);
@@ -2309,6 +2324,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       selectOnHover={selectedCountries.size === 0}
       onCountryHover={setHoverPreviewCountry}
       showSelectionChips
+      onClearAllCountries={() => { enterCountryDrilldown(new Set()); setHoverPreviewCountry(null); }}
       precomputedStats={countryLandingStats ?? {}}
       selectedTaxa={selectedTaxa}
       speciesLabel={isNewAssessments ? "# Unassessed" : undefined}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2337,12 +2337,11 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     />
   );
 
-  // Selection chips shown above BOTH the map and the table (see
-  // countryPillsContent's own doc in TaxaSummary.tsx) — living outside
-  // either column means neither one resizes as chips are added/removed/
-  // hovered. One chip per selected country (not collapsed into a region
-  // name, unlike the atop-table "France ×" chip elsewhere), each
-  // individually removable, plus "Clear all" once there's more than one.
+  // Selection chips shown at the top-left of the table's own column (see
+  // countryPillsContent's own doc in TaxaSummary.tsx). One chip per
+  // selected country (not collapsed into a region name, unlike the
+  // atop-table "France ×" chip elsewhere), each individually removable,
+  // plus "Clear all" once there's more than one.
   // Before anything's locked, hovering shows its own preview chip (dashed,
   // non-removable — there's nothing to remove yet, moving the mouse away
   // already clears it) so the table's live hover-preview has a visual

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2248,6 +2248,32 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   // selected" (see handleCountryDrilldown/selectOnHover).
   const [hoverPreviewCountry, setHoverPreviewCountry] = useState<string | null>(null);
 
+  // Measures the actual rendered height of the pills row below (it wraps to
+  // multiple lines once enough countries are selected, or long names push
+  // it past one line) so WorldMap's matching top spacer — see
+  // countryModeContent's topSpacerHeight — can reserve exactly that much,
+  // not a fixed guess. A fixed guess only matched the common 1-pill case;
+  // once pills wrapped to two lines, the table's column grew past what the
+  // map's spacer accounted for, and the paired grid's align-items: stretch
+  // inflated the map's card to match without its (fixed-projection-scale)
+  // content growing to fill it — the same gap-under-the-map problem this
+  // whole spacer exists to avoid, just reappearing at the wrap threshold.
+  // ResizeObserver (not just a selection-keyed effect) so a pure window-
+  // resize reflow — more/fewer pills fitting per line at the same
+  // selection — is caught too.
+  const pillsRef = useRef<HTMLDivElement>(null);
+  const [pillsHeight, setPillsHeight] = useState(34);
+  useEffect(() => {
+    const el = pillsRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const height = entries[0]?.contentRect.height;
+      if (height != null) setPillsHeight(Math.max(34, Math.ceil(height)));
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   const countryScope = selectedCountries.size > 0 ? [...selectedCountries]
     : hoverPreviewCountry ? [hoverPreviewCountry]
     : null;
@@ -2323,7 +2349,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       onCountrySelect={handleCountryDrilldown}
       selectOnHover={selectedCountries.size === 0}
       onCountryHover={setHoverPreviewCountry}
-      showTopSpacer
+      topSpacerHeight={pillsHeight}
       precomputedStats={countryLandingStats ?? {}}
       selectedTaxa={selectedTaxa}
       speciesLabel={isNewAssessments ? "# Unassessed" : undefined}
@@ -2338,54 +2364,62 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     />
   );
 
-  // Selection chips shown in normal flow above the table (see
-  // countryPillsContent's own doc in TaxaSummary.tsx — WorldMap reserves
-  // matching blank space via showTopSpacer so the map's card doesn't need
-  // to stretch past its own natural height to match). One chip per
-  // selected country (not collapsed into a region name, unlike the
-  // atop-table "France ×" chip elsewhere), each individually removable,
-  // plus "Clear all" once there's more than one.
+  // Selection chips shown in normal flow above the table. Wrapped in its
+  // own min-h-[34px] div with pillsRef attached — that's the box
+  // ResizeObserver measures above to drive WorldMap's topSpacerHeight, so
+  // the map's matching blank spacer always reserves exactly this box's
+  // real height (min 34px, taller once chips wrap to a second line) rather
+  // than a fixed guess that only held for the common 1-pill case. The
+  // wrapper renders unconditionally (even with nothing to show) so the
+  // measurement is always live; only the actual chip row inside is
+  // conditional. One chip per selected country (not collapsed into a
+  // region name, unlike the atop-table "France ×" chip elsewhere), each
+  // individually removable, plus "Clear all" once there's more than one.
   // Before anything's locked, hovering shows its own preview chip (dashed,
   // non-removable — there's nothing to remove yet, moving the mouse away
   // already clears it) so the table's live hover-preview has a visual
   // anchor. Reuses handleCountryDrilldown for removal — clicking a chip's ✕
   // for a country that's already selected always toggles it off, whichever
   // branch handleCountryDrilldown takes.
-  const countryPillsContent = (selectedCountries.size > 0 || hoverPreviewCountry) && (
-    <div className="flex flex-wrap items-center gap-1.5">
-      {selectedCountries.size > 0 ? (
-        <>
-          {[...selectedCountries]
-            .map(code => ({ code, name: ALPHA2_TO_NAME[code] ?? code }))
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map(({ code, name }) => (
-              <span
-                key={code}
-                className="inline-flex items-center gap-1.5 pl-3 pr-1.5 py-1 rounded-full bg-zinc-100 dark:bg-zinc-800 text-sm text-zinc-700 dark:text-zinc-300 max-w-full"
-              >
-                <span className="truncate">{name}</span>
+  const countryPillsContent = (
+    <div ref={pillsRef} className="min-h-[34px] mb-1.5">
+      {(selectedCountries.size > 0 || hoverPreviewCountry) && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {selectedCountries.size > 0 ? (
+            <>
+              {[...selectedCountries]
+                .map(code => ({ code, name: ALPHA2_TO_NAME[code] ?? code }))
+                .sort((a, b) => a.name.localeCompare(b.name))
+                .map(({ code, name }) => (
+                  <span
+                    key={code}
+                    className="inline-flex items-center gap-1.5 pl-3 pr-1.5 py-1 rounded-full bg-zinc-100 dark:bg-zinc-800 text-sm text-zinc-700 dark:text-zinc-300 max-w-full"
+                  >
+                    <span className="truncate">{name}</span>
+                    <button
+                      onClick={(e) => handleCountryDrilldown(code, name, e)}
+                      className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                      title={`Remove ${name}`}
+                    >
+                      ✕
+                    </button>
+                  </span>
+                ))}
+              {selectedCountries.size > 1 && (
                 <button
-                  onClick={(e) => handleCountryDrilldown(code, name, e)}
-                  className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                  title={`Remove ${name}`}
+                  onClick={() => { enterCountryDrilldown(new Set()); setHoverPreviewCountry(null); }}
+                  className="text-sm text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors"
                 >
-                  ✕
+                  Clear all
                 </button>
-              </span>
-            ))}
-          {selectedCountries.size > 1 && (
-            <button
-              onClick={() => { enterCountryDrilldown(new Set()); setHoverPreviewCountry(null); }}
-              className="text-sm text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors"
-            >
-              Clear all
-            </button>
+              )}
+            </>
+          ) : (
+            <span className="inline-flex items-center pl-3 pr-3 py-1 rounded-full bg-white dark:bg-zinc-800 border border-dashed border-zinc-300 dark:border-zinc-600 text-sm text-zinc-500 dark:text-zinc-400 max-w-full">
+              <span className="truncate">{ALPHA2_TO_NAME[hoverPreviewCountry!] ?? hoverPreviewCountry}</span>
+            </span>
           )}
-        </>
-      ) : (
-        <span className="inline-flex items-center pl-3 pr-3 py-1 rounded-full bg-white dark:bg-zinc-800 border border-dashed border-zinc-300 dark:border-zinc-600 text-sm text-zinc-500 dark:text-zinc-400 max-w-full">
-          <span className="truncate">{ALPHA2_TO_NAME[hoverPreviewCountry!] ?? hoverPreviewCountry}</span>
-        </span>
+        </div>
       )}
     </div>
   );

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2323,8 +2323,6 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       onCountrySelect={handleCountryDrilldown}
       selectOnHover={selectedCountries.size === 0}
       onCountryHover={setHoverPreviewCountry}
-      showSelectionChips
-      onClearAllCountries={() => { enterCountryDrilldown(new Set()); setHoverPreviewCountry(null); }}
       precomputedStats={countryLandingStats ?? {}}
       selectedTaxa={selectedTaxa}
       speciesLabel={isNewAssessments ? "# Unassessed" : undefined}
@@ -2339,6 +2337,57 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     />
   );
 
+  // Selection chips shown above BOTH the map and the table (see
+  // countryPillsContent's own doc in TaxaSummary.tsx) — living outside
+  // either column means neither one resizes as chips are added/removed/
+  // hovered. One chip per selected country (not collapsed into a region
+  // name, unlike the atop-table "France ×" chip elsewhere), each
+  // individually removable, plus "Clear all" once there's more than one.
+  // Before anything's locked, hovering shows its own preview chip (dashed,
+  // non-removable — there's nothing to remove yet, moving the mouse away
+  // already clears it) so the table's live hover-preview has a visual
+  // anchor. Reuses handleCountryDrilldown for removal — clicking a chip's ✕
+  // for a country that's already selected always toggles it off, whichever
+  // branch handleCountryDrilldown takes.
+  const countryPillsContent = (selectedCountries.size > 0 || hoverPreviewCountry) && (
+    <div className="flex flex-wrap items-center gap-1">
+      {selectedCountries.size > 0 ? (
+        <>
+          {[...selectedCountries]
+            .map(code => ({ code, name: ALPHA2_TO_NAME[code] ?? code }))
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map(({ code, name }) => (
+              <span
+                key={code}
+                className="inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-800 text-xs text-zinc-700 dark:text-zinc-300 max-w-full"
+              >
+                <span className="truncate">{name}</span>
+                <button
+                  onClick={(e) => handleCountryDrilldown(code, name, e)}
+                  className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                  title={`Remove ${name}`}
+                >
+                  ✕
+                </button>
+              </span>
+            ))}
+          {selectedCountries.size > 1 && (
+            <button
+              onClick={() => { enterCountryDrilldown(new Set()); setHoverPreviewCountry(null); }}
+              className="text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors"
+            >
+              Clear all
+            </button>
+          )}
+        </>
+      ) : (
+        <span className="inline-flex items-center pl-2 pr-2 py-0.5 rounded-full bg-white dark:bg-zinc-800 border border-dashed border-zinc-300 dark:border-zinc-600 text-xs text-zinc-500 dark:text-zinc-400 max-w-full">
+          <span className="truncate">{ALPHA2_TO_NAME[hoverPreviewCountry!] ?? hoverPreviewCountry}</span>
+        </span>
+      )}
+    </div>
+  );
+
   return (
     <div className="space-y-4 min-w-0">
       {/* Always show Taxa Summary table */}
@@ -2351,6 +2400,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
         layoutMode={layoutMode}
         onLayoutModeChange={setLayoutMode}
         countryModeContent={countryModeContent}
+        countryPillsContent={countryPillsContent}
         countryScope={countryScope}
         onClearCountryScope={() => { setSelectedCountries(new Set()); setHoverPreviewCountry(null); }}
         onToggleSubgroup={(sgId) => {

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2220,27 +2220,40 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   // each species once regardless of how many of these codes it matches (see
   // country-taxa-summary-duckdb.ts's countriesWhere), so there's no reason to
   // special-case region vs. multi-select here.
-  const countryScope = selectedCountries.size > 0 ? [...selectedCountries] : null;
+  // Hover preview — separate from selectedCountries (the real, locked
+  // selection) so scanning the map with the mouse never itself writes to
+  // URL-synced state. Only consulted as a countryScope fallback below when
+  // nothing's actually locked yet; once selectedCountries is non-empty this
+  // is ignored entirely, matching "hover only works if no country is
+  // selected" (see handleCountryDrilldown/selectOnHover).
+  const [hoverPreviewCountry, setHoverPreviewCountry] = useState<string | null>(null);
 
-  // Country view's own map/list select — fires on hover, not just click (see
-  // WorldMap's selectOnHover), so the table updates as you scan the map. Same
-  // plain-select-replaces/ctrl-click-toggles gesture as handleCountrySelect
-  // (the normal browsing view's country filter), just routed through
-  // enterCountryDrilldown so the country change stays atomic with clearing
-  // taxa/subgroups (see its own comment).
+  const countryScope = selectedCountries.size > 0 ? [...selectedCountries]
+    : hoverPreviewCountry ? [hoverPreviewCountry]
+    : null;
+
+  // Country view's own map/list select. Before anything's picked, hovering
+  // previews the table (see WorldMap's selectOnHover, gated below on
+  // selectedCountries.size === 0 so it stops once a country's locked in).
+  // The first click locks in a single country and switches off hover; every
+  // click after that toggles a country in/out of the selection, so you can
+  // build up a multi-select by clicking (no ctrl/cmd needed) — clicking the
+  // already-sole-selected country again clears back to the empty/hover state.
+  // ctrl/cmd-click still toggles directly even before anything's locked, for
+  // building a multi-select from scratch without an initial single pick.
+  // Routed through enterCountryDrilldown so the country change stays atomic
+  // with clearing taxa/subgroups (see its own comment).
   const handleCountryDrilldown = useCallback(
     (code: string, _name: string, event: React.MouseEvent) => {
       const isMultiSelect = event.metaKey || event.ctrlKey;
       enterCountryDrilldown(prev => {
-        if (isMultiSelect) {
-          const next = new Set(prev);
-          if (next.has(code)) next.delete(code);
-          else next.add(code);
-          return next;
-        } else {
-          if (prev.size === 1 && prev.has(code)) return new Set();
+        if (prev.size === 0 && !isMultiSelect) {
           return new Set([code]);
         }
+        const next = new Set(prev);
+        if (next.has(code)) next.delete(code);
+        else next.add(code);
+        return next;
       });
     },
     [enterCountryDrilldown]
@@ -2282,7 +2295,9 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     <WorldMap
       selectedCountries={selectedCountries}
       onCountrySelect={handleCountryDrilldown}
-      selectOnHover
+      selectOnHover={selectedCountries.size === 0}
+      onCountryHover={setHoverPreviewCountry}
+      onClearSelection={returnToCountryList}
       precomputedStats={countryLandingStats ?? {}}
       selectedTaxa={selectedTaxa}
       speciesLabel={isNewAssessments ? "# Unassessed" : undefined}
@@ -2310,7 +2325,6 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
         onLayoutModeChange={setLayoutMode}
         countryModeContent={countryModeContent}
         countryScope={countryScope}
-        onExitCountryScope={returnToCountryList}
         onClearCountryScope={() => setSelectedCountries(new Set())}
         onToggleSubgroup={(sgId) => {
           // Clicking a view root ancestor → clear subgroups to show its children.

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2323,6 +2323,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       onCountrySelect={handleCountryDrilldown}
       selectOnHover={selectedCountries.size === 0}
       onCountryHover={setHoverPreviewCountry}
+      showTopSpacer
       precomputedStats={countryLandingStats ?? {}}
       selectedTaxa={selectedTaxa}
       speciesLabel={isNewAssessments ? "# Unassessed" : undefined}
@@ -2337,15 +2338,13 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     />
   );
 
-  // Selection chips floated over the top-left of the table's own column
-  // (see countryPillsContent's own doc in TaxaSummary.tsx) — the wrapper
-  // there is pointer-events-none (floating shouldn't block clicks on the
-  // table underneath), so every actual chip/button here needs its own
-  // pointer-events-auto to stay clickable, plus a shadow so it reads as
-  // sitting on top of real table rows now rather than blank map space. One
-  // chip per selected country (not collapsed into a region name, unlike
-  // the atop-table "France ×" chip elsewhere), each individually
-  // removable, plus "Clear all" once there's more than one.
+  // Selection chips shown in normal flow above the table (see
+  // countryPillsContent's own doc in TaxaSummary.tsx — WorldMap reserves
+  // matching blank space via showTopSpacer so the map's card doesn't need
+  // to stretch past its own natural height to match). One chip per
+  // selected country (not collapsed into a region name, unlike the
+  // atop-table "France ×" chip elsewhere), each individually removable,
+  // plus "Clear all" once there's more than one.
   // Before anything's locked, hovering shows its own preview chip (dashed,
   // non-removable — there's nothing to remove yet, moving the mouse away
   // already clears it) so the table's live hover-preview has a visual
@@ -2353,7 +2352,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   // for a country that's already selected always toggles it off, whichever
   // branch handleCountryDrilldown takes.
   const countryPillsContent = (selectedCountries.size > 0 || hoverPreviewCountry) && (
-    <div className="flex flex-wrap items-center gap-1.5 max-w-full">
+    <div className="flex flex-wrap items-center gap-1.5">
       {selectedCountries.size > 0 ? (
         <>
           {[...selectedCountries]
@@ -2362,7 +2361,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
             .map(({ code, name }) => (
               <span
                 key={code}
-                className="pointer-events-auto inline-flex items-center gap-1.5 pl-3 pr-1.5 py-1 rounded-full bg-zinc-100 dark:bg-zinc-800 shadow-sm text-sm text-zinc-700 dark:text-zinc-300 max-w-full"
+                className="inline-flex items-center gap-1.5 pl-3 pr-1.5 py-1 rounded-full bg-zinc-100 dark:bg-zinc-800 text-sm text-zinc-700 dark:text-zinc-300 max-w-full"
               >
                 <span className="truncate">{name}</span>
                 <button
@@ -2377,14 +2376,14 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
           {selectedCountries.size > 1 && (
             <button
               onClick={() => { enterCountryDrilldown(new Set()); setHoverPreviewCountry(null); }}
-              className="pointer-events-auto text-sm text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors bg-white/80 dark:bg-zinc-900/80 rounded px-1"
+              className="text-sm text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors"
             >
               Clear all
             </button>
           )}
         </>
       ) : (
-        <span className="pointer-events-none inline-flex items-center pl-3 pr-3 py-1 rounded-full bg-white dark:bg-zinc-800 border border-dashed border-zinc-300 dark:border-zinc-600 shadow-sm text-sm text-zinc-500 dark:text-zinc-400 max-w-full">
+        <span className="inline-flex items-center pl-3 pr-3 py-1 rounded-full bg-white dark:bg-zinc-800 border border-dashed border-zinc-300 dark:border-zinc-600 text-sm text-zinc-500 dark:text-zinc-400 max-w-full">
           <span className="truncate">{ALPHA2_TO_NAME[hoverPreviewCountry!] ?? hoverPreviewCountry}</span>
         </span>
       )}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -340,7 +340,6 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     exitCountryModeForTaxon,
     returnToLayoutMode,
     enterCountryDrilldown,
-    returnToCountryList,
     selectedTaxa, setSelectedTaxa,
     selectedSubgroups, setSelectedSubgroups,
     selectedCategories, setSelectedCategories,
@@ -2309,6 +2308,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       onCountrySelect={handleCountryDrilldown}
       selectOnHover={selectedCountries.size === 0}
       onCountryHover={setHoverPreviewCountry}
+      showSelectionChips
       precomputedStats={countryLandingStats ?? {}}
       selectedTaxa={selectedTaxa}
       speciesLabel={isNewAssessments ? "# Unassessed" : undefined}
@@ -2336,7 +2336,6 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
         onLayoutModeChange={setLayoutMode}
         countryModeContent={countryModeContent}
         countryScope={countryScope}
-        onExitCountryScope={() => { returnToCountryList(); setHoverPreviewCountry(null); }}
         onClearCountryScope={() => { setSelectedCountries(new Set()); setHoverPreviewCountry(null); }}
         onToggleSubgroup={(sgId) => {
           // Clicking a view root ancestor → clear subgroups to show its children.

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2350,7 +2350,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   // for a country that's already selected always toggles it off, whichever
   // branch handleCountryDrilldown takes.
   const countryPillsContent = (selectedCountries.size > 0 || hoverPreviewCountry) && (
-    <div className="flex flex-wrap items-center gap-1">
+    <div className="flex flex-wrap items-center gap-1.5">
       {selectedCountries.size > 0 ? (
         <>
           {[...selectedCountries]
@@ -2359,7 +2359,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
             .map(({ code, name }) => (
               <span
                 key={code}
-                className="inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full bg-zinc-100 dark:bg-zinc-800 text-xs text-zinc-700 dark:text-zinc-300 max-w-full"
+                className="inline-flex items-center gap-1.5 pl-3 pr-1.5 py-1 rounded-full bg-zinc-100 dark:bg-zinc-800 text-sm text-zinc-700 dark:text-zinc-300 max-w-full"
               >
                 <span className="truncate">{name}</span>
                 <button
@@ -2374,14 +2374,14 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
           {selectedCountries.size > 1 && (
             <button
               onClick={() => { enterCountryDrilldown(new Set()); setHoverPreviewCountry(null); }}
-              className="text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors"
+              className="text-sm text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors"
             >
               Clear all
             </button>
           )}
         </>
       ) : (
-        <span className="inline-flex items-center pl-2 pr-2 py-0.5 rounded-full bg-white dark:bg-zinc-800 border border-dashed border-zinc-300 dark:border-zinc-600 text-xs text-zinc-500 dark:text-zinc-400 max-w-full">
+        <span className="inline-flex items-center pl-3 pr-3 py-1 rounded-full bg-white dark:bg-zinc-800 border border-dashed border-zinc-300 dark:border-zinc-600 text-sm text-zinc-500 dark:text-zinc-400 max-w-full">
           <span className="truncate">{ALPHA2_TO_NAME[hoverPreviewCountry!] ?? hoverPreviewCountry}</span>
         </span>
       )}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2337,11 +2337,15 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     />
   );
 
-  // Selection chips shown at the top-left of the table's own column (see
-  // countryPillsContent's own doc in TaxaSummary.tsx). One chip per
-  // selected country (not collapsed into a region name, unlike the
-  // atop-table "France ×" chip elsewhere), each individually removable,
-  // plus "Clear all" once there's more than one.
+  // Selection chips floated over the top-left of the table's own column
+  // (see countryPillsContent's own doc in TaxaSummary.tsx) — the wrapper
+  // there is pointer-events-none (floating shouldn't block clicks on the
+  // table underneath), so every actual chip/button here needs its own
+  // pointer-events-auto to stay clickable, plus a shadow so it reads as
+  // sitting on top of real table rows now rather than blank map space. One
+  // chip per selected country (not collapsed into a region name, unlike
+  // the atop-table "France ×" chip elsewhere), each individually
+  // removable, plus "Clear all" once there's more than one.
   // Before anything's locked, hovering shows its own preview chip (dashed,
   // non-removable — there's nothing to remove yet, moving the mouse away
   // already clears it) so the table's live hover-preview has a visual
@@ -2349,7 +2353,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   // for a country that's already selected always toggles it off, whichever
   // branch handleCountryDrilldown takes.
   const countryPillsContent = (selectedCountries.size > 0 || hoverPreviewCountry) && (
-    <div className="flex flex-wrap items-center gap-1.5">
+    <div className="flex flex-wrap items-center gap-1.5 max-w-full">
       {selectedCountries.size > 0 ? (
         <>
           {[...selectedCountries]
@@ -2358,7 +2362,7 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
             .map(({ code, name }) => (
               <span
                 key={code}
-                className="inline-flex items-center gap-1.5 pl-3 pr-1.5 py-1 rounded-full bg-zinc-100 dark:bg-zinc-800 text-sm text-zinc-700 dark:text-zinc-300 max-w-full"
+                className="pointer-events-auto inline-flex items-center gap-1.5 pl-3 pr-1.5 py-1 rounded-full bg-zinc-100 dark:bg-zinc-800 shadow-sm text-sm text-zinc-700 dark:text-zinc-300 max-w-full"
               >
                 <span className="truncate">{name}</span>
                 <button
@@ -2373,14 +2377,14 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
           {selectedCountries.size > 1 && (
             <button
               onClick={() => { enterCountryDrilldown(new Set()); setHoverPreviewCountry(null); }}
-              className="text-sm text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors"
+              className="pointer-events-auto text-sm text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors bg-white/80 dark:bg-zinc-900/80 rounded px-1"
             >
               Clear all
             </button>
           )}
         </>
       ) : (
-        <span className="inline-flex items-center pl-3 pr-3 py-1 rounded-full bg-white dark:bg-zinc-800 border border-dashed border-zinc-300 dark:border-zinc-600 text-sm text-zinc-500 dark:text-zinc-400 max-w-full">
+        <span className="pointer-events-none inline-flex items-center pl-3 pr-3 py-1 rounded-full bg-white dark:bg-zinc-800 border border-dashed border-zinc-300 dark:border-zinc-600 shadow-sm text-sm text-zinc-500 dark:text-zinc-400 max-w-full">
           <span className="truncate">{ALPHA2_TO_NAME[hoverPreviewCountry!] ?? hoverPreviewCountry}</span>
         </span>
       )}

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -2495,21 +2495,22 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         (countryStyleColumns, derived from layoutMode — see its definition
         above), whether or not a country is picked yet. The selected
         country's identity shows as removable chips in normal flow above
-        the table (countryPillsContent, built by RedListView), reserved via
-        min-h-[34px] so the space is there even with zero chips (nothing to
-        preview/lock yet) — otherwise the table would itself jump down the
-        moment a hover starts previewing a country. WorldMap gets a
-        showTopSpacer prop that reserves the exact same height at the top
-        of the map's own card (blank — the map has nothing to put there),
-        so both columns' natural heights include the same "extra" amount
-        and grid's align-items: stretch below doesn't need to inflate
-        either one to match the other. Without that matching spacer, only
-        growing the table's column stretched the map's card via align-
-        items: stretch, but WorldMap's choropleth renders at a fixed
-        projection scale — its content didn't grow to fill the extra
-        height, leaving a visible gap under the map. Uses `contents` to
-        no-op this grouping entirely outside country mode, rather than
-        branching (and duplicating) the huge table JSX below per mode. */}
+        the table — countryPillsContent (built by RedListView) already
+        includes its own min-h-[34px] reserving wrapper (with a ref
+        RedListView measures via ResizeObserver), so it's rendered directly
+        here with no extra wrapper of our own. That measured height feeds
+        WorldMap's topSpacerHeight, which reserves the exact same blank
+        height at the top of the map's own card, so both columns' natural
+        heights always include the same "extra" amount and grid's align-
+        items: stretch below doesn't need to inflate either one to match
+        the other. Without a matching (and correctly *measured*, not
+        guessed) spacer, only growing the table's column stretched the
+        map's card via align-items: stretch, but WorldMap's choropleth
+        renders at a fixed projection scale — its content didn't grow to
+        fill the extra height, leaving a visible gap under the map. Uses
+        `contents` to no-op this grouping entirely outside country mode,
+        rather than branching (and duplicating) the huge table JSX below
+        per mode. */}
     <div className={countryMode ? "grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4" : "contents"}>
       {/* No extra wrapper here — WorldMap already renders its own card (bg/border/
           padding); wrapping it again doubled up the box and, since neither div had
@@ -2525,7 +2526,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           columns get cramped or triggering horizontal scroll). */}
       {countryMode && <div>{countryModeContent}</div>}
       <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
-        {countryMode && <div className="min-h-[34px] mb-1.5">{countryPillsContent}</div>}
+        {countryMode && countryPillsContent}
         {/* Country name atop the table — shown whenever a country is scoped
             OUTSIDE Country View (the normal browsing view's "France ×" chip,
             via onClearCountryScope). Country View's own version is the

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -151,13 +151,10 @@ interface Props {
    * scopes this table's own fetches too. One country, a whole region, or an
    * arbitrary multi-select are all just "the current set of codes" here. */
   countryScope?: string[] | null;
-  /** Clears the country selection and re-enters the Country view landing page —
-   * used for the clear button atop the table while layoutMode is "country". */
-  onExitCountryScope?: () => void;
   /** Clears the country selection without changing layoutMode — used for the
-   * same clear button atop the table once a taxon's been clicked and this has
-   * exited to the full view (returning to the Country view landing page from
-   * there would be a surprising jump). */
+   * "France ×" chip atop the table when a country's scoped outside Country
+   * View. Country View's own equivalent lives on the map now (see WorldMap's
+   * country chips), not routed through here. */
   onClearCountryScope?: () => void;
 }
 
@@ -1046,7 +1043,7 @@ function DescribedInfoIcon({ nodeId, source, breakdown }: { nodeId: string; sour
   );
 }
 
-export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryScope, onExitCountryScope, onClearCountryScope }: Props) {
+export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryScope, onClearCountryScope }: Props) {
   const isNewAssessments = viewMode === "new-assessments";
   const [taxa, setTaxa] = useState<TaxonSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -2541,18 +2538,19 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           columns get cramped or triggering horizontal scroll). */}
       {countryMode && <div>{countryModeContent}</div>}
       <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
-        {/* Country name atop the table — shown whenever a country is scoped,
-            in both Country View's landing layout and the full (post-taxon-click)
-            view. The clear button behaves differently per context: in Country
-            View it returns to the country list (onExitCountryScope); in the
-            full view it just drops the country filter and stays put
-            (onClearCountryScope) — same as the "France ×" chip elsewhere. */}
-        {countryScoped && (
+        {/* Country name atop the table — shown whenever a country is scoped
+            OUTSIDE Country View (the normal browsing view's "France ×" chip,
+            via onClearCountryScope). Country View's own version lives on the
+            map itself instead (see WorldMap's country chips) — moving it
+            atop the table there made the zoomed table jump position every
+            time a country got locked/cleared, which read as jarring since
+            the map's own layout doesn't shift the same way. */}
+        {countryScoped && !countryMode && (
           <div className="flex items-center gap-1.5 mb-1.5 min-w-0 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
             <span className="truncate" title={countryScopeLabel}>{countryScopeLabel}</span>
-            {(countryMode ? onExitCountryScope : onClearCountryScope) && (
+            {onClearCountryScope && (
               <button
-                onClick={countryMode ? onExitCountryScope : onClearCountryScope}
+                onClick={onClearCountryScope}
                 className="text-sm font-normal text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors shrink-0"
                 title="Clear selected country"
               >
@@ -2983,26 +2981,33 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           {countryMode ? "Hover a country, or click to lock it and multi-select." : "Click to filter, Cmd/Ctrl+click to multi-select."}
         </span>
         <div className="flex flex-wrap items-center gap-3 pl-3 sm:pl-0">
-          {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed */}
-          <span className="inline-flex items-center gap-1.5">
-            <span className="text-xs text-zinc-400 dark:text-zinc-500">Source for # Described:</span>
-            <span className="inline-flex rounded-md overflow-hidden border border-zinc-300 dark:border-zinc-600 text-[10px] font-semibold" title="Switch # Described Species between IUCN Table 1a estimates and the Catalogue of Life backbone, for the rows with an official IUCN figure — every other row (sub-groups, SSC groups) always shows the CoL-derived count">
-              {(["iucn", "col"] as const).map((src) => (
-                <button
-                  key={src}
-                  onClick={(e) => { e.stopPropagation(); setDescribedSource(src); }}
-                  className={`px-1.5 py-0.5 transition-colors ${
-                    describedSource === src
-                      ? "bg-zinc-700 text-white dark:bg-zinc-200 dark:text-zinc-900"
-                      : "text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-700"
-                  }`}
-                >
-                  {src === "iucn" ? "IUCN" : "CoL"}
-                </button>
-              ))}
-            </span>
-          </span>
-          <span className="text-zinc-300 dark:text-zinc-700">|</span>
+          {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed.
+              Hidden in Country View — its plain 3-column table doesn't show a
+              # Described column at all (see COUNTRY_SCOPED_HIDDEN_COLUMNS), so the
+              toggle would have nothing to actually affect there. */}
+          {!countryMode && (
+            <>
+              <span className="inline-flex items-center gap-1.5">
+                <span className="text-xs text-zinc-400 dark:text-zinc-500">Source for # Described:</span>
+                <span className="inline-flex rounded-md overflow-hidden border border-zinc-300 dark:border-zinc-600 text-[10px] font-semibold" title="Switch # Described Species between IUCN Table 1a estimates and the Catalogue of Life backbone, for the rows with an official IUCN figure — every other row (sub-groups, SSC groups) always shows the CoL-derived count">
+                  {(["iucn", "col"] as const).map((src) => (
+                    <button
+                      key={src}
+                      onClick={(e) => { e.stopPropagation(); setDescribedSource(src); }}
+                      className={`px-1.5 py-0.5 transition-colors ${
+                        describedSource === src
+                          ? "bg-zinc-700 text-white dark:bg-zinc-200 dark:text-zinc-900"
+                          : "text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-700"
+                      }`}
+                    >
+                      {src === "iucn" ? "IUCN" : "CoL"}
+                    </button>
+                  ))}
+                </span>
+              </span>
+              <span className="text-zinc-300 dark:text-zinc-700">|</span>
+            </>
+          )}
           {/* Expand/Collapse all doesn't apply to Country View — its subgroup tree
               stays collapsed by default there regardless (fewer controls, per its
               single-country-focus design). */}

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -2529,10 +2529,15 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         either column specifically so chips changing (locking/clearing/
         hovering, which varies their count and text width) never resizes the
         map or shifts the (zoomed) table's position; both used to happen
-        when the chips lived inside one column or the other. Uses `contents`
-        to no-op this grouping entirely outside country mode, rather than
-        branching (and duplicating) the huge table JSX below per mode. */}
-    {countryMode && <div className="mb-1.5">{countryPillsContent}</div>}
+        when the chips lived inside one column or the other. min-h-[26px]
+        (one pill row's height) reserves that space unconditionally, even
+        with zero chips, so the table/map below don't themselves shift down
+        the moment a hover starts previewing a country — that shift was its
+        own kind of jarring, just one level up from the two this replaced.
+        Uses `contents` to no-op this grouping entirely outside country
+        mode, rather than branching (and duplicating) the huge table JSX
+        below per mode. */}
+    {countryMode && <div className="min-h-[26px] mb-1.5">{countryPillsContent}</div>}
     <div className={countryMode ? "grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4" : "contents"}>
       {/* No extra wrapper here — WorldMap already renders its own card (bg/border/
           padding); wrapping it again doubled up the box and, since neither div had

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -1237,7 +1237,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         <option value="country" disabled={isNewAssessments} title={isNewAssessments ? "Not available for New Assessments — Not Evaluated species have no location data" : undefined}>
           By Country
         </option>
-        <option value="ssc">By SSC Specialist Group</option>
+        <option value="ssc">By SSC Specialist Group (WIP)</option>
         <option value="table1a">Table 1a</option>
       </select>
     </span>
@@ -2520,7 +2520,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
       </div>,
       document.body
     )}
-    {/* Country view: map on the left half, taxa table on the right half.
+    {/* Country view: taxa table on the left half, map on the right half.
         The table always uses the plain 3-column style in this mode
         (countryStyleColumns, derived from layoutMode — see its definition
         above), whether or not a country is picked yet. The selected
@@ -2551,7 +2551,6 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           column (was 2/3 width, now 1/2 — zoom-[.75] keeps everything, fonts
           included, at the same proportions just smaller, rather than letting
           columns get cramped or triggering horizontal scroll). */}
-      {countryMode && <div>{countryModeContent}</div>}
       <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
         {/* Country name atop the table — shown whenever a country is scoped
             OUTSIDE Country View (the normal browsing view's "France ×" chip,
@@ -2982,6 +2981,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
       </table>
         </div>
       </div>
+      {countryMode && <div>{countryModeContent}</div>}
     </div>
     {/* Subtle controls: usage hint + # Described toggle + expand/table controls,
         all landing-only — hidden once a taxon is selected. Gated on perTaxa.length

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -2494,16 +2494,20 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         The table always uses the plain 3-column style in this mode
         (countryStyleColumns, derived from layoutMode — see its definition
         above), whether or not a country is picked yet. The selected
-        country's identity shows as removable chips at the top-left of the
-        table's own column (countryPillsContent, built by RedListView), not
-        spanning the map too. min-h-[34px] (one pill row's height) reserves
-        that space in the table's column unconditionally, even with zero
-        chips, so the table's own total height stays constant as chips are
-        added/removed/hovered — which in turn keeps the map from resizing
-        too, since grid's align-items: stretch matches both columns to
-        whichever's taller. Uses `contents` to no-op this grouping entirely
-        outside country mode, rather than branching (and duplicating) the
-        huge table JSX below per mode. */}
+        country's identity shows as removable chips floated (absolute) over
+        the top-left of the table's own column (countryPillsContent, built
+        by RedListView) — not in normal flow. A normal-flow reservation
+        there was tried first, but WorldMap's choropleth renders at a fixed
+        projection scale (doesn't grow taller to fill its container), so
+        growing the table's column by a pill row's worth of height stretched
+        the map's card to match (via align-items: stretch below) without the
+        map's own content growing to fill it — a visible gap under the map
+        that wasn't there before. Floating the pills instead keeps the
+        table's column at its original natural height, so the grid row (and
+        the map along with it) doesn't grow in the first place. Uses
+        `contents` to no-op this grouping entirely outside country mode,
+        rather than branching (and duplicating) the huge table JSX below per
+        mode. */}
     <div className={countryMode ? "grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4" : "contents"}>
       {/* No extra wrapper here — WorldMap already renders its own card (bg/border/
           padding); wrapping it again doubled up the box and, since neither div had
@@ -2518,12 +2522,14 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           included, at the same proportions just smaller, rather than letting
           columns get cramped or triggering horizontal scroll). */}
       {countryMode && <div>{countryModeContent}</div>}
-      <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
-        {countryMode && <div className="min-h-[34px] mb-1.5">{countryPillsContent}</div>}
+      <div className={countryMode ? "relative min-w-0 flex flex-col h-full" : "contents"}>
+        {countryMode && (
+          <div className="absolute top-2 left-2 z-20 pointer-events-none">{countryPillsContent}</div>
+        )}
         {/* Country name atop the table — shown whenever a country is scoped
             OUTSIDE Country View (the normal browsing view's "France ×" chip,
             via onClearCountryScope). Country View's own version is the
-            countryPillsContent block just above instead. */}
+            floating countryPillsContent block just above instead. */}
         {countryScoped && !countryMode && (
           <div className="flex items-center gap-1.5 mb-1.5 min-w-0 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
             <span className="truncate" title={countryScopeLabel}>{countryScopeLabel}</span>

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
-import { FaInfoCircle, FaExpandAlt, FaCompressAlt, FaChevronRight } from "react-icons/fa";
+import { FaInfoCircle, FaChevronRight } from "react-icons/fa";
 
 import { HiOutlineAdjustmentsHorizontal } from "react-icons/hi2";
 import TaxaIcon from "@/components/TaxaIcon";
@@ -1290,34 +1290,6 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
   }, [taxa, applySource]);
   const perTaxa = useMemo(() => taxa.filter((t) => t.id !== "all").map(t => applySource(t, t.id)), [taxa, applySource]);
 
-  // Expand all expandable taxa
-  const expandAll = useCallback(async () => {
-    const expandableTaxaIds = perTaxa.filter(t => isExpandable(t.id)).map(t => t.id);
-    setExpandedTaxa(new Set(expandableTaxaIds));
-    for (const taxonId of expandableTaxaIds) {
-      if (!subgroupDataRef.current[taxonId] && !loadingSubgroupsRef.current.has(taxonId)) {
-        setLoadingSubgroups((prev) => new Set(prev).add(taxonId));
-        const countryQs = countryKey ? `&country=${encodeURIComponent(countryKey)}` : "";
-        fetch(`/api/redlist/taxa-subgroups?nodeId=${taxonId}${countryQs}`)
-          .then(res => res.ok ? res.json() : null)
-          .then(data => {
-            if (data) setSubgroupData((prev) => ({ ...prev, [taxonId]: data.subgroups }));
-          })
-          .finally(() => {
-            setLoadingSubgroups((prev) => {
-              const next = new Set(prev);
-              next.delete(taxonId);
-              return next;
-            });
-          });
-      }
-    }
-  }, [perTaxa, countryKey]);
-
-  const collapseAll = useCallback(() => {
-    setExpandedTaxa(new Set());
-  }, []);
-
   // Fetch-if-needed, driven by table1aMode rather than a click handler, so it
   // also runs when the mode is entered via URL load or browser back/forward.
   // Uses a ref (not the loading state) to gate the fetch — including the
@@ -1403,8 +1375,6 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     sscFetchStartedRef.current = false;
     setSubgroupData({});
   }, [countryKey]);
-
-  const allExpanded = useMemo(() => perTaxa.filter(t => isExpandable(t.id)).every(t => expandedTaxa.has(t.id)), [perTaxa, expandedTaxa]);
 
   // Collapse all when returning to landing page (no taxa selected)
   useEffect(() => {
@@ -3022,21 +2992,6 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
                   ))}
                 </span>
               </span>
-              <span className="text-zinc-300 dark:text-zinc-700">|</span>
-            </>
-          )}
-          {/* Expand/Collapse all doesn't apply to Country View — its subgroup tree
-              stays collapsed by default there regardless (fewer controls, per its
-              single-country-focus design). */}
-          {!flatMode && !countryMode && (
-            <>
-              <button
-                onClick={allExpanded ? collapseAll : expandAll}
-                className="inline-flex items-center gap-1 text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-              >
-                {allExpanded ? <FaCompressAlt size={9} /> : <FaExpandAlt size={9} />}
-                {allExpanded ? "Collapse all" : "Expand all"}
-              </button>
               <span className="text-zinc-300 dark:text-zinc-700">|</span>
             </>
           )}

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -2490,24 +2490,20 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
       </div>,
       document.body
     )}
-    {/* Country view: taxa table on the left half, map on the right half.
+    {/* Country view: map on the left half, taxa table on the right half.
         The table always uses the plain 3-column style in this mode
         (countryStyleColumns, derived from layoutMode — see its definition
         above), whether or not a country is picked yet. The selected
-        country's identity shows as removable chips above BOTH the table and
-        the map (countryPillsContent, built by RedListView) — living outside
-        either column specifically so chips changing (locking/clearing/
-        hovering, which varies their count and text width) never resizes the
-        map or shifts the (zoomed) table's position; both used to happen
-        when the chips lived inside one column or the other. min-h-[34px]
-        (one pill row's height) reserves that space unconditionally, even
-        with zero chips, so the table/map below don't themselves shift down
-        the moment a hover starts previewing a country — that shift was its
-        own kind of jarring, just one level up from the two this replaced.
-        Uses `contents` to no-op this grouping entirely outside country
-        mode, rather than branching (and duplicating) the huge table JSX
-        below per mode. */}
-    {countryMode && <div className="min-h-[34px] mb-1.5">{countryPillsContent}</div>}
+        country's identity shows as removable chips at the top-left of the
+        table's own column (countryPillsContent, built by RedListView), not
+        spanning the map too. min-h-[34px] (one pill row's height) reserves
+        that space in the table's column unconditionally, even with zero
+        chips, so the table's own total height stays constant as chips are
+        added/removed/hovered — which in turn keeps the map from resizing
+        too, since grid's align-items: stretch matches both columns to
+        whichever's taller. Uses `contents` to no-op this grouping entirely
+        outside country mode, rather than branching (and duplicating) the
+        huge table JSX below per mode. */}
     <div className={countryMode ? "grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4" : "contents"}>
       {/* No extra wrapper here — WorldMap already renders its own card (bg/border/
           padding); wrapping it again doubled up the box and, since neither div had
@@ -2521,16 +2517,13 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           column (was 2/3 width, now 1/2 — zoom-[.75] keeps everything, fonts
           included, at the same proportions just smaller, rather than letting
           columns get cramped or triggering horizontal scroll). */}
+      {countryMode && <div>{countryModeContent}</div>}
       <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
+        {countryMode && <div className="min-h-[34px] mb-1.5">{countryPillsContent}</div>}
         {/* Country name atop the table — shown whenever a country is scoped
             OUTSIDE Country View (the normal browsing view's "France ×" chip,
-            via onClearCountryScope). Country View's own version lives above
-            both the table and the map instead (see countryPillsContent) —
-            moving it strictly atop the table made the zoomed table jump
-            position every time a country got locked/cleared; moving it onto
-            the map instead made the map itself flicker/resize as chips
-            changed size while hovering. Living above both avoids resizing
-            either one. */}
+            via onClearCountryScope). Country View's own version is the
+            countryPillsContent block just above instead. */}
         {countryScoped && !countryMode && (
           <div className="flex items-center gap-1.5 mb-1.5 min-w-0 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
             <span className="truncate" title={countryScopeLabel}>{countryScopeLabel}</span>
@@ -2951,7 +2944,6 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
       </table>
         </div>
       </div>
-      {countryMode && <div>{countryModeContent}</div>}
     </div>
     {/* Subtle controls: usage hint + # Described toggle + expand/table controls,
         all landing-only — hidden once a taxon is selected. Gated on perTaxa.length

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -2957,7 +2957,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
             Country View starts hover-driven, then locks to click+multi-select once a
             country's picked (see handleCountryDrilldown), so it gets its own wording. */}
         <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
-          {countryMode ? "Hover a country, or click to lock it and multi-select." : "Click to filter, Cmd/Ctrl+click to multi-select."}
+          {countryMode ? "Hover over a country, or click to lock it and multi-select." : "Click to filter, Cmd/Ctrl+click to multi-select."}
         </span>
         <div className="flex flex-wrap items-center gap-3 pl-3 sm:pl-0">
           {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed.

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -2494,20 +2494,22 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         The table always uses the plain 3-column style in this mode
         (countryStyleColumns, derived from layoutMode — see its definition
         above), whether or not a country is picked yet. The selected
-        country's identity shows as removable chips floated (absolute) over
-        the top-left of the table's own column (countryPillsContent, built
-        by RedListView) — not in normal flow. A normal-flow reservation
-        there was tried first, but WorldMap's choropleth renders at a fixed
-        projection scale (doesn't grow taller to fill its container), so
-        growing the table's column by a pill row's worth of height stretched
-        the map's card to match (via align-items: stretch below) without the
-        map's own content growing to fill it — a visible gap under the map
-        that wasn't there before. Floating the pills instead keeps the
-        table's column at its original natural height, so the grid row (and
-        the map along with it) doesn't grow in the first place. Uses
-        `contents` to no-op this grouping entirely outside country mode,
-        rather than branching (and duplicating) the huge table JSX below per
-        mode. */}
+        country's identity shows as removable chips in normal flow above
+        the table (countryPillsContent, built by RedListView), reserved via
+        min-h-[34px] so the space is there even with zero chips (nothing to
+        preview/lock yet) — otherwise the table would itself jump down the
+        moment a hover starts previewing a country. WorldMap gets a
+        showTopSpacer prop that reserves the exact same height at the top
+        of the map's own card (blank — the map has nothing to put there),
+        so both columns' natural heights include the same "extra" amount
+        and grid's align-items: stretch below doesn't need to inflate
+        either one to match the other. Without that matching spacer, only
+        growing the table's column stretched the map's card via align-
+        items: stretch, but WorldMap's choropleth renders at a fixed
+        projection scale — its content didn't grow to fill the extra
+        height, leaving a visible gap under the map. Uses `contents` to
+        no-op this grouping entirely outside country mode, rather than
+        branching (and duplicating) the huge table JSX below per mode. */}
     <div className={countryMode ? "grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4" : "contents"}>
       {/* No extra wrapper here — WorldMap already renders its own card (bg/border/
           padding); wrapping it again doubled up the box and, since neither div had
@@ -2522,14 +2524,12 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           included, at the same proportions just smaller, rather than letting
           columns get cramped or triggering horizontal scroll). */}
       {countryMode && <div>{countryModeContent}</div>}
-      <div className={countryMode ? "relative min-w-0 flex flex-col h-full" : "contents"}>
-        {countryMode && (
-          <div className="absolute top-2 left-2 z-20 pointer-events-none">{countryPillsContent}</div>
-        )}
+      <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
+        {countryMode && <div className="min-h-[34px] mb-1.5">{countryPillsContent}</div>}
         {/* Country name atop the table — shown whenever a country is scoped
             OUTSIDE Country View (the normal browsing view's "France ×" chip,
             via onClearCountryScope). Country View's own version is the
-            floating countryPillsContent block just above instead. */}
+            countryPillsContent block just above instead. */}
         {countryScoped && !countryMode && (
           <div className="flex items-center gap-1.5 mb-1.5 min-w-0 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
             <span className="truncate" title={countryScopeLabel}>{countryScopeLabel}</span>

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -78,9 +78,6 @@ const IUCN_SOURCE_URL = "https://nc.iucnredlist.org/redlist/content/attachment_f
 // SSC groups mode — one section per taxon that has an SSC pilot built out.
 // Add an entry here (nodeId, parentTaxon, title, catch-all id) when a new
 // taxon's SSC groups are added.
-// Named groups shown per section before collapsing behind "Show all" — the
-// catch-all row is never counted against this and always stays visible.
-const SSC_SECTION_COLLAPSE_SIZE = 5;
 const SSC_SECTIONS: { nodeId: string; parentTaxon: string; title: string; catchAllId: string }[] = [
   { nodeId: "ssc-groups", parentTaxon: "mammals", title: "MAMMAL SPECIALIST GROUPS", catchAllId: "ssc-other-mammals" },
   { nodeId: "ssc-reptile-groups", parentTaxon: "reptiles", title: "REPTILE SPECIALIST GROUPS", catchAllId: "ssc-snake-lizard-rla" },
@@ -154,10 +151,13 @@ interface Props {
    * scopes this table's own fetches too. One country, a whole region, or an
    * arbitrary multi-select are all just "the current set of codes" here. */
   countryScope?: string[] | null;
+  /** Clears the country selection and re-enters the Country view landing page —
+   * used for the clear button atop the table while layoutMode is "country". */
+  onExitCountryScope?: () => void;
   /** Clears the country selection without changing layoutMode — used for the
-   * "France ×" chip atop the table when a country's scoped outside Country
-   * View. Country View's own equivalent clear button lives on the map now
-   * (WorldMap's onClearSelection), not routed through here. */
+   * same clear button atop the table once a taxon's been clicked and this has
+   * exited to the full view (returning to the Country view landing page from
+   * there would be a surprising jump). */
   onClearCountryScope?: () => void;
 }
 
@@ -1046,7 +1046,7 @@ function DescribedInfoIcon({ nodeId, source, breakdown }: { nodeId: string; sour
   );
 }
 
-export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryScope, onClearCountryScope }: Props) {
+export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryScope, onExitCountryScope, onClearCountryScope }: Props) {
   const isNewAssessments = viewMode === "new-assessments";
   const [taxa, setTaxa] = useState<TaxonSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -1336,19 +1336,6 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
   // the precomputed SSC wrapper nodes' children instead of the top-level
   // Table 1a CSV groups (see SSC_SECTIONS above).
   const [sscData, setSscData] = useState<Table1aSectionData[] | null>(null);
-  // Which SSC sections (keyed by title) are expanded past the first
-  // SSC_SECTION_COLLAPSE_SIZE rows — collapsed by default so a taxon with 36
-  // groups (mammals) doesn't dwarf the page; the catch-all row always shows
-  // regardless of this state (see the render loop below).
-  const [expandedSscSections, setExpandedSscSections] = useState<Set<string>>(new Set());
-  const toggleSscSection = useCallback((title: string) => {
-    setExpandedSscSections((prev) => {
-      const next = new Set(prev);
-      if (next.has(title)) next.delete(title);
-      else next.add(title);
-      return next;
-    });
-  }, []);
   const [sscLoading, setSscLoading] = useState(false);
   const sscFetchStartedRef = useRef(false);
 
@@ -2554,18 +2541,18 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           columns get cramped or triggering horizontal scroll). */}
       {countryMode && <div>{countryModeContent}</div>}
       <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
-        {/* Country name atop the table — shown whenever a country is scoped
-            OUTSIDE Country View (the normal browsing view's "France ×" chip,
-            via onClearCountryScope). Country View's own version of this label
-            now lives on the map instead (see WorldMap's onClearSelection/
-            scopeLabel) — it drives the same table from the other side of the
-            grid, so showing it twice was redundant. */}
-        {countryScoped && !countryMode && (
+        {/* Country name atop the table — shown whenever a country is scoped,
+            in both Country View's landing layout and the full (post-taxon-click)
+            view. The clear button behaves differently per context: in Country
+            View it returns to the country list (onExitCountryScope); in the
+            full view it just drops the country filter and stays put
+            (onClearCountryScope) — same as the "France ×" chip elsewhere. */}
+        {countryScoped && (
           <div className="flex items-center gap-1.5 mb-1.5 min-w-0 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
             <span className="truncate" title={countryScopeLabel}>{countryScopeLabel}</span>
-            {onClearCountryScope && (
+            {(countryMode ? onExitCountryScope : onClearCountryScope) && (
               <button
-                onClick={onClearCountryScope}
+                onClick={countryMode ? onExitCountryScope : onClearCountryScope}
                 className="text-sm font-normal text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors shrink-0"
                 title="Clear selected country"
               >
@@ -2687,20 +2674,15 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
                           <td className={flexTdClasses}>{renderBreakdownBar(subByCategory)}</td>
                         )}
                       </tr>
-                      {/* Section rows — collapsed to SSC_SECTION_COLLAPSE_SIZE named
-                          groups by default in SSC mode (a 36-row mammal section would
-                          otherwise dwarf every other taxon); the catch-all row is
-                          pulled out of the collapse/expand entirely and always shown,
-                          since it's usually the largest, most load-bearing row. Table
-                          1a mode has no catch-all concept (section.catchAllId is
-                          undefined there), so it always renders every row. */}
+                      {/* Section rows — all named groups always shown; the catch-all
+                          row is pulled out and rendered last, since it's usually the
+                          largest, most load-bearing row. Table 1a mode has no
+                          catch-all concept (section.catchAllId is undefined there),
+                          so it always renders every row too. */}
                       {(() => {
                         const isSscSection = sscMode && section.catchAllId != null;
                         const catchAllRow = isSscSection ? rows.find(r => r.group === section.catchAllId) : undefined;
                         const namedRows = catchAllRow ? rows.filter(r => r.group !== section.catchAllId) : rows;
-                        const isExpanded = expandedSscSections.has(section.title);
-                        const visibleNamedRows = isSscSection && !isExpanded ? namedRows.slice(0, SSC_SECTION_COLLAPSE_SIZE) : namedRows;
-                        const hiddenCount = namedRows.length - visibleNamedRows.length;
                         const renderGroupRow = (row: (typeof rows)[number]) => (
                         <tr
                           key={row.group}
@@ -2835,29 +2817,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
                         );
                         return (
                           <>
-                            {visibleNamedRows.map(renderGroupRow)}
-                            {isSscSection && hiddenCount > 0 && (
-                              <tr
-                                className="hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer"
-                                onClick={() => toggleSscSection(section.title)}
-                              >
-                                <td colSpan={visibleColCount} className={`${cellPad} text-center`}>
-                                  <span className="text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors">
-                                    Show all {namedRows.length} groups ({hiddenCount} more)
-                                  </span>
-                                </td>
-                              </tr>
-                            )}
-                            {isSscSection && isExpanded && namedRows.length > SSC_SECTION_COLLAPSE_SIZE && (
-                              <tr
-                                className="hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer"
-                                onClick={() => toggleSscSection(section.title)}
-                              >
-                                <td colSpan={visibleColCount} className={`${cellPad} text-center`}>
-                                  <span className="text-xs text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors">Show less</span>
-                                </td>
-                              </tr>
-                            )}
+                            {namedRows.map(renderGroupRow)}
                             {catchAllRow && renderGroupRow(catchAllRow)}
                           </>
                         );

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -1233,11 +1233,11 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         }}
         className="text-xs bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md px-1.5 py-0.5 text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
       >
-        <option value="taxonomic">Standard view</option>
-        <option value="table1a">Table 1a view</option>
-        <option value="ssc">SSC group view</option>
+        <option value="taxonomic">By Taxon</option>
+        <option value="table1a">Table 1a</option>
+        <option value="ssc">By SSC Specialist Group</option>
         <option value="country" disabled={isNewAssessments} title={isNewAssessments ? "Not available for New Assessments — Not Evaluated species have no location data" : undefined}>
-          Country view
+          By Country
         </option>
       </select>
     </span>

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -154,13 +154,10 @@ interface Props {
    * scopes this table's own fetches too. One country, a whole region, or an
    * arbitrary multi-select are all just "the current set of codes" here. */
   countryScope?: string[] | null;
-  /** Clears the country selection and re-enters the Country view landing page —
-   * used for the clear button atop the table while layoutMode is "country". */
-  onExitCountryScope?: () => void;
   /** Clears the country selection without changing layoutMode — used for the
-   * same clear button atop the table once a taxon's been clicked and this has
-   * exited to the full view (returning to the Country view landing page from
-   * there would be a surprising jump). */
+   * "France ×" chip atop the table when a country's scoped outside Country
+   * View. Country View's own equivalent clear button lives on the map now
+   * (WorldMap's onClearSelection), not routed through here. */
   onClearCountryScope?: () => void;
 }
 
@@ -1049,7 +1046,7 @@ function DescribedInfoIcon({ nodeId, source, breakdown }: { nodeId: string; sour
   );
 }
 
-export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryScope, onExitCountryScope, onClearCountryScope }: Props) {
+export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryScope, onClearCountryScope }: Props) {
   const isNewAssessments = viewMode === "new-assessments";
   const [taxa, setTaxa] = useState<TaxonSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -2533,14 +2530,15 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
       </div>,
       document.body
     )}
-    {/* Country view: taxa table on the left half, map on the right half.
+    {/* Country view: map on the left half, taxa table on the right half.
         The table always uses the plain 3-column style in this mode
         (countryStyleColumns, derived from layoutMode — see its definition
         above), whether or not a country is picked yet. The selected country's
-        identity shows atop the table itself (below) in both this landing mode
-        and, once a taxon's clicked, the full view too. Uses `contents` to
-        no-op this grouping entirely outside country mode, rather than
-        branching (and duplicating) the huge table JSX below per mode. */}
+        identity shows atop the map itself now (WorldMap's onClearSelection/
+        scopeLabel), not atop the table — see the comment on the other, non-
+        country-mode instance of that label below. Uses `contents` to no-op
+        this grouping entirely outside country mode, rather than branching
+        (and duplicating) the huge table JSX below per mode. */}
     <div className={countryMode ? "grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4" : "contents"}>
       {/* No extra wrapper here — WorldMap already renders its own card (bg/border/
           padding); wrapping it again doubled up the box and, since neither div had
@@ -2554,19 +2552,20 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           column (was 2/3 width, now 1/2 — zoom-[.75] keeps everything, fonts
           included, at the same proportions just smaller, rather than letting
           columns get cramped or triggering horizontal scroll). */}
+      {countryMode && <div>{countryModeContent}</div>}
       <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
-        {/* Country name atop the table — shown whenever a country is scoped,
-            in both Country View's landing layout and the full (post-taxon-click)
-            view. The clear button behaves differently per context: in Country
-            View it returns to the country list (onExitCountryScope); in the
-            full view it just drops the country filter and stays put
-            (onClearCountryScope) — same as the "France ×" chip elsewhere. */}
-        {countryScoped && (
+        {/* Country name atop the table — shown whenever a country is scoped
+            OUTSIDE Country View (the normal browsing view's "France ×" chip,
+            via onClearCountryScope). Country View's own version of this label
+            now lives on the map instead (see WorldMap's onClearSelection/
+            scopeLabel) — it drives the same table from the other side of the
+            grid, so showing it twice was redundant. */}
+        {countryScoped && !countryMode && (
           <div className="flex items-center gap-1.5 mb-1.5 min-w-0 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
             <span className="truncate" title={countryScopeLabel}>{countryScopeLabel}</span>
-            {(countryMode ? onExitCountryScope : onClearCountryScope) && (
+            {onClearCountryScope && (
               <button
-                onClick={countryMode ? onExitCountryScope : onClearCountryScope}
+                onClick={onClearCountryScope}
                 className="text-sm font-normal text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors shrink-0"
                 title="Clear selected country"
               >
@@ -3008,7 +3007,6 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
       </table>
         </div>
       </div>
-      {countryMode && <div>{countryModeContent}</div>}
     </div>
     {/* Subtle controls: usage hint + # Described toggle + expand/table controls,
         all landing-only — hidden once a taxon is selected. Gated on perTaxa.length
@@ -3019,10 +3017,10 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     {perTaxa.length > 0 && selectedTaxa.size === 0 && (
       <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 mt-1.5">
         {/* Usage hint — desktop only; the toggles below matter more on mobile than this prose.
-            Country View has no multi-select (a country click always narrows to that one
-            country — see handleCountryDrilldown), so the normal hint doesn't apply there. */}
+            Country View starts hover-driven, then locks to click+multi-select once a
+            country's picked (see handleCountryDrilldown), so it gets its own wording. */}
         <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
-          {countryMode ? "Hover a country to view its data." : "Click to filter, Cmd/Ctrl+click to multi-select."}
+          {countryMode ? "Hover a country, or click to lock it and multi-select." : "Click to filter, Cmd/Ctrl+click to multi-select."}
         </span>
         <div className="flex flex-wrap items-center gap-3 pl-3 sm:pl-0">
           {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed */}

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -1234,11 +1234,11 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         className="text-xs bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md px-1.5 py-0.5 text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
       >
         <option value="taxonomic">By Taxon</option>
-        <option value="table1a">Table 1a</option>
-        <option value="ssc">By SSC Specialist Group</option>
         <option value="country" disabled={isNewAssessments} title={isNewAssessments ? "Not available for New Assessments — Not Evaluated species have no location data" : undefined}>
           By Country
         </option>
+        <option value="ssc">By SSC Specialist Group</option>
+        <option value="table1a">Table 1a</option>
       </select>
     </span>
   );
@@ -2520,7 +2520,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
       </div>,
       document.body
     )}
-    {/* Country view: taxa table on the left half, map on the right half.
+    {/* Country view: map on the left half, taxa table on the right half.
         The table always uses the plain 3-column style in this mode
         (countryStyleColumns, derived from layoutMode — see its definition
         above), whether or not a country is picked yet. The selected
@@ -2529,7 +2529,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         either column specifically so chips changing (locking/clearing/
         hovering, which varies their count and text width) never resizes the
         map or shifts the (zoomed) table's position; both used to happen
-        when the chips lived inside one column or the other. min-h-[26px]
+        when the chips lived inside one column or the other. min-h-[34px]
         (one pill row's height) reserves that space unconditionally, even
         with zero chips, so the table/map below don't themselves shift down
         the moment a hover starts previewing a country — that shift was its
@@ -2537,7 +2537,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         Uses `contents` to no-op this grouping entirely outside country
         mode, rather than branching (and duplicating) the huge table JSX
         below per mode. */}
-    {countryMode && <div className="min-h-[26px] mb-1.5">{countryPillsContent}</div>}
+    {countryMode && <div className="min-h-[34px] mb-1.5">{countryPillsContent}</div>}
     <div className={countryMode ? "grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4" : "contents"}>
       {/* No extra wrapper here — WorldMap already renders its own card (bg/border/
           padding); wrapping it again doubled up the box and, since neither div had
@@ -2551,6 +2551,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           column (was 2/3 width, now 1/2 — zoom-[.75] keeps everything, fonts
           included, at the same proportions just smaller, rather than letting
           columns get cramped or triggering horizontal scroll). */}
+      {countryMode && <div>{countryModeContent}</div>}
       <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
         {/* Country name atop the table — shown whenever a country is scoped
             OUTSIDE Country View (the normal browsing view's "France ×" chip,
@@ -2981,7 +2982,6 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
       </table>
         </div>
       </div>
-      {countryMode && <div>{countryModeContent}</div>}
     </div>
     {/* Subtle controls: usage hint + # Described toggle + expand/table controls,
         all landing-only — hidden once a taxon is selected. Gated on perTaxa.length

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -146,6 +146,12 @@ interface Props {
    * owns the country-stats data and click-through wiring), kept out of this
    * component so it doesn't need its own dynamic WorldMap import. */
   countryModeContent?: React.ReactNode;
+  /** Rendered above BOTH the map and the table in Country View — the current
+   * selection as removable name chips (built by RedListView, which owns the
+   * selection/hover state). Living above the whole grid rather than inside
+   * either column means neither the map nor the (zoomed) table ever resizes
+   * as chips are added/removed while hovering/locking/clearing countries. */
+  countryPillsContent?: React.ReactNode;
   /** Set whenever at least one country is selected — independent of layoutMode,
    * so selecting countries anywhere (not just via the Country view landing page)
    * scopes this table's own fetches too. One country, a whole region, or an
@@ -1043,7 +1049,7 @@ function DescribedInfoIcon({ nodeId, source, breakdown }: { nodeId: string; sour
   );
 }
 
-export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryScope, onClearCountryScope }: Props) {
+export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope, onClearCountryScope }: Props) {
   const isNewAssessments = viewMode === "new-assessments";
   const [taxa, setTaxa] = useState<TaxonSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -2514,15 +2520,19 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
       </div>,
       document.body
     )}
-    {/* Country view: map on the left half, taxa table on the right half.
+    {/* Country view: taxa table on the left half, map on the right half.
         The table always uses the plain 3-column style in this mode
         (countryStyleColumns, derived from layoutMode — see its definition
-        above), whether or not a country is picked yet. The selected country's
-        identity shows atop the map itself now (WorldMap's onClearSelection/
-        scopeLabel), not atop the table — see the comment on the other, non-
-        country-mode instance of that label below. Uses `contents` to no-op
-        this grouping entirely outside country mode, rather than branching
-        (and duplicating) the huge table JSX below per mode. */}
+        above), whether or not a country is picked yet. The selected
+        country's identity shows as removable chips above BOTH the table and
+        the map (countryPillsContent, built by RedListView) — living outside
+        either column specifically so chips changing (locking/clearing/
+        hovering, which varies their count and text width) never resizes the
+        map or shifts the (zoomed) table's position; both used to happen
+        when the chips lived inside one column or the other. Uses `contents`
+        to no-op this grouping entirely outside country mode, rather than
+        branching (and duplicating) the huge table JSX below per mode. */}
+    {countryMode && <div className="mb-1.5">{countryPillsContent}</div>}
     <div className={countryMode ? "grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4" : "contents"}>
       {/* No extra wrapper here — WorldMap already renders its own card (bg/border/
           padding); wrapping it again doubled up the box and, since neither div had
@@ -2536,15 +2546,16 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           column (was 2/3 width, now 1/2 — zoom-[.75] keeps everything, fonts
           included, at the same proportions just smaller, rather than letting
           columns get cramped or triggering horizontal scroll). */}
-      {countryMode && <div>{countryModeContent}</div>}
       <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
         {/* Country name atop the table — shown whenever a country is scoped
             OUTSIDE Country View (the normal browsing view's "France ×" chip,
-            via onClearCountryScope). Country View's own version lives on the
-            map itself instead (see WorldMap's country chips) — moving it
-            atop the table there made the zoomed table jump position every
-            time a country got locked/cleared, which read as jarring since
-            the map's own layout doesn't shift the same way. */}
+            via onClearCountryScope). Country View's own version lives above
+            both the table and the map instead (see countryPillsContent) —
+            moving it strictly atop the table made the zoomed table jump
+            position every time a country got locked/cleared; moving it onto
+            the map instead made the map itself flicker/resize as chips
+            changed size while hovering. Living above both avoids resizing
+            either one. */}
         {countryScoped && !countryMode && (
           <div className="flex items-center gap-1.5 mb-1.5 min-w-0 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
             <span className="truncate" title={countryScopeLabel}>{countryScopeLabel}</span>
@@ -2965,6 +2976,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
       </table>
         </div>
       </div>
+      {countryMode && <div>{countryModeContent}</div>}
     </div>
     {/* Subtle controls: usage hint + # Described toggle + expand/table controls,
         all landing-only — hidden once a taxon is selected. Gated on perTaxa.length

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -2533,7 +2533,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
       </div>,
       document.body
     )}
-    {/* Country view: map on the left third, taxa table on the right two-thirds.
+    {/* Country view: taxa table on the left half, map on the right half.
         The table always uses the plain 3-column style in this mode
         (countryStyleColumns, derived from layoutMode — see its definition
         above), whether or not a country is picked yet. The selected country's
@@ -2541,7 +2541,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         and, once a taxon's clicked, the full view too. Uses `contents` to
         no-op this grouping entirely outside country mode, rather than
         branching (and duplicating) the huge table JSX below per mode. */}
-    <div className={countryMode ? "grid grid-cols-1 lg:grid-cols-3 gap-4 mb-4" : "contents"}>
+    <div className={countryMode ? "grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4" : "contents"}>
       {/* No extra wrapper here — WorldMap already renders its own card (bg/border/
           padding); wrapping it again doubled up the box and, since neither div had
           an explicit height, left the map's own h-full with nothing to fill,
@@ -2549,9 +2549,12 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           align-items: stretch now makes both columns match the taller one — no
           artificial min-height on the map side, so the row settles at the
           table's own natural content height instead of leaving dead space
-          below the last row. 1/3 map, 2/3 table (col-span-1/col-span-2). */}
-      {countryMode && <div className="lg:col-span-1">{countryModeContent}</div>}
-      <div className={countryMode ? "min-w-0 flex flex-col h-full lg:col-span-2" : "contents"}>
+          below the last row. Even 1/2-1/2 split (col-span-1 each); the table's
+          own scrollRef box below is zoomed down to compensate for the narrower
+          column (was 2/3 width, now 1/2 — zoom-[.75] keeps everything, fonts
+          included, at the same proportions just smaller, rather than letting
+          columns get cramped or triggering horizontal scroll). */}
+      <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
         {/* Country name atop the table — shown whenever a country is scoped,
             in both Country View's landing layout and the full (post-taxon-click)
             view. The clear button behaves differently per context: in Country
@@ -2572,7 +2575,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
             )}
           </div>
         )}
-        <div ref={scrollRef} className={`relative bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-x-auto ${countryMode ? "flex-1" : ""}`}>
+        <div ref={scrollRef} className={`relative bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-x-auto ${countryMode ? "flex-1 [zoom:.75]" : ""}`}>
           {/* Country-switch refetch indicator — see the loading-gate comment
               above renderRow's skeleton branch for why this doesn't blank the table. */}
           {loading && taxa.length > 0 && (
@@ -3005,6 +3008,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
       </table>
         </div>
       </div>
+      {countryMode && <div>{countryModeContent}</div>}
     </div>
     {/* Subtle controls: usage hint + # Described toggle + expand/table controls,
         all landing-only — hidden once a taxon is selected. Gated on perTaxa.length
@@ -3018,7 +3022,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
             Country View has no multi-select (a country click always narrows to that one
             country — see handleCountryDrilldown), so the normal hint doesn't apply there. */}
         <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
-          {countryMode ? "Click a country to view its data." : "Click to filter, Cmd/Ctrl+click to multi-select."}
+          {countryMode ? "Hover a country to view its data." : "Click to filter, Cmd/Ctrl+click to multi-select."}
         </span>
         <div className="flex flex-wrap items-center gap-3 pl-3 sm:pl-0">
           {/* IUCN ↔ CoL source toggle: flips the described count + recomputes % Assessed */}

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -113,6 +113,16 @@ export function parseParams(search: string) {
   return {
     viewMode: (viewParam === "new-assessments" ? "new-assessments" : "reassessments") as ViewMode,
     layoutMode: (layoutParam === "table1a" || layoutParam === "ssc" || layoutParam === "country" ? layoutParam : null) as LayoutMode,
+    // Remembers the layout mode a taxon drill-down exited FROM (see
+    // exitCountryModeForTaxon) — survives even while layoutMode itself is
+    // null/something-else, so "All Species" and the site logo's Home button
+    // can jump back to Country View's landing page rather than the generic
+    // default, and so that memory itself survives a reload/shared link
+    // (page.tsx's Home handler reads this directly off the URL, outside this
+    // hook entirely). Cleared wherever a new layoutMode is deliberately set
+    // (setLayoutMode/navigateToTaxonSubgroup/returnToLayoutMode) — a fresh,
+    // explicit mode choice overrides whatever "return to X" memory it held.
+    originLayout: (p.get("origin") === "table1a" || p.get("origin") === "ssc" || p.get("origin") === "country" ? p.get("origin") : null) as LayoutMode,
     // Expanded from the flat `taxa` token list (+ legacy `subgroups=`) above.
     taxa: taxaSet,
     subgroups: subgroupSet,
@@ -192,6 +202,7 @@ export function parseParams(search: string) {
 export function buildQs(state: {
   viewMode: ViewMode;
   layoutMode?: LayoutMode;
+  originLayout?: LayoutMode;
   taxa: Set<string>;
   subgroups: Set<string>;
   categories: Set<string>;
@@ -228,6 +239,7 @@ export function buildQs(state: {
   const p = new URLSearchParams();
   if (state.viewMode === "new-assessments") p.set("view", "new-assessments");
   if (state.layoutMode) p.set("layout", state.layoutMode);
+  if (state.originLayout) p.set("origin", state.originLayout);
   // taxa + subgroups collapse to a single flat `taxa` token list (e.g.
   // invertebrates + inv-corals → taxa=corals); no separate subgroups param.
   const taxaTokens = collapseTaxaToTokens(state.taxa, state.subgroups);
@@ -427,7 +439,9 @@ export function useFilterParams() {
   const setLayoutMode = useCallback(
     (mode: LayoutMode) => {
       setState(prev => {
-        const next = { ...prev, layoutMode: mode };
+        // A deliberate, explicit mode choice overrides any "return to X"
+        // memory exitCountryModeForTaxon left behind — see originLayout's doc.
+        const next = { ...prev, layoutMode: mode, originLayout: null as LayoutMode };
         queueMicrotask(() => syncUrl(next, true)); // push so back button exits the mode
         return next;
       });
@@ -443,7 +457,7 @@ export function useFilterParams() {
   const navigateToTaxonSubgroup = useCallback(
     (taxonId: string, subgroupId: string) => {
       setState(prev => {
-        const next = { ...prev, taxa: new Set([taxonId]), subgroups: new Set([subgroupId]), layoutMode: null, breakdown: null };
+        const next = { ...prev, taxa: new Set([taxonId]), subgroups: new Set([subgroupId]), layoutMode: null, originLayout: null as LayoutMode, breakdown: null };
         queueMicrotask(() => syncUrl(next, true));
         return next;
       });
@@ -459,11 +473,16 @@ export function useFilterParams() {
   // "back" press would land on some half-updated intermediate (e.g.
   // layoutMode cleared but taxa not yet set) instead of cleanly restoring
   // the Country View landing page. countries is deliberately left untouched
-  // — the taxon drill-down stays scoped to whatever was selected.
+  // — the taxon drill-down stays scoped to whatever was selected. Also
+  // records originLayout: "country" — layoutMode itself is about to go
+  // null, so without this nothing durable remembers we came from Country
+  // View. RedListView's "All Species" row (and the site logo's Home button,
+  // reading straight off the URL) use this to jump back to that landing
+  // page instead of the generic default view.
   const exitCountryModeForTaxon = useCallback(
     (taxonId: string) => {
       setState(prev => {
-        const next = { ...prev, taxa: new Set([taxonId]), subgroups: new Set<string>(), layoutMode: null, breakdown: null };
+        const next = { ...prev, taxa: new Set([taxonId]), subgroups: new Set<string>(), layoutMode: null as LayoutMode, originLayout: "country" as LayoutMode, breakdown: null };
         queueMicrotask(() => syncUrl(next, true));
         return next;
       });
@@ -475,11 +494,13 @@ export function useFilterParams() {
   // landing page and re-enters a flat-table layout mode, atomically (one
   // history push). Used when clicking the "Mammals" ancestor row after
   // drilling out of SSC groups mode should return to that table instead of
-  // falling through to the plain taxon tree view.
+  // falling through to the plain taxon tree view, and (passing "country")
+  // by RedListView's "All Species" row to consume an originLayout memory
+  // left by exitCountryModeForTaxon and land back on Country View properly.
   const returnToLayoutMode = useCallback(
     (mode: LayoutMode) => {
       setState(prev => {
-        const next = { ...prev, taxa: new Set<string>(), subgroups: new Set<string>(), layoutMode: mode, breakdown: null };
+        const next = { ...prev, taxa: new Set<string>(), subgroups: new Set<string>(), layoutMode: mode, originLayout: null as LayoutMode, breakdown: null };
         queueMicrotask(() => syncUrl(next, true));
         return next;
       });
@@ -799,6 +820,7 @@ export function useFilterParams() {
   return {
     viewMode: state.viewMode,
     layoutMode: state.layoutMode,
+    originLayout: state.originLayout,
     selectedTaxa: state.taxa,
     selectedSubgroups: state.subgroups,
     selectedCategories: state.categories,

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -451,6 +451,26 @@ export function useFilterParams() {
     [syncUrl]
   );
 
+  // Exits Country View to the full charts+species-table view when a taxon's
+  // clicked from the country-scoped landing/list (see RedListView's
+  // handleToggleTaxon) — atomic (one setState + one history push), same
+  // reasoning as navigateToTaxonSubgroup above: without this, layoutMode and
+  // taxa/subgroups would each get their own history entry, so a single
+  // "back" press would land on some half-updated intermediate (e.g.
+  // layoutMode cleared but taxa not yet set) instead of cleanly restoring
+  // the Country View landing page. countries is deliberately left untouched
+  // — the taxon drill-down stays scoped to whatever was selected.
+  const exitCountryModeForTaxon = useCallback(
+    (taxonId: string) => {
+      setState(prev => {
+        const next = { ...prev, taxa: new Set([taxonId]), subgroups: new Set<string>(), layoutMode: null, breakdown: null };
+        queueMicrotask(() => syncUrl(next, true));
+        return next;
+      });
+    },
+    [syncUrl]
+  );
+
   // Reverse of navigateToTaxonSubgroup — clears taxa/subgroups back to the
   // landing page and re-enters a flat-table layout mode, atomically (one
   // history push). Used when clicking the "Mammals" ancestor row after
@@ -818,6 +838,7 @@ export function useFilterParams() {
     setViewMode,
     setLayoutMode,
     navigateToTaxonSubgroup,
+    exitCountryModeForTaxon,
     returnToLayoutMode,
     enterCountryDrilldown,
     returnToCountryList,

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -523,16 +523,6 @@ export function useFilterParams() {
     [syncUrl]
   );
 
-  // Reverse of enterCountryDrilldown — clears the country scope and re-enters
-  // the Country view landing page.
-  const returnToCountryList = useCallback(() => {
-    setState(prev => {
-      const next = { ...prev, countries: new Set<string>(), layoutMode: "country" as LayoutMode, breakdown: null };
-      queueMicrotask(() => syncUrl(next, true));
-      return next;
-    });
-  }, [syncUrl]);
-
   const setSelectedSystems = useCallback(
     (updater: Set<string> | ((prev: Set<string>) => Set<string>)) => {
       setState(prev => {
@@ -841,7 +831,6 @@ export function useFilterParams() {
     exitCountryModeForTaxon,
     returnToLayoutMode,
     enterCountryDrilldown,
-    returnToCountryList,
     setSelectedTaxa,
     setSelectedSubgroups,
     setSelectedCategories,


### PR DESCRIPTION
## Summary
- Country view's landing layout is an even 1/2-1/2 split. Map on the left, table on the right.
- The table is resized (zoomed to 75%) rather than just letting it reflow into the narrower column — keeps font size/padding proportions intact.
- **Hover previews, click locks:** before anything's selected, hovering a country updates the table live. The first click locks a single country in and switches off hover; every click after toggles a country in/out of the selection (no ctrl/cmd needed for multi-select once locked).
- **Selection shown as bigger removable chips, reserved (normal flow) above the table — and the map always matches its height exactly, even when chips wrap to multiple lines.** The pill row's real rendered height is measured live via ResizeObserver and mirrored as WorldMap's `topSpacerHeight`, a blank spacer of that exact size below its own toolbar. (A fixed-size guess only covered the common 1-line case; enough countries selected wraps the pill row to a second line, and since the choropleth renders at a fixed projection scale — its content doesn't grow to fill extra height — any un-mirrored growth on the table's side reopens a gap under the map.) A "Clear all" appears once more than one country is selected, and hovering (before anything's locked) shows its own dashed preview chip.
- **"All Species" and the Home button return to Country View properly** when you've drilled into a taxon from it — same country selection intact for "All Species"; filters/taxa/countries cleared for Home, matching Home's existing behavior.
- **List view**: the # Assessed/% Outdated/# GBIF Obs color-mode dropdown (only meaningful for the map's own coloring) is hidden. Min/max range filters for # Assessed, # Outdated, and % Outdated live behind a filter icon per column header (tinted when active) instead of a permanent row — opens a small popover, closes on outside click.
- Removed the "Source for # Described" IUCN/CoL toggle in Country View — its table already hides that column entirely.
- Renamed and reordered the "View:" dropdown: **By Taxon**, **By Country**, **By SSC Specialist Group (WIP)**, **Table 1a** — flagged SSC as WIP since that mode isn't considered ready yet.
- Removed the "Expand all"/"Collapse all" toggle button (standard browsing view) — per-row expand/collapse is untouched.
- Fixed a stale-selection bug and a related history-push bug so browser back-navigation and clearing behave correctly.
- `CountryStatsList`'s rows are denser so the List view's height lines up with the Map view's.
- SSC groups view: removed the "Show all N groups (M more)" / "Show less" per-section collapse — every group renders directly.
- Fixed Country View's hint text grammar ("Hover over a country...").

## Screenshots

One country locked — pill above the table, map height matched:

![One pill, heights matched](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-385-country-halfhalf-hover/28-one-pill.png)

Five countries locked, pills wrapped to two lines — map still exactly matches the table's (taller) height, no gap:

![Five wrapped pills, heights still matched](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-385-country-halfhalf-hover/29-five-pills-wrapped-matched.png)

List view — filter icon opens a min/max popover instead of a permanent row:

![Filter icon popover](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-385-country-halfhalf-hover/19-filter-icon-popover.png)

Filtered — icon stays tinted blue to show the column has an active filter:

![Filtered with active icon](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-385-country-halfhalf-hover/20-filtered-active-icon.png)

List view — row height still matches the Map view's height:

![List view height matches map view](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-385-country-halfhalf-hover/05-listview-matched-height.png)

## Test plan
- [x] Verified in-browser: map left, table right, even halves; table zoomed appropriately.
- [x] Measured map/table heights across landing, mid-hover, 1 locked, and 5 locked (wrapped to 2 lines) — map and table stay exactly matched at every stage (331/371/399px as chips grow), no gap ever appears under the map.
- [x] Clicked "Clear all" after 5 wrapped pills — confirmed both map and table shrink back to their original matched height (371px) together.
- [x] Locked countries via click — confirmed independent pills + "Clear all" reserved above the table, each pill removable on its own.
- [x] Drilled into Mammals from a country-locked Country View, clicked "All Species" — confirmed it returns to the Country View landing page with the same country still selected.
- [x] Same drill-down, then clicked the site logo (Home) — confirmed it also lands on Country View, filters/taxa/countries cleared same as Home's normal behavior.
- [x] Confirmed "Source for # Described" no longer renders in Country View.
- [x] Toggled Map ↔ List in Country View and confirmed the card height still doesn't jump.
- [x] Switched to List view and confirmed the color-mode dropdown is gone (reappears in Map view).
- [x] Clicked a filter icon, typed a min value, confirmed the row count/pagination narrows and the icon turns blue; clicked outside and confirmed the popover closes but the filter stays applied.
- [x] Confirmed the "View:" dropdown order is By Taxon, By Country, By SSC Specialist Group (WIP), Table 1a.
- [x] Switched to SSC groups view and confirmed every group renders with no "Show all"/"Show less" controls.
- [x] Confirmed "Expand all"/"Collapse all" no longer renders anywhere, and per-row expand/collapse still works.