### PR TITLE
Fix stale weekly-sync allowlist (breaks the bump-PR step)

### DIFF
--- a/.github/workflows/weekly-sync.yml
+++ b/.github/workflows/weekly-sync.yml
@@ -117,7 +117,14 @@ jobs:
           # Explicit allowlist ONLY — see the safety notes above. Never `git add
           # -A`/`.` here: data/ holds ~400MB of raw per-species data that must
           # never touch git, only these small, already-committed aggregate files.
-          git add latest-sync.txt data/taxa-summary.json data/node-children-summaries.json data/country-stats.json
+          # Keep this list in exact sync with app/.gitignore's `!/data/...`
+          # exceptions (the 7 dual git-tracked-and-R2-published data/ files) plus
+          # the 2 git-tracked src/config/ pipeline outputs — data/node-children-
+          # summaries.json (referenced here until now) was split into the two
+          # table1a-/ssc-group- files below a while back and this list was never
+          # updated, so this step would have failed with "pathspec did not match
+          # any files" on the next run to actually reach it.
+          git add latest-sync.txt data/taxa-summary.json data/table1a-children-summaries.json data/ssc-group-children-summaries.json data/country-stats.json data/vernacular-names.json data/col-split-candidates.parquet data/col-to-assessed.parquet
           git add src/config/col-taxon-ids.json src/config/col-release.json
 
           if git diff --cached --quiet; then

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Phases 7–12 build the **Catalogue of Life backbone** (run on a full sync only)
 12. `build-col-taxon-ids` — resolves every taxon name referenced in `taxonomy-tree.ts`'s filters against `backbone.parquet` → `src/config/col-taxon-ids.json` (each name's CoL taxon id, so the dashboard can link a name straight to its CoL page). Small and derived from committed source, so — unlike the other outputs here — it's **committed to git**, not published to R2. Re-run standalone (`npx tsx scripts/build-col-taxon-ids.ts`) whenever a node's filter changes, without needing a full sync.
 
 Phase 13 runs **last**, after the CoL backbone, since it depends on those artifacts:
-13. `build-taxa-summary` — aggregates per-taxon CSVs + the CoL backbone (`species/`, `species_link.parquet`) → `data/taxa-summary.json` and `data/node-children-summaries.json`, including per-group `col_described`/`col_ne` counts
+13. `build-taxa-summary` — aggregates per-taxon CSVs + the CoL backbone (`species/`, `species_link.parquet`) → `data/taxa-summary.json` and `data/table1a-children-summaries.json`/`data/ssc-group-children-summaries.json` (split from a single `node-children-summaries.json` — the old combined name, kept here as a pointer for anyone searching it), including per-group `col_described`/`col_ne` counts
 
 **Publishing a refresh.** `app/data/` lives in a private R2 bucket; the active version is pinned via `app/latest-sync.txt`. To publish a fresh sync:
 


### PR DESCRIPTION
## Summary
- `weekly-sync.yml`'s `git add` allowlist for the bump-PR step still named the old combined `data/node-children-summaries.json`, which was split into `data/table1a-children-summaries.json` + `data/ssc-group-children-summaries.json` a while back. The allowlist was never updated, so once a real sync run produces a diff, the "Open a PR bumping the sync pointer" step would fail with `pathspec did not match any files`.
- While fixing that, brought the allowlist fully in sync with `app/.gitignore`'s 7 tracked `data/*` exceptions — it was also missing `data/vernacular-names.json`, `data/col-split-candidates.parquet`, and `data/col-to-assessed.parquet`.
- Fixed the same stale filename reference in `README.md`'s pipeline-phase docs (phase 13).

This is a narrow, CI-bug-focused fix. A separate follow-up PR will cover the broader data-pipeline reorg (raw/derived directory split, README drift beyond this one reference, a single source of truth for the tracked-file list).

## Test plan
- [x] Confirmed the new allowlist matches `app/.gitignore`'s `!/data/...` exceptions exactly (7 files) plus the 2 git-tracked `src/config/` outputs.
- [x] Sanity-checked the edited YAML (no tabs, structure intact).
- [ ] No live weekly-sync run has exercised this step yet since the fix (the bug only manifests when a sync actually produces a diff) — worth watching the next scheduled/dispatched run.