### PR TITLE
Fix Not Evaluated count mismatch (Mammals: 530 vs 520) + block NE for All Species

### DIFF
--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -775,6 +775,24 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // Reset NE fetch when taxon selection changes
   useEffect(() => { setNeSpecies([]); setNeSpeciesFetched(false); }, [neFetchTaxon]);
 
+  // "All Species" (or any multi-taxon selection, which also resolves neFetchTaxon to
+  // "all") has ~1.8M not-evaluated species — far past querySpecies's NE_CAP, so the
+  // fetch above would return tooLarge with an empty species list. Previously this just
+  // made the pill silently disappear (neCount fell back to 0) while any already-active
+  // "NE" filter stayed selected but matched nothing, showing "0 species" with no
+  // explanation. Block it instead: keep the pill visible but disabled, and drop "NE"
+  // from selectedCategories if a prior taxon-scoped selection is carried into this state.
+  const neBlockedForAll = neFetchTaxon === "all";
+  useEffect(() => {
+    if (!neBlockedForAll) return;
+    setSelectedCategories(prev => {
+      if (!prev.has("NE")) return prev;
+      const next = new Set(prev);
+      next.delete("NE");
+      return next;
+    });
+  }, [neBlockedForAll, setSelectedCategories]);
+
   // All species = assessed + NE (in new-assessments mode, assessedSpecies already contains NE species)
   const species = useMemo(() => isNewAssessments ? assessedSpecies : [...assessedSpecies, ...neSpecies], [assessedSpecies, neSpecies, isNewAssessments]);
   const neCount = neSpecies.length;
@@ -3635,9 +3653,11 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 <>{totalFiltered.toLocaleString()} species</>
               )}
             </span>
-            {!isNewAssessments && neCount > 0 && (
+            {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
               <button
+                disabled={neBlockedForAll}
                 onClick={() => {
+                  if (neBlockedForAll) return;
                   setSelectedCategories(prev => {
                     const next = new Set(prev);
                     if (next.has("NE")) {
@@ -3649,14 +3669,16 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   });
                 }}
                 className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
-                  selectedCategories.has("NE")
+                  neBlockedForAll
+                    ? "bg-white text-zinc-400 border border-zinc-200 opacity-60 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500 dark:border-zinc-700"
+                    : selectedCategories.has("NE")
                     ? "bg-zinc-500 text-white"
                     : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
                 }`}
-                title="Show Not Evaluated species from GBIF"
+                title={neBlockedForAll ? "Not Evaluated species must be loaded per taxon group — too many to load for All Species at once" : "Show Not Evaluated species from GBIF"}
               >
                 Not Evaluated
-                <span className="text-[10px] opacity-70">({neCount.toLocaleString()})</span>
+                {!neBlockedForAll && <span className="text-[10px] opacity-70">({neCount.toLocaleString()})</span>}
               </button>
             )}
           </div>

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -16,7 +16,8 @@ import { NODE_INDEX, getCsvGroupsForNode } from "@/lib/taxonomy-utils";
 import { canonicalizeTaxonId, mapTaxonId } from "@/lib/data/taxonomy-constants";
 import { getTaxaSummary } from "@/lib/data/species-store";
 import { isDynamicNodeId, dynamicNodeFilter } from "@/lib/dynamic-taxon";
-import { filterToSql } from "@/lib/taxonomy-sql";
+import { filterToSql, sqlStrList } from "@/lib/taxonomy-sql";
+import { COL_DOMESTIC_EXCLUDE_NAMES } from "@/config/col-described-overrides";
 
 const DATA_DIR = path.join(process.cwd(), "data");
 // Dev has the parquets on disk; on Vercel they aren't bundled → read from R2.
@@ -200,6 +201,18 @@ export function toSpeciesRow(r: Record<string, unknown>) {
 // otherwise surface as "not evaluated". Keep in sync with build-taxa-summary.
 const EXCLUDED_COL_IDS_SQL = `('6MB3T')`; // Homo sapiens
 
+// Domestic/feral forms (dog, cat, cattle, etc.) excluded from the NE universe here too —
+// each has a wild-form sibling species already counted separately (see
+// COL_DOMESTIC_EXCLUDE_NAMES's doc comment), so counting the domestic form as "Not
+// Evaluated" as well would double up. Matches build-taxa-summary.ts's colCountsByGroup,
+// whose precomputed col_ne this live count must agree with (#397 — Mammals showed 530
+// live vs. 520 precomputed, a gap of exactly these 10 names). Node-scoped queries that
+// go through filterToSql already exclude the wider COL_EXCLUDE_ALL_NODES (this list plus
+// the Bison SG name overrides) via whereSql, making this redundant-but-harmless for them;
+// this is the only exclusion applied for the taxon_group-partition fast path (top-level
+// taxa like "mammals"), which bypasses filterToSql entirely.
+const NOT_DOMESTIC_SQL = `coalesce(lower(scientific_name), '') NOT IN (${sqlStrList(COL_DOMESTIC_EXCLUDE_NAMES)})`;
+
 // Per-taxon_group not-evaluated counts from the precomputed taxa-summary (in memory),
 // used to decide tooLarge instantly without scanning species/ on R2.
 let neByGroupCache: Map<string, number> | null = null;
@@ -279,7 +292,7 @@ export async function querySpecies(opts: {
     // The NE list IS the CoL extant universe under the taxon, not already assessed
     // (minus the small EXCLUDED_COL_IDS denylist). species/ is partitioned by taxon_group,
     // so the SAME `whereSql` used for the assessed parquet filters + prunes it.
-    const univFilter = `${whereSql} AND in_base AND (extinct IS NOT TRUE OR col_id IN (SELECT col_id FROM ne_ex_ew_col_ids)) AND col_id NOT IN ${assessedColIds} AND col_id NOT IN ${EXCLUDED_COL_IDS_SQL}`;
+    const univFilter = `${whereSql} AND in_base AND (extinct IS NOT TRUE OR col_id IN (SELECT col_id FROM ne_ex_ew_col_ids)) AND col_id NOT IN ${assessedColIds} AND col_id NOT IN ${EXCLUDED_COL_IDS_SQL} AND ${NOT_DOMESTIC_SQL}`;
 
     // Count first (cheap). A giant aggregate (insects ~935k, invertebrates ~1.3M) exceeds
     // the cap — serializing it is a 250MB+ payload the browser can't load. Flag `tooLarge`


### PR DESCRIPTION
## Summary

- **Fix the live "Not Evaluated" count to match the precomputed table.** Mammals showed **530** Not Evaluated in the species list view but **520** in the Table 1a taxonomic breakdown. Root cause: `build-taxa-summary.ts`'s precomputed `col_ne` excludes 10 domesticated mammal forms (`COL_DOMESTIC_EXCLUDE_NAMES` — dog, cat, cattle, horse, pig, etc., each with a wild sibling species already counted separately), but the live `querySpecies` NE-universe query in `species-duckdb.ts` never applied that exclusion. Top-level nodes like "mammals" resolve via a fast `taxon_group`-only path that bypasses `filterToSql` (the only place the exclusion lived), so the 10 domestic forms leaked into the live count. Applied the same exclusion directly in `querySpecies`'s NE universe filter — verified live count now returns exactly 520, and other taxa (birds, reptiles, amphibians, fishes, plants, fungi) are unaffected (no domestic-name overlap).
- **Block the "Not Evaluated" pill when scoped to All Species.** All Species' NE universe (~1.8M species) exceeds `querySpecies`'s `NE_CAP`, so the fetch returned `tooLarge` with an empty species list — the pill just silently disappeared, while "NE" stayed stuck in the active category filter matching nothing. Now the pill stays visible but disabled with an explanatory tooltip, and switching to All Species automatically drops any active NE filter.

## Screenshots

Mammals scoped — Not Evaluated pill now shows 520, matching the table:

![Mammals NE pill](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-398-mammals-ne-count/01-mammals-520.png)

All Species scoped — pill is disabled (greyed out) instead of silently breaking:

![All Species NE pill blocked](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-398-mammals-ne-count/02-allspecies-blocked.png)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `eslint` on both changed files passes
- [x] Verified via API: `GET /api/redlist/species?taxon=mammals&category=NE` now returns 520 (was 530), matching `taxa-summary.json`'s `colNe`
- [x] Verified other taxa (birds, reptiles, amphibians, fishes, plants, fungi) unaffected by the domestic-name exclusion
- [x] Browser-verified (Playwright): Mammals-scoped pill shows "Not Evaluated (520)"; All-Species-scoped pill renders disabled with tooltip, click is a no-op, and any previously-active NE filter is auto-cleared when switching to All Species

🤖 Generated with [Claude Code](https://claude.com/claude-code)