### PR TITLE
Country view: fix stale hover-race table data, add loading dim, fix map/table alignment

### DIFF
--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -257,19 +257,6 @@ interface WorldMapProps {
   // Called with the hovered country's code on mouseenter, and null on
   // mouseleave, only while selectOnHover is true.
   onCountryHover?: (countryCode: string | null) => void;
-  // When set, reserves a blank strip of exactly this many px right below
-  // the toolbar row — matching (via the caller's own ResizeObserver
-  // measurement, not a fixed guess) the real height of the selection-chip
-  // row Country View's paired table reserves above itself, so both sides
-  // of that grid always have the same "extra" natural height and neither
-  // needs align-items: stretch to inflate it to match the other — a fixed
-  // guess only covers the common 1-line-of-chips case; once chips wrap to
-  // a second line the table's column grows past it, and since the
-  // choropleth renders at a fixed projection scale (its content doesn't
-  // grow to fill extra height), stretching the map's card to match left a
-  // visible gap under the map. Omitted for the other WorldMap usages,
-  // which have no paired chip row.
-  topSpacerHeight?: number;
 }
 
 const DEFAULT_CENTER: [number, number] = [10, 10];
@@ -277,7 +264,7 @@ const DEFAULT_ZOOM = 1.0;
 const MIN_ZOOM = 1.0;
 const MAX_ZOOM = 8.0;
 
-function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover, topSpacerHeight }: WorldMapProps) {
+function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomputedStats, precomputedStatsTotal, selectedTaxa, speciesLabel = "# Assessed", onRegionFilter, endemicsOnly = false, onEndemicsToggle, footer, showGbifToggle = true, showOutdatedMode = true, mapViewMode, onMapViewModeChange, mapSortKey, mapSortDirection, onMapSortChange, selectOnHover = false, onCountryHover }: WorldMapProps) {
   const [hoveredCountry, setHoveredCountry] = useState<string | null>(null);
   const [hoveredCountryCode, setHoveredCountryCode] = useState<string | null>(null);
   const [speciesStats, setSpeciesStats] = useState<CountryStats>(precomputedStats || {});
@@ -608,8 +595,6 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
           )}
         </div>
       </div>
-
-      {topSpacerHeight != null && <div className="mb-1.5" style={{ height: topSpacerHeight }} />}
 
       {/* Hover tooltip (map view only) */}
       {viewMode === "map" && hoveredCountry && (

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2248,32 +2248,6 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
   // selected" (see handleCountryDrilldown/selectOnHover).
   const [hoverPreviewCountry, setHoverPreviewCountry] = useState<string | null>(null);
 
-  // Measures the actual rendered height of the pills row below (it wraps to
-  // multiple lines once enough countries are selected, or long names push
-  // it past one line) so WorldMap's matching top spacer — see
-  // countryModeContent's topSpacerHeight — can reserve exactly that much,
-  // not a fixed guess. A fixed guess only matched the common 1-pill case;
-  // once pills wrapped to two lines, the table's column grew past what the
-  // map's spacer accounted for, and the paired grid's align-items: stretch
-  // inflated the map's card to match without its (fixed-projection-scale)
-  // content growing to fill it — the same gap-under-the-map problem this
-  // whole spacer exists to avoid, just reappearing at the wrap threshold.
-  // ResizeObserver (not just a selection-keyed effect) so a pure window-
-  // resize reflow — more/fewer pills fitting per line at the same
-  // selection — is caught too.
-  const pillsRef = useRef<HTMLDivElement>(null);
-  const [pillsHeight, setPillsHeight] = useState(34);
-  useEffect(() => {
-    const el = pillsRef.current;
-    if (!el) return;
-    const observer = new ResizeObserver((entries) => {
-      const height = entries[0]?.contentRect.height;
-      if (height != null) setPillsHeight(Math.max(34, Math.ceil(height)));
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
-
   const countryScope = selectedCountries.size > 0 ? [...selectedCountries]
     : hoverPreviewCountry ? [hoverPreviewCountry]
     : null;
@@ -2349,7 +2323,6 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
       onCountrySelect={handleCountryDrilldown}
       selectOnHover={selectedCountries.size === 0}
       onCountryHover={setHoverPreviewCountry}
-      topSpacerHeight={pillsHeight}
       precomputedStats={countryLandingStats ?? {}}
       selectedTaxa={selectedTaxa}
       speciesLabel={isNewAssessments ? "# Unassessed" : undefined}
@@ -2364,62 +2337,55 @@ export default function RedListView({ viewMode = "reassessments", sharedTaxa, sh
     />
   );
 
-  // Selection chips shown in normal flow above the table. Wrapped in its
-  // own min-h-[34px] div with pillsRef attached — that's the box
-  // ResizeObserver measures above to drive WorldMap's topSpacerHeight, so
-  // the map's matching blank spacer always reserves exactly this box's
-  // real height (min 34px, taller once chips wrap to a second line) rather
-  // than a fixed guess that only held for the common 1-pill case. The
-  // wrapper renders unconditionally (even with nothing to show) so the
-  // measurement is always live; only the actual chip row inside is
-  // conditional. One chip per selected country (not collapsed into a
-  // region name, unlike the atop-table "France ×" chip elsewhere), each
-  // individually removable, plus "Clear all" once there's more than one.
+  // Selection chips — rendered by TaxaSummary in a dedicated row of its own
+  // above BOTH the map and the table (aligned under the table's half via a
+  // matching grid template, with the map's half left blank), not inside
+  // either component, so neither one's own height is ever affected by how
+  // many chips are showing or whether they've wrapped to a second line.
+  // One chip per selected country (not collapsed into a region name,
+  // unlike the atop-table "France ×" chip elsewhere), each individually
+  // removable, plus "Clear all" once there's more than one.
   // Before anything's locked, hovering shows its own preview chip (dashed,
   // non-removable — there's nothing to remove yet, moving the mouse away
   // already clears it) so the table's live hover-preview has a visual
   // anchor. Reuses handleCountryDrilldown for removal — clicking a chip's ✕
   // for a country that's already selected always toggles it off, whichever
   // branch handleCountryDrilldown takes.
-  const countryPillsContent = (
-    <div ref={pillsRef} className="min-h-[34px] mb-1.5">
-      {(selectedCountries.size > 0 || hoverPreviewCountry) && (
-        <div className="flex flex-wrap items-center gap-1.5">
-          {selectedCountries.size > 0 ? (
-            <>
-              {[...selectedCountries]
-                .map(code => ({ code, name: ALPHA2_TO_NAME[code] ?? code }))
-                .sort((a, b) => a.name.localeCompare(b.name))
-                .map(({ code, name }) => (
-                  <span
-                    key={code}
-                    className="inline-flex items-center gap-1.5 pl-3 pr-1.5 py-1 rounded-full bg-zinc-100 dark:bg-zinc-800 text-sm text-zinc-700 dark:text-zinc-300 max-w-full"
-                  >
-                    <span className="truncate">{name}</span>
-                    <button
-                      onClick={(e) => handleCountryDrilldown(code, name, e)}
-                      className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                      title={`Remove ${name}`}
-                    >
-                      ✕
-                    </button>
-                  </span>
-                ))}
-              {selectedCountries.size > 1 && (
+  const countryPillsContent = (selectedCountries.size > 0 || hoverPreviewCountry) && (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {selectedCountries.size > 0 ? (
+        <>
+          {[...selectedCountries]
+            .map(code => ({ code, name: ALPHA2_TO_NAME[code] ?? code }))
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map(({ code, name }) => (
+              <span
+                key={code}
+                className="inline-flex items-center gap-1.5 pl-3 pr-1.5 py-1 rounded-full bg-zinc-100 dark:bg-zinc-800 text-sm text-zinc-700 dark:text-zinc-300 max-w-full"
+              >
+                <span className="truncate">{name}</span>
                 <button
-                  onClick={() => { enterCountryDrilldown(new Set()); setHoverPreviewCountry(null); }}
-                  className="text-sm text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors"
+                  onClick={(e) => handleCountryDrilldown(code, name, e)}
+                  className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                  title={`Remove ${name}`}
                 >
-                  Clear all
+                  ✕
                 </button>
-              )}
-            </>
-          ) : (
-            <span className="inline-flex items-center pl-3 pr-3 py-1 rounded-full bg-white dark:bg-zinc-800 border border-dashed border-zinc-300 dark:border-zinc-600 text-sm text-zinc-500 dark:text-zinc-400 max-w-full">
-              <span className="truncate">{ALPHA2_TO_NAME[hoverPreviewCountry!] ?? hoverPreviewCountry}</span>
-            </span>
+              </span>
+            ))}
+          {selectedCountries.size > 1 && (
+            <button
+              onClick={() => { enterCountryDrilldown(new Set()); setHoverPreviewCountry(null); }}
+              className="text-sm text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 underline transition-colors"
+            >
+              Clear all
+            </button>
           )}
-        </div>
+        </>
+      ) : (
+        <span className="inline-flex items-center pl-3 pr-3 py-1 rounded-full bg-white dark:bg-zinc-800 border border-dashed border-zinc-300 dark:border-zinc-600 text-sm text-zinc-500 dark:text-zinc-400 max-w-full">
+          <span className="truncate">{ALPHA2_TO_NAME[hoverPreviewCountry!] ?? hoverPreviewCountry}</span>
+        </span>
       )}
     </div>
   );

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -2525,23 +2525,28 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         The table always uses the plain 3-column style in this mode
         (countryStyleColumns, derived from layoutMode — see its definition
         above), whether or not a country is picked yet. The selected
-        country's identity shows as removable chips in normal flow above
-        the table — countryPillsContent (built by RedListView) already
-        includes its own min-h-[34px] reserving wrapper (with a ref
-        RedListView measures via ResizeObserver), so it's rendered directly
-        here with no extra wrapper of our own. That measured height feeds
-        WorldMap's topSpacerHeight, which reserves the exact same blank
-        height at the top of the map's own card, so both columns' natural
-        heights always include the same "extra" amount and grid's align-
-        items: stretch below doesn't need to inflate either one to match
-        the other. Without a matching (and correctly *measured*, not
-        guessed) spacer, only growing the table's column stretched the
-        map's card via align-items: stretch, but WorldMap's choropleth
-        renders at a fixed projection scale — its content didn't grow to
-        fill the extra height, leaving a visible gap under the map. Uses
-        `contents` to no-op this grouping entirely outside country mode,
-        rather than branching (and duplicating) the huge table JSX below
-        per mode. */}
+        country's identity shows as removable chips in a row of its own
+        ABOVE this whole grid — same grid-cols template so its columns line
+        up with the map/table below, but with the left (map) cell left
+        empty and the chips confined to the right (table) cell. min-h-
+        [34px] on that cell reserves the space unconditionally (a blank gap
+        before anything's hovered/selected), so it never grows *this* grid
+        below it into needing align-items: stretch to force the map's card
+        to match a taller table. Chips living inside either component
+        (tried both: atop just the table, floated over the map, enclosed in
+        the table's own card) always ended up needing some mechanism to
+        keep the map's card the same height as the table's — a separate row
+        above both sidesteps the problem entirely, since neither column's
+        own natural height is ever affected by how many chips are showing.
+        Uses `contents` to no-op this grouping entirely outside country
+        mode, rather than branching (and duplicating) the huge table JSX
+        below per mode. */}
+    {countryMode && (
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-1.5">
+        <div aria-hidden="true" />
+        <div className="min-h-[34px]">{countryPillsContent}</div>
+      </div>
+    )}
     <div className={countryMode ? "grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4" : "contents"}>
       {/* No extra wrapper here — WorldMap already renders its own card (bg/border/
           padding); wrapping it again doubled up the box and, since neither div had
@@ -2556,21 +2561,11 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           included, at the same proportions just smaller, rather than letting
           columns get cramped or triggering horizontal scroll). */}
       {countryMode && <div>{countryModeContent}</div>}
-      <div className={countryMode ? "min-w-0 flex flex-col h-full bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl shadow-sm p-3" : "contents"}>
-        {/* The pills + table both live inside this same bordered/padded card
-            now — matching WorldMap's own card (border/rounded-xl/p-3
-            wrapping its "Country" heading+toolbar, then its content) so both
-            components' outer boxes start flush at the top of the grid row.
-            Previously only the scrollRef box below had this border/padding,
-            with the (unboxed) pills sitting above it — the map's card
-            started at the row's top edge while the table's bordered box
-            started lower, below that gap, even though their total heights
-            already matched via topSpacerHeight. */}
-        {countryMode && countryPillsContent}
+      <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
         {/* Country name atop the table — shown whenever a country is scoped
             OUTSIDE Country View (the normal browsing view's "France ×" chip,
             via onClearCountryScope). Country View's own version is the
-            countryPillsContent block just above instead. */}
+            chips row above the grid instead. */}
         {countryScoped && !countryMode && (
           <div className="flex items-center gap-1.5 mb-1.5 min-w-0 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
             <span className="truncate" title={countryScopeLabel}>{countryScopeLabel}</span>
@@ -2585,7 +2580,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
             )}
           </div>
         )}
-        <div ref={scrollRef} className={countryMode ? "relative overflow-x-auto flex-1 [zoom:.75]" : "relative bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-x-auto"}>
+        <div ref={scrollRef} className={`relative bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-x-auto ${countryMode ? "flex-1 [zoom:.75]" : ""}`}>
           {/* Country-switch refetch indicator — see the loading-gate comment
               above renderRow's skeleton branch for why this doesn't blank the table. */}
           {loading && taxa.length > 0 && (

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -1094,6 +1094,14 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
   // countries on in either order produces the same key (and cache-friendly
   // URL), not one per click order.
   const countryKey = countryScoped ? [...countryScope!].sort().join(",") : "";
+  // Kept in sync every render (plain assignment, not an effect — refs don't
+  // need one) so the promise-chained fetches below (toggleExpand, Table 1a,
+  // SSC groups — unlike the main fetchTaxa effect above, these aren't
+  // effect-cleanup-cancellable) can tell, once their response finally
+  // resolves, whether countryKey has already moved on to a different
+  // country and skip applying a now-stale result.
+  const countryKeyRef = useRef(countryKey);
+  countryKeyRef.current = countryKey;
   // Display name for the atop-table label: the one country's name, the whole
   // region's name if the selection exactly matches one (e.g. picked via the
   // region dropdown, or by happening to cmd-click every one of its countries),
@@ -1193,10 +1201,15 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     // Fetch subgroup data if not already loaded (read from refs to avoid stale closures)
     if (!subgroupDataRef.current[taxonId] && !loadingSubgroupsRef.current.has(taxonId)) {
       setLoadingSubgroups((prev) => new Set(prev).add(taxonId));
+      const requestCountryKey = countryKey;
       try {
         const countryQs = countryKey ? `&country=${encodeURIComponent(countryKey)}` : "";
         const res = await fetch(`/api/redlist/taxa-subgroups?nodeId=${taxonId}${countryQs}`);
-        if (res.ok) {
+        // Bail if the country changed while this was in flight — countryKey
+        // changing already clears subgroupData wholesale (see the effect
+        // above), and applying this now-stale response would silently
+        // re-add wrongly-scoped numbers for taxonId right after that clear.
+        if (res.ok && countryKeyRef.current === requestCountryKey) {
           const data = await res.json();
           setSubgroupData((prev) => ({ ...prev, [taxonId]: data.subgroups }));
         }
@@ -1300,10 +1313,14 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     if (!table1aMode || table1aData || table1aFetchStartedRef.current) return;
     table1aFetchStartedRef.current = true;
     setTable1aLoading(true);
+    const requestCountryKey = countryKey;
     const countryQs = countryKey ? `&country=${encodeURIComponent(countryKey)}` : "";
     fetch(`/api/redlist/taxa-summary?table1a=true${countryQs}`)
       .then(res => res.ok ? res.json() : null)
-      .then(data => { if (data) setTable1aData(data.sections); })
+      // countryKey changing already resets table1aData/table1aFetchStartedRef
+      // (see the effect above) so a fresh fetch can start — but doesn't cancel
+      // THIS one, so skip applying it if it resolves after that happened.
+      .then(data => { if (data && countryKeyRef.current === requestCountryKey) setTable1aData(data.sections); })
       .finally(() => setTable1aLoading(false));
   }, [table1aMode, table1aData, countryKey]);
 
@@ -1318,6 +1335,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     if (!sscMode || sscData || sscFetchStartedRef.current) return;
     sscFetchStartedRef.current = true;
     setSscLoading(true);
+    const requestCountryKey = countryKey;
     const countryQs = countryKey ? `&country=${encodeURIComponent(countryKey)}` : "";
     Promise.all(
       SSC_SECTIONS.map((section) =>
@@ -1352,7 +1370,10 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           })
       )
     )
-      .then((sections) => setSscData(sections.filter((s): s is Table1aSectionData => s != null)))
+      // Same staleness guard as the Table 1a fetch above — countryKey
+      // changing already reset sscData/sscFetchStartedRef, but didn't cancel
+      // this in-flight request.
+      .then((sections) => { if (countryKeyRef.current === requestCountryKey) setSscData(sections.filter((s): s is Table1aSectionData => s != null)); })
       .finally(() => setSscLoading(false));
   }, [sscMode, sscData, countryKey]);
 
@@ -1407,22 +1428,32 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     //   expands taxa (mutates expandedTaxa), which would re-trigger the effect
   }, [selectedSubgroups]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Aborts the in-flight request whenever countryKey changes again before it
+  // resolves — without this, rapid country hovering could fire many quick
+  // requests whose responses race each other, and whichever happened to
+  // resolve LAST (not necessarily the one for the currently-hovered/
+  // selected country) would win and overwrite `taxa` with stale, wrongly-
+  // scoped numbers — visibly "stuck" even after the hover preview and its
+  // pill had already cleared back to no selection.
   useEffect(() => {
+    const controller = new AbortController();
     async function fetchTaxa() {
       setLoading(true);
       try {
         const countryQs = countryKey ? `?country=${encodeURIComponent(countryKey)}` : "";
-        const res = await fetch(`/api/redlist/taxa-summary${countryQs}`);
+        const res = await fetch(`/api/redlist/taxa-summary${countryQs}`, { signal: controller.signal });
         if (!res.ok) throw new Error("Failed to load taxa");
         const data = await res.json();
         setTaxa(data.taxa);
       } catch (err) {
+        if (controller.signal.aborted) return;
         setError(err instanceof Error ? err.message : "Failed to load taxa");
       } finally {
-        setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       }
     }
     fetchTaxa();
+    return () => controller.abort();
   }, [countryKey]);
 
   // Only the very first load (no data yet) shows the full-table skeleton below —
@@ -2525,7 +2556,16 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           included, at the same proportions just smaller, rather than letting
           columns get cramped or triggering horizontal scroll). */}
       {countryMode && <div>{countryModeContent}</div>}
-      <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
+      <div className={countryMode ? "min-w-0 flex flex-col h-full bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl shadow-sm p-3" : "contents"}>
+        {/* The pills + table both live inside this same bordered/padded card
+            now — matching WorldMap's own card (border/rounded-xl/p-3
+            wrapping its "Country" heading+toolbar, then its content) so both
+            components' outer boxes start flush at the top of the grid row.
+            Previously only the scrollRef box below had this border/padding,
+            with the (unboxed) pills sitting above it — the map's card
+            started at the row's top edge while the table's bordered box
+            started lower, below that gap, even though their total heights
+            already matched via topSpacerHeight. */}
         {countryMode && countryPillsContent}
         {/* Country name atop the table — shown whenever a country is scoped
             OUTSIDE Country View (the normal browsing view's "France ×" chip,
@@ -2545,7 +2585,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
             )}
           </div>
         )}
-        <div ref={scrollRef} className={`relative bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-x-auto ${countryMode ? "flex-1 [zoom:.75]" : ""}`}>
+        <div ref={scrollRef} className={countryMode ? "relative overflow-x-auto flex-1 [zoom:.75]" : "relative bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-x-auto"}>
           {/* Country-switch refetch indicator — see the loading-gate comment
               above renderRow's skeleton branch for why this doesn't blank the table. */}
           {loading && taxa.length > 0 && (
@@ -2558,7 +2598,15 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           )}
           <table className="w-full">
             {renderHead()}
-        <tbody>
+        {/* Dims every row's numbers (not just a corner spinner) while a
+            country-switch refetch is in flight — the row-level content below
+            deliberately keeps showing the previous country's numbers during
+            that refetch (see the skeleton-gate comment above) rather than
+            blanking to a skeleton, so without this there's no visual cue
+            that any given number might already be stale. Scoped to
+            !flatMode: Table 1a/SSC's own refetch (flatLoading) already
+            blanks to a loading row instead of leaving stale content up. */}
+        <tbody className={!flatMode && loading && taxa.length > 0 ? "opacity-50 transition-opacity duration-200" : "transition-opacity duration-200"}>
           {flatMode ? (
             /* Table 1a / SSC groups view: sections with headers, individual rows, subtotals */
             flatLoading ? (


### PR DESCRIPTION
## Summary
- **Fixed a real bug**: rapidly hovering across many countries then moving the cursor off the map could leave the table stuck showing an earlier-hovered country's numbers, even after the hover preview (and its pill) had already cleared back to no selection. Root cause: the main taxa-summary fetch (re-fired on every hover, keyed on the current country) had no staleness guard — whichever response happened to resolve last won, regardless of request order. Fixed with an `AbortController` that cancels the in-flight request whenever the country changes again before it resolves. Applied the same class of fix to the three other country-keyed fetches that shared the pattern (subgroup fetch on row-expand, Table 1a fetch, SSC groups fetch).
- **Added a loading indicator**: the table body now dims to 50% opacity while a country-switch refetch is in flight (previously kept showing the old country's numbers with zero visual cue they might already be stale), fading back in once fresh data lands. Beyond the existing small corner spinner.
- **Selection chips now live in their own row above both the map and the table**, using the same grid-cols template as the map+table row so its columns line up — the map's half stays empty, chips are confined to the table's half. This reserves a blank strip above both from the start (growing as chips wrap to more lines), and — as a side effect — completely sidesteps the "keep the map's card the same height as the table's" problem chased across several earlier rounds: since neither the map's nor the table's own column is ever affected by chip count, both just size normally and stay matched via ordinary grid stretch. Removed the topSpacerHeight/ResizeObserver machinery that existed solely for that syncing.

## Screenshots

Landing state — reserved blank strip above both, cards aligned:

![Landing with blank gap](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-390-country-hover-fixes/03-landing-blank-gap.png)

Hovering — pill appears aligned to the table's half, not spanning full width or sitting on the map:

![Pill aligned to table's half](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-390-country-hover-fixes/04-pill-aligned-to-table.png)

Five countries locked, pills wrapped to two lines — map and table cards still exactly the same height as each other, just both pushed down together:

![Wrapped pills, cards still matched](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-390-country-hover-fixes/05-wrapped-pills-still-matched.png)

Table body dimmed while a country-switch refetch is in flight (network throttled to make it visible):

![Loading dim](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-390-country-hover-fixes/02-loading-dim.png)

## Test plan
- [x] Simulated rapid hovering across 30-40 points on the map then moving off it entirely — confirmed (via network monitoring) that several in-flight `/api/redlist/taxa-summary` requests are actually aborted mid-flight, not just left to race.
- [x] Confirmed the table settles back to the exact global/unscoped baseline numbers after moving off the map, with no locked or hover-preview pill showing.
- [x] Throttled the network and hovered a country — confirmed (via computed `opacity`) the table body visibly dims during the in-flight fetch and returns to full opacity once it resolves.
- [x] Measured the map's card and the table's card — pixel-identical height (331px) whether idle, mid-hover, or with 5 wrapped pills selected, with the pair shifting down together as the pill row grows and back up when cleared.
- [x] Confirmed pills render left-aligned with the table's own left edge, not the map's, with the map's half of the pill row staying empty.
- [x] Typecheck and lint clean.