### PR TITLE
Show ancestor breadcrumb rows when jumping to a taxon via search

### DIFF
--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { buildQs, type ViewMode } from "../hooks/useFilterParams";
 import { CATEGORY_COLORS } from "../config/taxa";
-import { findNode } from "../lib/taxonomy-utils";
+import { findNode, getViewRootForNode } from "../lib/taxonomy-utils";
 
 interface SearchResult {
   id: number;
@@ -20,11 +20,14 @@ interface SearchResult {
 }
 
 // A higher-rank taxon (class/order/family) the query matched — pinned above the
-// species hits. Selecting it browses the whole taxon via ?taxa=<taxon>.
+// species hits. Selecting it browses the whole taxon via ?taxa=<taxon>, or — when
+// nodeId resolved server-side — via the curated/dynamic node it corresponds to (see
+// selectTaxon), so the taxa-summary table's ancestor-breadcrumb rows populate too.
 interface TaxonSuggestion {
   name: string;
   rank: "class" | "order" | "family";
   taxon: string;
+  nodeId: string | null;
 }
 
 /**
@@ -151,20 +154,29 @@ export function SpeciesSearchBar() {
     []
   );
 
-  // Browse a whole higher-rank taxon (e.g. Felidae): navigate to ?taxa=<taxon> in the
-  // arbitrary-rank taxon flows through resolveWhere → querySpecies just like a
-  // curated node; no species is preselected. Preserve the current view: from the
-  // new-assessments view, browsing a taxon shows its not-evaluated species (charts
-  // come from the assessed/reassessments view).
+  // Browse a whole higher-rank taxon (e.g. Felidae). When suggestTaxa resolved a real
+  // node (nodeId) for it — a curated static node, or a well-formed dynamic drilldown
+  // id — select it as a display-root + sub-group pair, exactly like clicking through
+  // TaxaSummary's own tree would: this is what makes the ancestor-breadcrumb rows
+  // (Mammals → Carnivora → Felidae → ...) populate above the table, and gives the
+  // per-taxon stat card a proper curated label instead of the generic arbitrary-rank
+  // fallback. Otherwise (nodeId null) fall back to the old bare ?taxa=<taxon> browse,
+  // which still flows through resolveWhere → querySpecies just like a curated node,
+  // just without a resolvable tree position. No species is preselected either way.
+  // Preserve the current view: from the new-assessments view, browsing a taxon shows
+  // its not-evaluated species (charts come from the assessed/reassessments view).
   const selectTaxon = useCallback((t: TaxonSuggestion) => {
     const currentView: ViewMode =
       new URLSearchParams(window.location.search).get("view") === "new-assessments"
         ? "new-assessments"
         : "reassessments";
+    const viewRoot = t.nodeId ? getViewRootForNode(t.nodeId) : null;
+    const taxa = viewRoot ?? t.taxon;
+    const subgroup = viewRoot && t.nodeId !== viewRoot ? t.nodeId : null;
     const qs = buildQs({
       viewMode: currentView,
-      taxa: new Set([t.taxon]),
-      subgroups: new Set(),
+      taxa: new Set([taxa]),
+      subgroups: subgroup ? new Set([subgroup]) : new Set(),
       categories: new Set(),
       yearRanges: new Set(),
       assessmentYears: new Set(),

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -1436,6 +1436,19 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     }
   }, [countryKey]);
 
+  // A node's own summary comes from its PARENT's subgroupData bucket (that's what
+  // ensureSubgroupData(parentId) fetches — the parent's children, one of which is
+  // this node). So "has this node's real data arrived yet" is exactly "does the
+  // parent's bucket exist in subgroupData" — not yet present means either the fetch
+  // is still in flight or hasn't been dispatched yet, both of which read the same to
+  // the user (show a loading state, not a misleading zero). The immediate parent
+  // (getAncestors(id)[0]) is the right bucket regardless of static or dynamic id —
+  // both delegate through the same getAncestors contract.
+  const isSummaryPending = useCallback((id: string): boolean => {
+    const parentId = getAncestors(id)[0];
+    return parentId != null && !(parentId in subgroupData);
+  }, [subgroupData]);
+
   // Fetch subgroup data when a taxon is expanded
   const toggleExpand = useCallback(async (taxonId: string) => {
     setExpandedTaxa((prev) => {
@@ -1933,6 +1946,19 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     );
   };
 
+  // Same footprint as renderBar (count/bar/percent), but a pulsing skeleton instead
+  // of real numbers — used in place of renderBar for a breadcrumb/collapsed row whose
+  // summary hasn't streamed in yet (see isSummaryPending), so a still-loading
+  // Assessed/Outdated/Not-Evaluated cell doesn't flash a misleading "0" for the
+  // several seconds a live-drilldown fetch can take.
+  const renderPendingBar = () => (
+    <div className="flex items-center gap-1.5 sm:gap-3 min-w-[150px] sm:min-w-[230px] md:min-w-[250px]">
+      <div className="w-[48px] sm:w-[60px] h-3.5 sm:h-2.5 rounded bg-zinc-200 dark:bg-zinc-700 animate-pulse flex-shrink-0" />
+      <div className="flex-1 min-w-[40px] h-3.5 sm:h-2.5 rounded-full bg-zinc-200 dark:bg-zinc-700 animate-pulse" />
+      <div className="w-[44px] sm:w-[52px] h-3.5 sm:h-2.5 rounded bg-zinc-200 dark:bg-zinc-700 animate-pulse flex-shrink-0" />
+    </div>
+  );
+
   // Render a stacked category breakdown bar
   const renderBreakdownBar = (byCategory: Record<string, number>) => {
     const total = Object.values(byCategory).reduce((sum, n) => sum + n, 0);
@@ -2208,7 +2234,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
   };
 
   // Render an ancestor context row with full data — clicking navigates to that level.
-  const renderAncestorRow = (sg: SubGroupSummary, color: string, depth: number, topTaxonId: string, isViewRoot: boolean) => {
+  const renderAncestorRow = (sg: SubGroupSummary, color: string, depth: number, topTaxonId: string, isViewRoot: boolean, isPending = false) => {
     const { value: sgDescribed, source: sgDescribedSource } = resolveDescribed(sg.id, sg.estimatedDescribed, sg.colDescribed);
     const sgPctAssessed = sgDescribed > 0 ? (sg.totalAssessed / sgDescribed) * 100 : 0;
     const sgPctOutdated = sg.totalAssessed > 0 ? (sg.outdated / sg.totalAssessed) * 100 : 0;
@@ -2260,30 +2286,38 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         </td>
         {isVisible("described") && (
           <td className={numericTdNoDividerClasses}>
-            <span className="text-sm text-zinc-700 dark:text-zinc-300 tabular-nums inline-flex items-center gap-1">
-              {sgDescribed.toLocaleString()}
-              <DescribedInfoIcon nodeId={sg.id} source={sgDescribedSource} breakdown={sg.colBreakdown} />
-            </span>
+            {isPending && sgDescribed === 0 ? (
+              <span className="inline-block w-12 h-3.5 rounded bg-zinc-200 dark:bg-zinc-700 animate-pulse" />
+            ) : (
+              <span className="text-sm text-zinc-700 dark:text-zinc-300 tabular-nums inline-flex items-center gap-1">
+                {sgDescribed.toLocaleString()}
+                <DescribedInfoIcon nodeId={sg.id} source={sgDescribedSource} breakdown={sg.colBreakdown} />
+              </span>
+            )}
           </td>
         )}
         {colDescribedCell(sg.colDescribed)}
         {isVisible("assessed") && (
           <td className={flexTdClasses}>
-            {renderBar(sgPctAssessed, getAssessedBarColor(sgPctAssessed), false, sg.totalAssessed)}
+            {isPending ? renderPendingBar() : renderBar(sgPctAssessed, getAssessedBarColor(sgPctAssessed), false, sg.totalAssessed)}
           </td>
         )}
         {isVisible("outdated") && (
           <td className={flexTdClasses}>
-            {sg.totalAssessed > 0
-              ? renderBar(sgPctOutdated, getOutdatedBarColor(sgPctOutdated), false, sg.outdated)
-              : <span className="text-sm text-zinc-400">—</span>}
+            {isPending
+              ? renderPendingBar()
+              : sg.totalAssessed > 0
+                ? renderBar(sgPctOutdated, getOutdatedBarColor(sgPctOutdated), false, sg.outdated)
+                : <span className="text-sm text-zinc-400">—</span>}
           </td>
         )}
         {isVisible("gbifUnassessed") && (
           <td className={flexTdClasses}>
-            {sg.gbifNeSpeciesCount > 0 && sgDescribed > 0
-              ? renderBar((sg.gbifNeSpeciesCount / sgDescribed) * 100, "#3b82f6", false, sg.gbifNeSpeciesCount)
-              : <span className="text-sm text-zinc-400">—</span>}
+            {isPending
+              ? renderPendingBar()
+              : sg.gbifNeSpeciesCount > 0 && sgDescribed > 0
+                ? renderBar((sg.gbifNeSpeciesCount / sgDescribed) * 100, "#3b82f6", false, sg.gbifNeSpeciesCount)
+                : <span className="text-sm text-zinc-400">—</span>}
           </td>
         )}
         {colNeCell(sg.colNe, sgDescribed)}
@@ -2309,7 +2343,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
   };
 
   // Render a standalone subgroup row (used when table is collapsed to a selected subgroup)
-  const renderCollapsedSubgroupRow = (taxon: TaxonSummary, sg: SubGroupSummary, depth: number) => {
+  const renderCollapsedSubgroupRow = (taxon: TaxonSummary, sg: SubGroupSummary, depth: number, isPending = false) => {
     const { value: sgDescribed, source: sgDescribedSource } = resolveDescribed(sg.id, sg.estimatedDescribed, sg.colDescribed);
     const sgPctAssessed = sgDescribed > 0 ? (sg.totalAssessed / sgDescribed) * 100 : 0;
     const sgPctOutdated = sg.totalAssessed > 0 ? (sg.outdated / sg.totalAssessed) * 100 : 0;
@@ -2345,30 +2379,38 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         </td>
         {isVisible("described") && (
           <td className={numericTdNoDividerClasses}>
-            <span className="text-sm md:text-base text-zinc-700 dark:text-zinc-300 tabular-nums inline-flex items-center gap-1">
-              {sgDescribed.toLocaleString()}
-              <DescribedInfoIcon nodeId={sg.id} source={sgDescribedSource} breakdown={sg.colBreakdown} />
-            </span>
+            {isPending && sgDescribed === 0 ? (
+              <span className="inline-block w-12 h-3.5 rounded bg-zinc-200 dark:bg-zinc-700 animate-pulse" />
+            ) : (
+              <span className="text-sm md:text-base text-zinc-700 dark:text-zinc-300 tabular-nums inline-flex items-center gap-1">
+                {sgDescribed.toLocaleString()}
+                <DescribedInfoIcon nodeId={sg.id} source={sgDescribedSource} breakdown={sg.colBreakdown} />
+              </span>
+            )}
           </td>
         )}
         {colDescribedCell(sg.colDescribed)}
         {isVisible("assessed") && (
           <td className={flexTdClasses}>
-            {renderBar(sgPctAssessed, getAssessedBarColor(sgPctAssessed), false, sg.totalAssessed)}
+            {isPending ? renderPendingBar() : renderBar(sgPctAssessed, getAssessedBarColor(sgPctAssessed), false, sg.totalAssessed)}
           </td>
         )}
         {isVisible("outdated") && (
           <td className={flexTdClasses}>
-            {sg.totalAssessed > 0
-              ? renderBar(sgPctOutdated, getOutdatedBarColor(sgPctOutdated), false, sg.outdated)
-              : <span className="text-sm text-zinc-400">—</span>}
+            {isPending
+              ? renderPendingBar()
+              : sg.totalAssessed > 0
+                ? renderBar(sgPctOutdated, getOutdatedBarColor(sgPctOutdated), false, sg.outdated)
+                : <span className="text-sm text-zinc-400">—</span>}
           </td>
         )}
         {isVisible("gbifUnassessed") && (
           <td className={flexTdClasses}>
-            {sg.gbifNeSpeciesCount > 0 && sgDescribed > 0
-              ? renderBar((sg.gbifNeSpeciesCount / sgDescribed) * 100, "#3b82f6", false, sg.gbifNeSpeciesCount)
-              : <span className="text-sm text-zinc-400">—</span>}
+            {isPending
+              ? renderPendingBar()
+              : sg.gbifNeSpeciesCount > 0 && sgDescribed > 0
+                ? renderBar((sg.gbifNeSpeciesCount / sgDescribed) * 100, "#3b82f6", false, sg.gbifNeSpeciesCount)
+                : <span className="text-sm text-zinc-400">—</span>}
           </td>
         )}
         {colNeCell(sg.colNe, sgDescribed)}
@@ -3254,7 +3296,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
                               return;
                             }
                           }
-                          rows.push(renderAncestorRow(ancestorData, parentTaxon.color, i + 1, parentTaxon.id, false));
+                          rows.push(renderAncestorRow(ancestorData, parentTaxon.color, i + 1, parentTaxon.id, false, isSummaryPending(aId)));
                         });
 
                         // Search ALL fetched subgroup data for this node (any depth)
@@ -3283,7 +3325,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
                         // there are none, i.e. sgId is a direct child of the
                         // view root, e.g. Rodentia under Mammals).
                         const selectedDepth = intermediateAncestorIds.length + 1;
-                        rows.push(renderCollapsedSubgroupRow(parentTaxon, sgData, selectedDepth));
+                        rows.push(renderCollapsedSubgroupRow(parentTaxon, sgData, selectedDepth, isSummaryPending(sgId)));
                         // Render children if expanded — one step further still.
                         // renderSubgroupRow's own paddingLeft formula is
                         // `(depth-1)*12`, so to land one indent past

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -15,7 +15,7 @@ import { DuckDBInstance, type DuckDBConnection } from "@duckdb/node-api";
 import { NODE_INDEX, getCsvGroupsForNode } from "@/lib/taxonomy-utils";
 import { canonicalizeTaxonId, mapTaxonId } from "@/lib/data/taxonomy-constants";
 import { getTaxaSummary } from "@/lib/data/species-store";
-import { isDynamicNodeId, dynamicNodeFilter } from "@/lib/dynamic-taxon";
+import { isDynamicNodeId, dynamicNodeFilter, buildDynamicNodeId, nextDynamicRank } from "@/lib/dynamic-taxon";
 import { filterToSql } from "@/lib/taxonomy-sql";
 
 const DATA_DIR = path.join(process.cwd(), "data");
@@ -657,8 +657,51 @@ export interface TaxonSuggestion {
   name: string;
   /** Rank the query matched at. */
   rank: "class" | "order" | "family";
-  /** Lowercased token to pass as ?taxa= (what resolveWhere/querySpecies match on). */
+  /** Lowercased token to pass as ?taxa= (what resolveWhere/querySpecies match on) —
+   * kept as the fallback when nodeId can't be resolved. */
   taxon: string;
+  /** A curated static node id (e.g. "felidae") or a synthetic dynamic drilldown id
+   * (e.g. "reptiles~order:squamata") this rank+value resolves to, or null if neither
+   * — in which case the caller falls back to the old bare `taxon` browse. Resolving
+   * to a real node means the caller can select it as a sub-group (selectedSubgroups)
+   * instead of an arbitrary ?taxa= token, so TaxaSummary's ancestor-breadcrumb rows
+   * and the per-taxon stat card both pick it up for free (see resolveTaxonSuggestionNode). */
+  nodeId: string | null;
+}
+
+// rank+value → a curated static node whose filter is EXACTLY that one class/order/family
+// dimension (a single value, no other filters/exclusions) — the same node a user reaches
+// by clicking through the tree, so a search jump to it gets full ancestor breadcrumbs and
+// curated labels for free. Mirrors GROUP_TO_LEAF_NODE's single-dimension-match pattern above.
+const RANK_VALUE_TO_NODE: Map<string, string> = (() => {
+  const m = new Map<string, string>();
+  const DIMS = ["classNames", "orderNames", "families"] as const;
+  for (const [id, node] of NODE_INDEX) {
+    const f = node.filter;
+    const dims = DIMS.filter((k) => f[k]?.length);
+    if (dims.length !== 1 || f[dims[0]]!.length !== 1) continue;
+    if (f.excludeClasses || f.excludeOrders || f.excludeFamilies || f.genera || f.excludeGenera ||
+        f.speciesNames || f.excludeSpeciesNames || f.extraSpeciesNames) continue;
+    const rank = dims[0] === "classNames" ? "class" : dims[0] === "orderNames" ? "order" : "family";
+    const key = `${rank}:${f[dims[0]]![0]}`;
+    if (!m.has(key)) m.set(key, id);
+  }
+  return m;
+})();
+
+// Resolves a suggestTaxa match to a real node: a curated static node if one matches
+// exactly, else a single-segment dynamic id built against the CSV group's leaf display
+// node — but only when this rank is genuinely the FIRST live-enumerable level for that
+// root (nextDynamicRank on the bare root), so the id is well-formed for later expansion.
+// A "family" match under a root that drills order-first (the common case) would produce
+// a malformed skip-ahead id if built here, so it's left null and falls back to the bare
+// ?taxa= browse instead — no ancestor breadcrumb for that one, but no broken node either.
+function resolveTaxonSuggestionNode(rank: TaxonSuggestion["rank"], value: string, taxonGroup: string): string | null {
+  const staticHit = RANK_VALUE_TO_NODE.get(`${rank}:${value}`);
+  if (staticHit) return staticHit;
+  const leafRoot = GROUP_TO_LEAF_NODE.get(taxonGroup);
+  if (!leafRoot || nextDynamicRank(leafRoot) !== rank) return null;
+  return buildDynamicNodeId(leafRoot, [{ rank, value }]);
 }
 
 // Recognize a higher-rank taxon (class / order / family) the user is typing, so the
@@ -680,7 +723,7 @@ export async function suggestTaxa(query: string, limit = 3): Promise<TaxonSugges
     { col: "class_name", rank: "class" },
   ];
   const part = (src: string, col: string, rank: string) =>
-    `SELECT DISTINCT ${col} AS name, '${rank}' AS rank FROM '${parquetUri(src)}'
+    `SELECT DISTINCT ${col} AS name, '${rank}' AS rank, taxon_group FROM '${parquetUri(src)}'
      WHERE ${col} IS NOT NULL AND ${col} LIKE $q || '%'`;
   const parts = RANKS.flatMap(({ col, rank }) =>
     [part("assessed.parquet", col, rank), part("unassessed.parquet", col, rank)]);
@@ -688,17 +731,20 @@ export async function suggestTaxa(query: string, limit = 3): Promise<TaxonSugges
   // Exact match first, then shortest (closest) name, then alphabetical. DISTINCT in the
   // sub-selects collapses per-file dupes; the outer query dedupes across ranks by name.
   const sql = `
-    SELECT name, any_value(rank) AS rank FROM (${parts.join(" UNION ALL ")})
+    SELECT name, any_value(rank) AS rank, any_value(taxon_group) AS taxon_group
+    FROM (${parts.join(" UNION ALL ")})
     GROUP BY name
     ORDER BY (name = $q) DESC, length(name), name
     LIMIT ${lim}`;
   const rows = (await conn.runAndReadAll(sql, { q })).getRowObjects();
   return rows.map((r) => {
     const name = String(r.name);
+    const rank = String(r.rank) as TaxonSuggestion["rank"];
     return {
       name: name.charAt(0).toUpperCase() + name.slice(1),
-      rank: String(r.rank) as TaxonSuggestion["rank"],
+      rank,
       taxon: name,
+      nodeId: resolveTaxonSuggestionNode(rank, name, String(r.taxon_group)),
     };
   });
 }

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -12,10 +12,10 @@
 import * as fs from "fs";
 import * as path from "path";
 import { DuckDBInstance, type DuckDBConnection } from "@duckdb/node-api";
-import { NODE_INDEX, getCsvGroupsForNode } from "@/lib/taxonomy-utils";
+import { NODE_INDEX, getCsvGroupsForNode, getAncestors } from "@/lib/taxonomy-utils";
 import { canonicalizeTaxonId, mapTaxonId } from "@/lib/data/taxonomy-constants";
 import { getTaxaSummary } from "@/lib/data/species-store";
-import { isDynamicNodeId, dynamicNodeFilter, buildDynamicNodeId, nextDynamicRank } from "@/lib/dynamic-taxon";
+import { isDynamicNodeId, dynamicNodeFilter, buildDynamicNodeId, rankOrderFor, type DynamicSegment } from "@/lib/dynamic-taxon";
 import { filterToSql } from "@/lib/taxonomy-sql";
 
 const DATA_DIR = path.join(process.cwd(), "data");
@@ -660,23 +660,40 @@ export interface TaxonSuggestion {
   /** Lowercased token to pass as ?taxa= (what resolveWhere/querySpecies match on) —
    * kept as the fallback when nodeId can't be resolved. */
   taxon: string;
-  /** A curated static node id (e.g. "felidae") or a synthetic dynamic drilldown id
-   * (e.g. "reptiles~order:squamata") this rank+value resolves to, or null if neither
-   * — in which case the caller falls back to the old bare `taxon` browse. Resolving
-   * to a real node means the caller can select it as a sub-group (selectedSubgroups)
-   * instead of an arbitrary ?taxa= token, so TaxaSummary's ancestor-breadcrumb rows
-   * and the per-taxon stat card both pick it up for free (see resolveTaxonSuggestionNode). */
+  /** A curated by-taxon node id or a synthetic dynamic drilldown id (e.g.
+   * "reptiles~order:squamata", or a multi-segment "crustaceans~class:malacostraca~
+   * order:isopoda") this rank+value resolves to, or null if neither — in which case
+   * the caller falls back to the old bare `taxon` browse. Resolving to a real node
+   * means the caller can select it as a sub-group (selectedSubgroups) instead of an
+   * arbitrary ?taxa= token, so TaxaSummary's ancestor-breadcrumb rows and the
+   * per-taxon stat card both pick it up for free (see resolveTaxonSuggestionNode).
+   * Deliberately never an SSC Specialist Group node — those are a second, independent
+   * lens over the same species (see taxonomy-tree.ts's "SSC SPECIALIST GROUPS"
+   * section) reachable only via SSC groups mode, not a substitute for the plain
+   * by-taxon node a tree-click would reach. */
   nodeId: string | null;
 }
 
-// rank+value → a curated static node whose filter is EXACTLY that one class/order/family
-// dimension (a single value, no other filters/exclusions) — the same node a user reaches
-// by clicking through the tree, so a search jump to it gets full ancestor breadcrumbs and
-// curated labels for free. Mirrors GROUP_TO_LEAF_NODE's single-dimension-match pattern above.
+// SSC Specialist Group nodes (taxonomy-tree.ts's "ssc-groups"/"ssc-reptile-groups"/etc.
+// containers and their children) all use the "ssc-" id prefix by convention; the
+// ancestor-chain check is a defensive backstop in case a future group's id doesn't
+// follow it. suggestTaxa must never resolve a search hit to one of these — see
+// TaxonSuggestion.nodeId's doc comment.
+function isSscGroupNode(id: string): boolean {
+  if (id.startsWith("ssc-")) return true;
+  return getAncestors(id).some((a) => a.startsWith("ssc-"));
+}
+
+// rank+value → a curated by-taxon node whose filter is EXACTLY that one class/order/family
+// dimension (a single value, no other filters/exclusions), excluding SSC Specialist Group
+// nodes — the same node a user reaches by clicking through the default tree, so a search
+// jump to it gets full ancestor breadcrumbs and curated labels for free. Mirrors
+// GROUP_TO_LEAF_NODE's single-dimension-match pattern above.
 const RANK_VALUE_TO_NODE: Map<string, string> = (() => {
   const m = new Map<string, string>();
   const DIMS = ["classNames", "orderNames", "families"] as const;
   for (const [id, node] of NODE_INDEX) {
+    if (isSscGroupNode(id)) continue;
     const f = node.filter;
     const dims = DIMS.filter((k) => f[k]?.length);
     if (dims.length !== 1 || f[dims[0]]!.length !== 1) continue;
@@ -689,19 +706,57 @@ const RANK_VALUE_TO_NODE: Map<string, string> = (() => {
   return m;
 })();
 
-// Resolves a suggestTaxa match to a real node: a curated static node if one matches
-// exactly, else a single-segment dynamic id built against the CSV group's leaf display
-// node — but only when this rank is genuinely the FIRST live-enumerable level for that
-// root (nextDynamicRank on the bare root), so the id is well-formed for later expansion.
-// A "family" match under a root that drills order-first (the common case) would produce
-// a malformed skip-ahead id if built here, so it's left null and falls back to the bare
-// ?taxa= browse instead — no ancestor breadcrumb for that one, but no broken node either.
-function resolveTaxonSuggestionNode(rank: TaxonSuggestion["rank"], value: string, taxonGroup: string): string | null {
+const RANK_TO_COLUMN: Record<TaxonSuggestion["rank"], string> = {
+  class: "class_name", order: "order_name", family: "family",
+};
+
+// Resolves a suggestTaxa match to a real node: a curated by-taxon node if one matches
+// exactly (never an SSC Specialist Group node — see isSscGroupNode), else a dynamic
+// drilldown id built against the CSV group's leaf display node. A dynamic id needs every
+// rank from the root's first live-enumerable level down to the matched one, in order
+// (e.g. Isopoda is an "order" match, but Crustaceans drills class-first, so the id needs
+// a class:<value> segment before order:isopoda) — dynamicNodeFilter ANDs each segment's
+// field independently, so a single skip-ahead segment would still filter species
+// correctly, but would leave nextDynamicRank/dynamicNodeAncestors reading the wrong depth
+// for further expansion and ancestor rows. The extra rank value(s) come from one small
+// lookup against a representative row (cheap: at most 2 columns, exact-match on already-
+// warm parquets, LIMIT 1). Falls back to null (old bare ?taxa= browse) only if the root
+// isn't live-drillable at all, or an ancestor rank's lookup comes back empty.
+async function resolveTaxonSuggestionNode(
+  conn: DuckDBConnection, rank: TaxonSuggestion["rank"], value: string, taxonGroup: string,
+): Promise<string | null> {
   const staticHit = RANK_VALUE_TO_NODE.get(`${rank}:${value}`);
   if (staticHit) return staticHit;
   const leafRoot = GROUP_TO_LEAF_NODE.get(taxonGroup);
-  if (!leafRoot || nextDynamicRank(leafRoot) !== rank) return null;
-  return buildDynamicNodeId(leafRoot, [{ rank, value }]);
+  if (!leafRoot) return null;
+  const order = rankOrderFor(leafRoot);
+  const idx = order.indexOf(rank);
+  if (idx === -1) return null;
+  const segments: DynamicSegment[] = [];
+  if (idx > 0) {
+    // genus is always last in rankOrderFor's list, and idx points at class/order/family
+    // (suggestTaxa never matches genus), so a rank strictly before idx can never be
+    // "genus" — safe to narrow to TaxonSuggestion["rank"] for the RANK_TO_COLUMN lookup.
+    const priorRanks = order.slice(0, idx) as TaxonSuggestion["rank"][];
+    const cols = priorRanks.map((r) => RANK_TO_COLUMN[r]);
+    const matchCol = RANK_TO_COLUMN[rank];
+    const sql = `
+      SELECT ${cols.join(", ")} FROM (
+        SELECT ${cols.join(", ")} FROM '${parquetUri("assessed.parquet")}' WHERE ${matchCol} = $v AND taxon_group = $tg
+        UNION ALL
+        SELECT ${cols.join(", ")} FROM '${parquetUri("unassessed.parquet")}' WHERE ${matchCol} = $v AND taxon_group = $tg
+      ) LIMIT 1`;
+    const rows = (await conn.runAndReadAll(sql, { v: value, tg: taxonGroup })).getRowObjects();
+    if (rows.length === 0) return null;
+    for (const r of priorRanks) {
+      const v = rows[0][RANK_TO_COLUMN[r]];
+      // Coalesce a null ancestor rank to "" — the Unclassified bucket for that rank,
+      // same convention filterToSql/matchesFilter already use, not an error case.
+      segments.push({ rank: r, value: v == null ? "" : String(v).toLowerCase() });
+    }
+  }
+  segments.push({ rank, value });
+  return buildDynamicNodeId(leafRoot, segments);
 }
 
 // Recognize a higher-rank taxon (class / order / family) the user is typing, so the
@@ -737,14 +792,14 @@ export async function suggestTaxa(query: string, limit = 3): Promise<TaxonSugges
     ORDER BY (name = $q) DESC, length(name), name
     LIMIT ${lim}`;
   const rows = (await conn.runAndReadAll(sql, { q })).getRowObjects();
-  return rows.map((r) => {
+  return Promise.all(rows.map(async (r) => {
     const name = String(r.name);
     const rank = String(r.rank) as TaxonSuggestion["rank"];
     return {
       name: name.charAt(0).toUpperCase() + name.slice(1),
       rank,
       taxon: name,
-      nodeId: resolveTaxonSuggestionNode(rank, name, String(r.taxon_group)),
+      nodeId: await resolveTaxonSuggestionNode(conn, rank, name, String(r.taxon_group)),
     };
-  });
+  }));
 }

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -12,7 +12,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { DuckDBInstance, type DuckDBConnection } from "@duckdb/node-api";
-import { NODE_INDEX, getCsvGroupsForNode, getAncestors } from "@/lib/taxonomy-utils";
+import { NODE_INDEX, getCsvGroupsForNode, getAncestors, stripNodePrefix } from "@/lib/taxonomy-utils";
 import { canonicalizeTaxonId, mapTaxonId } from "@/lib/data/taxonomy-constants";
 import { getTaxaSummary } from "@/lib/data/species-store";
 import { isDynamicNodeId, dynamicNodeFilter, buildDynamicNodeId, rankOrderFor, type DynamicSegment } from "@/lib/dynamic-taxon";
@@ -723,15 +723,72 @@ const RANK_TO_COLUMN: Record<TaxonSuggestion["rank"], string> = {
   class: "class_name", order: "order_name", family: "family",
 };
 
+// Same single-dimension-match search as GROUP_TO_LEAF_NODE above, but prefers a group's
+// "inv-"/"pl-"/"fu-"-prefixed virtual-duplicate id over its bare one when both exist for
+// the same csvGroup (insects/molluscs/crustaceans/etc. — see dynamic-taxon.ts's
+// DYNAMIC_DRILLDOWN_ROOTS comment). The prefixed id is the one actually nested under
+// invertebrates/plantae/fungi in the default "By Taxon" view that TaxaSummary's
+// ancestor-breadcrumb rendering and this search feature both operate within; the bare id
+// is Table1a mode's separate flat id, whose own ancestor is "all" directly (not
+// invertebrates/plantae/fungi) — a dynamic id built off it resolves to the right species
+// (csvGroups is identical either way) but its ancestor chain doesn't match the id
+// TaxaSummary's precomputed children-summaries use for that group, so the breadcrumb row
+// fails to find its own data and renders a zeroed placeholder (confirmed via a live repro:
+// searching "isopoda" showed "Crustaceans 0 assessed" instead of the real ~3,410 — the
+// exact bug class collapseTaxaToTokens's isDynamicNodeId check fixed elsewhere in this
+// file's git history). GROUP_TO_LEAF_NODE itself must stay bare-preferring: its other
+// callers (querySpecies's search-result rows) set a plain ?taxa= root with no sub-group,
+// where the bare Table1a id is exactly right and no breadcrumb is ever attempted.
+//
+// Unlike GROUP_TO_LEAF_NODE, this is a function (not a precomputed map): a group
+// doesn't always have its own single-csvGroup leaf node (Insects has none — its 8
+// Table 1a groups, beetles/butterflies/etc., only ever appear together under one
+// umbrella node with csvGroups: ALL_INSECT_GROUPS; the per-order split is live-only),
+// so this also has to fall back to the smallest umbrella node whose csvGroups
+// includes the target group. A first-match memo (like GROUP_TO_LEAF_NODE's) would
+// silently return whichever node NODE_INDEX iteration happened to visit first — for
+// Insects that was briefly "ssc-dung-beetle" (an SSC node scoped to just Coleoptera
+// genera, but nothing here checked `genera`/`speciesNames`/etc., only the class/
+// order/family dimensions RANK_VALUE_TO_NODE cares about) before this was rewritten
+// to scan every candidate and pick deliberately, not first-found. Memoized (NODE_INDEX
+// is built once at import time and never changes) since this can run once per
+// suggestion per search request.
+const viewLeafForGroupCache = new Map<string, string | null>();
+function findViewLeafForGroup(taxonGroup: string): string | null {
+  const cached = viewLeafForGroupCache.get(taxonGroup);
+  if (cached !== undefined) return cached;
+  let best: { id: string; size: number } | null = null;
+  for (const [id, node] of NODE_INDEX) {
+    if (isSscGroupNode(id)) continue;
+    const f = node.filter;
+    if (!f.csvGroups.includes(taxonGroup)) continue;
+    // Only a node with NO OTHER filter dimension at all qualifies — anything else is
+    // a curated sub-split of the group (a static family/order node, or a Specialist
+    // Group carved out some other way, e.g. by genera/speciesNames), not the group's
+    // own top-level container.
+    if (f.classNames || f.orderNames || f.families || f.genera || f.excludeClasses ||
+        f.excludeOrders || f.excludeFamilies || f.excludeGenera || f.speciesNames ||
+        f.excludeSpeciesNames || f.extraSpeciesNames) continue;
+    const size = f.csvGroups.length;
+    const prefersOverBest = !best || size < best.size ||
+      (size === best.size && stripNodePrefix(id) !== id && stripNodePrefix(best.id) === best.id);
+    if (prefersOverBest) best = { id, size };
+  }
+  const result = best?.id ?? null;
+  viewLeafForGroupCache.set(taxonGroup, result);
+  return result;
+}
+
 // Resolves a suggestTaxa match to a real node: a curated by-taxon node if one matches
 // exactly (never an SSC Specialist Group node — see isSscGroupNode), else a dynamic
-// drilldown id built against the CSV group's leaf display node. A dynamic id needs every
-// rank from the root's first live-enumerable level down to the matched one, in order
-// (e.g. Isopoda is an "order" match, but Crustaceans drills class-first, so the id needs
-// a class:<value> segment before order:isopoda) — dynamicNodeFilter ANDs each segment's
-// field independently, so a single skip-ahead segment would still filter species
-// correctly, but would leave nextDynamicRank/dynamicNodeAncestors reading the wrong depth
-// for further expansion and ancestor rows. The extra rank value(s) come from one small
+// drilldown id built against the CSV group's leaf display node (its "By Taxon"-view
+// variant — see findViewLeafForGroup). A dynamic id needs every rank from the root's
+// first live-enumerable level down to the matched one, in order (e.g. Isopoda is an
+// "order" match, but Crustaceans drills class-first, so the id needs a class:<value>
+// segment before order:isopoda) — dynamicNodeFilter ANDs each segment's field
+// independently, so a single skip-ahead segment would still filter species correctly,
+// but would leave nextDynamicRank/dynamicNodeAncestors reading the wrong depth for
+// further expansion and ancestor rows. The extra rank value(s) come from one small
 // lookup against a representative row (cheap: at most 2 columns, exact-match on already-
 // warm parquets, LIMIT 1). Falls back to null (old bare ?taxa= browse) only if the root
 // isn't live-drillable at all, or an ancestor rank's lookup comes back empty.
@@ -740,7 +797,7 @@ async function resolveTaxonSuggestionNode(
 ): Promise<string | null> {
   const staticHit = RANK_VALUE_TO_NODE.get(`${rank}:${value}`);
   if (staticHit) return staticHit;
-  const leafRoot = GROUP_TO_LEAF_NODE.get(taxonGroup);
+  const leafRoot = findViewLeafForGroup(taxonGroup);
   if (!leafRoot) return null;
   const order = rankOrderFor(leafRoot);
   const idx = order.indexOf(rank);

--- a/app/src/lib/dynamic-taxon.ts
+++ b/app/src/lib/dynamic-taxon.ts
@@ -3,10 +3,11 @@
  * chain grafted onto one of the static default-view roots, e.g.
  * "mammals~order:rodentia~family:muridae". `~` never appears in a real static
  * node id (taxonomy-tree.ts ids are all lowercase-hyphen), so isDynamicNodeId is
- * unambiguous and never collides with NODE_INDEX or the unrelated bare-token
- * arbitrary-rank search feature (species-duckdb.ts's resolveWhere/suggestTaxa,
- * used by the search bar to jump straight to e.g. "turdidae" as a root
- * selection — untouched by this module).
+ * unambiguous and never collides with NODE_INDEX or the bare-token arbitrary-rank
+ * search feature (species-duckdb.ts's resolveWhere, used as a fallback when a
+ * search-bar taxon suggestion can't be resolved to a real node — see
+ * suggestTaxa/resolveTaxonSuggestionNode, which DOES build ids via this module's
+ * buildDynamicNodeId/nextDynamicRank when a match resolves to one).
  *
  * matchesFilter/filterToSql already support multiple simultaneous positive
  * dimensions ANDed together and already coalesce null order_name/family to ""

--- a/app/src/lib/dynamic-taxon.ts
+++ b/app/src/lib/dynamic-taxon.ts
@@ -63,7 +63,11 @@ const ROOT_RANK_ORDER: Record<string, DynamicRank[]> = {
   other_invertebrates: CLASS_FIRST_RANK_ORDER,
   "inv-other_invertebrates": CLASS_FIRST_RANK_ORDER,
 };
-function rankOrderFor(rootId: string): DynamicRank[] {
+/** The rank sequence a root drills through (e.g. ["order","family","genus"], or
+ *  ["class","order","family","genus"] for a class-first root) — exported so a
+ *  caller building a multi-segment id from a single matched rank (e.g. search's
+ *  resolveTaxonSuggestionNode) knows which ranks must come before it in the chain. */
+export function rankOrderFor(rootId: string): DynamicRank[] {
   return ROOT_RANK_ORDER[rootId] ?? DEFAULT_RANK_ORDER;
 }
 


### PR DESCRIPTION
## Summary
- Searching a class/order/family (the "Browse Felidae →" suggestion) previously navigated to a bare, unresolvable `?taxa=<name>` token — so TaxaSummary's ancestor-breadcrumb rows (the tree branch leading down to the node, e.g. Mammals → Carnivora → Felidae) never showed, unlike drilling in via clicking through the tree. Only the "All Species" row appeared.
- `suggestTaxa` now resolves each match to a real by-taxon node: a curated static node if one matches that single dimension exactly, else a dynamic drilldown id built by fetching the full ancestor rank chain (e.g. Isopoda, an order under Crustaceans' class-first drilldown, resolves to `inv-crustaceans~class:malacostraca~order:isopoda`; Felidae resolves to `mammals~order:carnivora~family:felidae`; Coleoptera, one of 8 Table 1a groups sharing one Insects umbrella node, resolves to `inv-insects~order:coleoptera`).
- **Explicitly excludes SSC Specialist Group nodes** — those are a second, independent lens over the same species (reachable only via SSC groups mode), not a substitute for the plain by-taxon node a tree-click would reach.
- **Uses the correct "By Taxon" view node id**, not the bare Table1a-mode id — several groups (Crustaceans, Molluscs, Insects, etc.) have both, and only the `inv-`/`pl-`/`fu-`-prefixed one is actually nested under Invertebrates/Plantae/Fungi in the default view; the bare one's ancestor is "all" directly, so a dynamic id built off it produced a lookup miss and a permanently-zeroed ancestor row.
- **Handles umbrella groups** — Insects has no single-csvGroup leaf node of its own (its 8 Table 1a groups share one node); the resolver picks the smallest non-SSC node whose csvGroups covers the target, falling back to the umbrella when no single-group leaf exists.
- **Loading state**: while an ancestor row's live summary is still streaming in (a few seconds for a deep live-drilldown chain), it now shows a pulsing skeleton instead of a misleading "0 assessed" / "0.0%" — added `isSummaryPending` (checks whether the node's parent's subgroup-summary fetch has landed yet) and a `renderPendingBar` skeleton, wired into both the ancestor rows and the selected node's own row.
- The search bar selects the resolved node as a display-root + sub-group pair — exactly like a tree click would — so the breadcrumb rows and the per-taxon stat card's curated label come for free.
- Falls back to the old bare-name browse, unchanged, only if the root isn't live-drillable at all.

## Screenshots

Searching "felidae" → `mammals~order:carnivora~family:felidae`, full by-taxon breadcrumb, no SSC group involved:

![Felidae search result](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-400-taxon-search-breadcrumb/01-felidae-search.png)

Searching "isopoda" → `inv-crustaceans~class:malacostraca~order:isopoda`, full chain through the class-first Crustacean drilldown, correct live counts at every level:

![Isopoda search result](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-400-taxon-search-breadcrumb/03-isopoda-search.png)

Searching "coleoptera" → `inv-insects~order:coleoptera`, correctly resolves through the Insects umbrella node (no single-csvGroup Beetles node exists):

![Coleoptera search result](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-400-taxon-search-breadcrumb/04-coleoptera-search.png)

Loading state (artificially delayed here to capture it) — pulsing skeletons instead of a misleading "0" while Crustaceans/Malacostraca/Isopoda's own summaries are still streaming in:

![Loading skeleton state](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-400-taxon-search-breadcrumb/05-loading-skeleton.png)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 679/679 passing
- [x] Verified in a real browser (Playwright + direct API checks) for:
  - Static-node hit: "felidae" → `mammals~order:carnivora~family:felidae`
  - Multi-segment dynamic hit (class-first root): "isopoda" → `inv-crustaceans~class:malacostraca~order:isopoda`, correct live counts at every breadcrumb level
  - Multi-segment dynamic hit (order-first root): "muridae" → `mammals~order:rodentia~family:muridae`
  - Umbrella-group hit: "coleoptera" → `inv-insects~order:coleoptera` (and swept hymenoptera/diptera/hemiptera/orthoptera/odonata/araneae/pinales/cycadales/agaricales/gastropoda/decapoda — all correct)
  - SSC exclusion confirmed even for a rank ONLY curated via SSC (e.g. "scleractinia") — falls through to the dynamic path rather than leaking to SSC
  - Loading skeleton confirmed via an artificially delayed API response (Playwright route interception) — pending rows show pulsing placeholders, settle to correct real numbers once the fetch resolves
  - Fallback (genuinely unresolvable): unchanged
- [x] Merged latest `main` to resolve a conflict in `species-duckdb.ts` (unrelated concurrent domestic-species-exclusion change)