### PR TITLE
weekly-sync.yml: commit col-release.json so the CoL XR citation never goes stale

### DIFF
--- a/.github/workflows/weekly-sync.yml
+++ b/.github/workflows/weekly-sync.yml
@@ -33,8 +33,8 @@ name: Weekly data sync
 #     API key or token).
 #   - The PR step stages an explicit file allowlist, never `git add -A`/`.`,
 #     so the ~400MB of raw per-species data (gitignored, private-R2-only)
-#     can never accidentally end up in a commit — only the two small
-#     aggregate JSON files (already committed today) plus col-taxon-ids.json.
+#     can never accidentally end up in a commit — only the small, already-
+#     committed aggregate/config files staged explicitly below.
 #   - Every script in this pipeline only logs aggregate counts/durations,
 #     never per-species rows, so the (publicly-visible) Action logs are safe.
 
@@ -118,7 +118,7 @@ jobs:
           # -A`/`.` here: data/ holds ~400MB of raw per-species data that must
           # never touch git, only these small, already-committed aggregate files.
           git add latest-sync.txt data/taxa-summary.json data/node-children-summaries.json data/country-stats.json
-          git add src/config/col-taxon-ids.json
+          git add src/config/col-taxon-ids.json src/config/col-release.json
 
           if git diff --cached --quiet; then
             echo "Nothing to commit — skipping PR."


### PR DESCRIPTION
## Summary
`fetch-col-xr.ts` already re-resolves the true latest CoL XR release every sync (no hardcoded key, by design — a prior incident, #276, was a hardcoded key silently going stale for 7 months) and rewrites `src/config/col-release.json` to match. But the weekly-sync workflow's PR step never staged that file in its explicit git-add allowlist, so the freshly-resolved value was silently discarded when each run's workspace tore down instead of ever reaching `main`. It happened to still read correctly today only because the XR release hasn't advanced since it was last committed by other means — the moment it does, the citation would go stale with nothing to signal it.

Adds `src/config/col-release.json` to the allowlist so this fix actually reaches main going forward. Also tightened the file's own top-of-file comment describing the allowlist, which had already drifted stale (didn't mention `country-stats.json` from #376) — reworded to describe the mechanism instead of enumerating an exact file list that'll drift again.

## Test plan
- [x] One-line, low-risk change to an already-tested workflow (validated end-to-end in #378/#388)
- [x] Confirm on the next real sync that `col-release.json` actually appears in the auto-generated data-bump PR