### PR TITLE
Redesign taxa-view header controls and filter cards (closes #401-404)

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -43,9 +43,8 @@ export default function RedListPage() {
   const [sharedTaxa, setSharedTaxa] = useState<Set<string>>(new Set());
   const [sharedSubgroups, setSharedSubgroups] = useState<Set<string>>(new Set());
 
-  // View-mode switch — previously two header buttons here, now surfaced
-  // instead by RedListView itself (next to its own Assessed/Not Evaluated
-  // stat card, where the mode actually matters), via this callback.
+  // View-mode switch, surfaced as a header control (top row) so it's visible
+  // and reachable regardless of which taxon/layout is currently selected.
   const handleViewModeChange = (mode: ViewMode) => {
     if (viewMode === mode) return;
     setViewMode(mode);
@@ -100,7 +99,31 @@ export default function RedListPage() {
             {brand.subtitle && (
               <p className="[grid-area:subtitle] text-[15px] md:text-[1.375rem] text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
             )}
-            <div className="[grid-area:controls] flex items-center gap-2 sm:justify-self-end">
+            <div className="[grid-area:controls] flex items-center gap-2 flex-wrap sm:justify-self-end">
+              <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
+                <button
+                  type="button"
+                  onClick={() => handleViewModeChange("reassessments")}
+                  className={`px-2 py-1 font-medium transition-colors ${
+                    viewMode !== "new-assessments"
+                      ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                      : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                  }`}
+                >
+                  Assessed
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleViewModeChange("new-assessments")}
+                  className={`px-2 py-1 font-medium transition-colors ${
+                    viewMode === "new-assessments"
+                      ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                      : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                  }`}
+                >
+                  Not Evaluated
+                </button>
+              </div>
               <ThemeToggle />
             </div>
             <div className="[grid-area:search] sm:justify-self-end">

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -108,12 +108,12 @@ export default function RedListPage() {
             {brand.subtitle && (
               <p className="[grid-area:subtitle] text-[15px] md:text-[1.375rem] text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
             )}
-            <div className="[grid-area:search] sm:justify-self-end">
+            <div className="[grid-area:search] flex items-center gap-2 sm:justify-self-end">
               <SpeciesSearchBar />
+              <ThemeToggle />
             </div>
             <div className="[grid-area:view] flex items-center gap-2 flex-wrap sm:justify-self-end">
               <div ref={setViewSelectorSlotEl} className="flex items-center" />
-              <ThemeToggle />
             </div>
           </div>
         </div>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -43,8 +43,17 @@ export default function RedListPage() {
   const [sharedTaxa, setSharedTaxa] = useState<Set<string>>(new Set());
   const [sharedSubgroups, setSharedSubgroups] = useState<Set<string>>(new Set());
 
-  // View-mode switch, surfaced as a header control (top row) so it's visible
-  // and reachable regardless of which taxon/layout is currently selected.
+  // Portal target for TaxaSummary's View-by selector (Standard/Table 1a/SSC/
+  // Country) — a callback ref so it's available as soon as the header div
+  // mounts. Keeping the selector's own state inside TaxaSummary (URL-synced
+  // via useFilterParams) and just portaling its markup up here means it's
+  // reachable from the persistent top row at any drill-down depth, without
+  // lifting that state out of RedListView.
+  const [viewSelectorSlotEl, setViewSelectorSlotEl] = useState<HTMLDivElement | null>(null);
+
+  // View-mode switch — previously two header buttons here, now surfaced
+  // instead by RedListView itself (next to its own Assessed/Not Evaluated
+  // stat card, where the mode actually matters), via this callback.
   const handleViewModeChange = (mode: ViewMode) => {
     if (viewMode === mode) return;
     setViewMode(mode);
@@ -100,30 +109,7 @@ export default function RedListPage() {
               <p className="[grid-area:subtitle] text-[15px] md:text-[1.375rem] text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
             )}
             <div className="[grid-area:controls] flex items-center gap-2 flex-wrap sm:justify-self-end">
-              <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
-                <button
-                  type="button"
-                  onClick={() => handleViewModeChange("reassessments")}
-                  className={`px-2 py-1 font-medium transition-colors ${
-                    viewMode !== "new-assessments"
-                      ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                      : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                  }`}
-                >
-                  Assessed
-                </button>
-                <button
-                  type="button"
-                  onClick={() => handleViewModeChange("new-assessments")}
-                  className={`px-2 py-1 font-medium transition-colors ${
-                    viewMode === "new-assessments"
-                      ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                      : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                  }`}
-                >
-                  Not Evaluated
-                </button>
-              </div>
+              <div ref={setViewSelectorSlotEl} className="flex items-center" />
               <ThemeToggle />
             </div>
             <div className="[grid-area:search] sm:justify-self-end">
@@ -140,6 +126,7 @@ export default function RedListPage() {
           sharedSubgroups={sharedSubgroups}
           onTaxaChange={setSharedTaxa}
           onSubgroupsChange={setSharedSubgroups}
+          viewSelectorSlotEl={viewSelectorSlotEl}
         />
       </main>
 

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -43,17 +43,8 @@ export default function RedListPage() {
   const [sharedTaxa, setSharedTaxa] = useState<Set<string>>(new Set());
   const [sharedSubgroups, setSharedSubgroups] = useState<Set<string>>(new Set());
 
-  // Portal target for TaxaSummary's View-by selector (Standard/Table 1a/SSC/
-  // Country) — a callback ref so it's available as soon as the header div
-  // mounts. Keeping the selector's own state inside TaxaSummary (URL-synced
-  // via useFilterParams) and just portaling its markup up here means it's
-  // reachable from the persistent top row at any drill-down depth, without
-  // lifting that state out of RedListView.
-  const [viewSelectorSlotEl, setViewSelectorSlotEl] = useState<HTMLDivElement | null>(null);
-
-  // View-mode switch — previously two header buttons here, now surfaced
-  // instead by RedListView itself (next to its own Assessed/Not Evaluated
-  // stat card, where the mode actually matters), via this callback.
+  // View-mode switch, surfaced as a header control (top row) so it's visible
+  // and reachable regardless of which taxon/layout is currently selected.
   const handleViewModeChange = (mode: ViewMode) => {
     if (viewMode === mode) return;
     setViewMode(mode);
@@ -108,8 +99,31 @@ export default function RedListPage() {
             {brand.subtitle && (
               <p className="[grid-area:subtitle] text-[15px] md:text-[1.375rem] text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
             )}
-            <div className="[grid-area:controls] flex items-center gap-2 sm:justify-self-end">
-              <div ref={setViewSelectorSlotEl} className="flex items-center" />
+            <div className="[grid-area:controls] flex items-center gap-2 flex-wrap sm:justify-self-end">
+              <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
+                <button
+                  type="button"
+                  onClick={() => handleViewModeChange("reassessments")}
+                  className={`px-2 py-1 font-medium transition-colors ${
+                    viewMode !== "new-assessments"
+                      ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                      : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                  }`}
+                >
+                  Assessed
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleViewModeChange("new-assessments")}
+                  className={`px-2 py-1 font-medium transition-colors ${
+                    viewMode === "new-assessments"
+                      ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                      : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                  }`}
+                >
+                  Not Evaluated
+                </button>
+              </div>
               <ThemeToggle />
             </div>
             <div className="[grid-area:search] sm:justify-self-end">
@@ -126,7 +140,6 @@ export default function RedListPage() {
           sharedSubgroups={sharedSubgroups}
           onTaxaChange={setSharedTaxa}
           onSubgroupsChange={setSharedSubgroups}
-          viewSelectorSlotEl={viewSelectorSlotEl}
         />
       </main>
 

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -43,8 +43,17 @@ export default function RedListPage() {
   const [sharedTaxa, setSharedTaxa] = useState<Set<string>>(new Set());
   const [sharedSubgroups, setSharedSubgroups] = useState<Set<string>>(new Set());
 
-  // View-mode switch, surfaced as a header control (top row) so it's visible
-  // and reachable regardless of which taxon/layout is currently selected.
+  // Portal target for TaxaSummary's View-by selector (Standard/Table 1a/SSC/
+  // Country) — a callback ref so it's available as soon as the header div
+  // mounts. Keeping the selector's own state inside TaxaSummary (URL-synced
+  // via useFilterParams) and just portaling its markup up here means it's
+  // reachable from the persistent top row at any drill-down depth, without
+  // lifting that state out of RedListView.
+  const [viewSelectorSlotEl, setViewSelectorSlotEl] = useState<HTMLDivElement | null>(null);
+
+  // View-mode switch — previously two header buttons here, now surfaced
+  // instead by RedListView itself (next to its own Assessed/Not Evaluated
+  // stat card, where the mode actually matters), via this callback.
   const handleViewModeChange = (mode: ViewMode) => {
     if (viewMode === mode) return;
     setViewMode(mode);
@@ -99,31 +108,8 @@ export default function RedListPage() {
             {brand.subtitle && (
               <p className="[grid-area:subtitle] text-[15px] md:text-[1.375rem] text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
             )}
-            <div className="[grid-area:controls] flex items-center gap-2 flex-wrap sm:justify-self-end">
-              <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
-                <button
-                  type="button"
-                  onClick={() => handleViewModeChange("reassessments")}
-                  className={`px-2 py-1 font-medium transition-colors ${
-                    viewMode !== "new-assessments"
-                      ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                      : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                  }`}
-                >
-                  Assessed
-                </button>
-                <button
-                  type="button"
-                  onClick={() => handleViewModeChange("new-assessments")}
-                  className={`px-2 py-1 font-medium transition-colors ${
-                    viewMode === "new-assessments"
-                      ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                      : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                  }`}
-                >
-                  Not Evaluated
-                </button>
-              </div>
+            <div className="[grid-area:controls] flex items-center gap-2 sm:justify-self-end">
+              <div ref={setViewSelectorSlotEl} className="flex items-center" />
               <ThemeToggle />
             </div>
             <div className="[grid-area:search] sm:justify-self-end">
@@ -140,6 +126,7 @@ export default function RedListPage() {
           sharedSubgroups={sharedSubgroups}
           onTaxaChange={setSharedTaxa}
           onSubgroupsChange={setSharedSubgroups}
+          viewSelectorSlotEl={viewSelectorSlotEl}
         />
       </main>
 

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -70,11 +70,11 @@ export default function RedListPage() {
   return (
     <div className="min-h-screen flex flex-col bg-zinc-50 dark:bg-zinc-950 px-4 sm:px-6 py-4 md:px-16 md:py-8">
       <main className="max-w-5xl w-full min-w-0 mx-auto flex-1">
-        {/* Header: two aligned rows (title | view-toggle, subtitle | search).
+        {/* Header: two aligned rows (title | search, subtitle | view + theme).
             Globe sits inline with the title so the subtitle, controls and
             search bar share the same flush-left edge as the table below. */}
         <div className="mb-[0.9rem] md:mb-[1.35rem]">
-          <div className="min-w-0 grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center gap-x-3 gap-y-1.5 sm:gap-y-3 [grid-template-areas:'title'_'subtitle'_'controls'_'search'] sm:[grid-template-areas:'title_controls'_'subtitle_search']">
+          <div className="min-w-0 grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center gap-x-3 gap-y-1.5 sm:gap-y-3 [grid-template-areas:'title'_'subtitle'_'search'_'view'] sm:[grid-template-areas:'title_search'_'subtitle_view']">
             <button
               type="button"
               onClick={() => {
@@ -108,12 +108,12 @@ export default function RedListPage() {
             {brand.subtitle && (
               <p className="[grid-area:subtitle] text-[15px] md:text-[1.375rem] text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
             )}
-            <div className="[grid-area:controls] flex items-center gap-2 flex-wrap sm:justify-self-end">
-              <div ref={setViewSelectorSlotEl} className="flex items-center" />
-              <ThemeToggle />
-            </div>
             <div className="[grid-area:search] sm:justify-self-end">
               <SpeciesSearchBar />
+            </div>
+            <div className="[grid-area:view] flex items-center gap-2 flex-wrap sm:justify-self-end">
+              <div ref={setViewSelectorSlotEl} className="flex items-center" />
+              <ThemeToggle />
             </div>
           </div>
         </div>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -43,14 +43,6 @@ export default function RedListPage() {
   const [sharedTaxa, setSharedTaxa] = useState<Set<string>>(new Set());
   const [sharedSubgroups, setSharedSubgroups] = useState<Set<string>>(new Set());
 
-  // Portal target for TaxaSummary's View-by selector (Standard/Table 1a/SSC/
-  // Country) — a callback ref so it's available as soon as the header div
-  // mounts. Keeping the selector's own state inside TaxaSummary (URL-synced
-  // via useFilterParams) and just portaling its markup up here means it's
-  // reachable from the persistent top row at any drill-down depth, without
-  // lifting that state out of RedListView.
-  const [viewSelectorSlotEl, setViewSelectorSlotEl] = useState<HTMLDivElement | null>(null);
-
   // View-mode switch — previously two header buttons here, now surfaced
   // instead by RedListView itself (next to its own Assessed/Not Evaluated
   // stat card, where the mode actually matters), via this callback.
@@ -70,11 +62,11 @@ export default function RedListPage() {
   return (
     <div className="min-h-screen flex flex-col bg-zinc-50 dark:bg-zinc-950 px-4 sm:px-6 py-4 md:px-16 md:py-8">
       <main className="max-w-5xl w-full min-w-0 mx-auto flex-1">
-        {/* Header: two aligned rows (title | search, subtitle | view + theme).
+        {/* Header: two aligned rows (title | controls, subtitle | search).
             Globe sits inline with the title so the subtitle, controls and
             search bar share the same flush-left edge as the table below. */}
         <div className="mb-[0.9rem] md:mb-[1.35rem]">
-          <div className="min-w-0 grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center gap-x-3 gap-y-1.5 sm:gap-y-3 [grid-template-areas:'title'_'subtitle'_'search'_'view'] sm:[grid-template-areas:'title_search'_'subtitle_view']">
+          <div className="min-w-0 grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center gap-x-3 gap-y-1.5 sm:gap-y-3 [grid-template-areas:'title'_'subtitle'_'controls'_'search'] sm:[grid-template-areas:'title_controls'_'subtitle_search']">
             <button
               type="button"
               onClick={() => {
@@ -108,12 +100,11 @@ export default function RedListPage() {
             {brand.subtitle && (
               <p className="[grid-area:subtitle] text-[15px] md:text-[1.375rem] text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
             )}
-            <div className="[grid-area:search] flex items-center gap-2 sm:justify-self-end">
-              <SpeciesSearchBar />
+            <div className="[grid-area:controls] flex items-center gap-2 sm:justify-self-end">
               <ThemeToggle />
             </div>
-            <div className="[grid-area:view] flex items-center gap-2 flex-wrap sm:justify-self-end">
-              <div ref={setViewSelectorSlotEl} className="flex items-center" />
+            <div className="[grid-area:search] sm:justify-self-end">
+              <SpeciesSearchBar />
             </div>
           </div>
         </div>
@@ -126,7 +117,6 @@ export default function RedListPage() {
           sharedSubgroups={sharedSubgroups}
           onTaxaChange={setSharedTaxa}
           onSubgroupsChange={setSharedSubgroups}
-          viewSelectorSlotEl={viewSelectorSlotEl}
         />
       </main>
 

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2465,7 +2465,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
         selectedSubgroups={selectedSubgroups}
         disableAllSpecies={isNewAssessments}
         viewMode={viewMode}
-        onViewModeChange={onViewModeChange}
         layoutMode={layoutMode}
         onLayoutModeChange={setLayoutMode}
         countryModeContent={countryModeContent}
@@ -2540,14 +2539,22 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               sub-group row drilled into via TaxaSummary's own tree
               (selectedSubgroupTaxon: dynamic order/family/genus, or a static SSC
               group), or a non-curated arbitrary rank reached via search
-              (arbitraryTaxon). Two stat cards: the taxon (name + rank) and the
-              matched-species count (mirrors the table's totalFiltered). The
-              Assessed/Not Evaluated toggle lives paired with the View selector
-              at the bottom-right of TaxaSummary's own table now, not here — see
-              its onViewModeChange prop. TaxaSummary's own breadcrumb table
-              above already shows the tree branch that led here (Mammals →
-              Rodentia → Heteromyidae → ...) when applicable — this is purely an
-              additional, more prominent summary, not a replacement for it. */}
+              (arbitraryTaxon). Two fixed-fact stat cards — the taxon (name +
+              rank) and its total species count (taxaFilteredSpeciesBase, NOT
+              totalFiltered) — neither reacts to pill filters; the Matching
+              Filters row below is what shows the filtered/live numbers. The
+              second card's header IS the Assessed/Not Evaluated toggle rather
+              than a plain caption: the toggle's own button labels already say
+              "Assessed"/"Not Evaluated", so a separate caption saying the same
+              thing would be redundant, and this keeps the toggle visible at
+              both the landing page and single-taxon drill-down (unlike the
+              View selector, which is landing-only — browsing mode stops
+              mattering once you've committed to a taxon, but Assessed/Not
+              Evaluated scope matters just as much here as there). TaxaSummary's
+              own breadcrumb table above already shows the tree branch that led
+              here (Mammals → Rodentia → Heteromyidae → ...) when applicable —
+              this is purely an additional, more prominent summary, not a
+              replacement for it. */}
           {focusedTaxonCard && !isSingleSpecies && (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
@@ -2559,45 +2566,62 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 </div>
               </div>
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
-                <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                  {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
-                </div>
-                <div className="mt-0.5 flex items-baseline gap-1.5">
-                  {speciesLoading && assessedSpecies.length === 0 ? (
-                    <Spinner className="h-6 w-6" />
-                  ) : (
-                    <>
-                      <span className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                        {totalFiltered.toLocaleString()}
-                      </span>
-                      {totalFiltered !== taxaFilteredSpeciesBase.length && (
-                        <span className="text-sm font-medium text-zinc-400 dark:text-zinc-500">
-                          matching filters
-                        </span>
-                      )}
-                    </>
-                  )}
+                {onViewModeChange ? (
+                  <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs w-fit">
+                    <button
+                      type="button"
+                      onClick={() => onViewModeChange("reassessments")}
+                      className={`px-2 py-1 font-medium transition-colors ${
+                        !isNewAssessments
+                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                      }`}
+                    >
+                      Assessed
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onViewModeChange("new-assessments")}
+                      className={`px-2 py-1 font-medium transition-colors ${
+                        isNewAssessments
+                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                      }`}
+                    >
+                      Not Evaluated
+                    </button>
+                  </div>
+                ) : (
+                  <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                    {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
+                  </div>
+                )}
+                <div className="mt-1 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                  {speciesLoading && assessedSpecies.length === 0
+                    ? <Spinner className="h-6 w-6" />
+                    : taxaFilteredSpeciesBase.length.toLocaleString()}
                 </div>
               </div>
             </div>
           )}
 
-          {/* Matching Filters — replaces the old separate "applied filters" row.
-              Only rendered when there's something to show: an active filter
-              (hasActiveFilters), a Starred toggle (pinnedSpecies.length > 0), or
-              the Not Evaluated shortcut. Deliberately excludes selectedTaxa/
-              selectedSubgroups/breakdownFilter — those are taxonomy navigation,
-              not filters; Home is what clears them, not this card's Clear all.
-              The heading restates the same number as the stat card above
-              (totalFiltered) so the card is self-explanatory without having to
-              look back up — not true redundancy since they're adjacent. */}
+          {/* Active Filters / Matched Species — two cards mirroring the Taxon/
+              Assessed-Species row above (same grid pattern: a fixed-fact card
+              on the left, a live-number card on the right), shown only when
+              there's something to display: an active filter (hasActiveFilters),
+              a Starred toggle (pinnedSpecies.length > 0), or the Not Evaluated
+              shortcut. Deliberately excludes selectedTaxa/selectedSubgroups/
+              breakdownFilter from both the chip list and Clear all — those are
+              taxonomy navigation, not filters; Home is what clears them.
+              Matched Species (right) only renders once hasActiveFilters is
+              true — with no active filter it would just repeat the taxon's own
+              fixed total already shown in the card above, so the left card
+              spans full width by itself instead (className below has no grid
+              classes in that case, so it's just a plain block). */}
           {(hasActiveFilters || pinnedSpecies.length > 0 || (!isNewAssessments && (neCount > 0 || neBlockedForAll))) && (
-            <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 md:p-4">
-              {hasActiveFilters && (
-                <div className="mb-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                  {totalFiltered.toLocaleString()} Matching Filters
-                </div>
-              )}
+            <div className={hasActiveFilters ? "grid grid-cols-1 sm:grid-cols-2 gap-4" : ""}>
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 md:p-4">
+              <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Active Filters</div>
               <div className="flex flex-wrap items-center gap-2 md:gap-4">
               {hasActiveFilters && (
                 <button
@@ -2873,6 +2897,19 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               </button>
             )}
               </div>
+              </div>
+              {hasActiveFilters && (
+                <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 md:p-4">
+                  <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                    Matched Species
+                  </div>
+                  <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                    {speciesLoading && totalFiltered === 0 && !singleSpeciesPreview
+                      ? <Spinner className="h-6 w-6" />
+                      : totalFiltered.toLocaleString()}
+                  </div>
+                </div>
+              )}
             </div>
           )}
 

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -143,42 +143,6 @@ interface SpeciesDetails {
 }
 
 
-// Debounced search input - manages own state for instant typing, debounces parent updates
-function DebouncedSearchInput({
-  onSearch,
-  initialValue = "",
-  placeholder = "Search species...",
-  className,
-}: {
-  onSearch: (value: string) => void;
-  initialValue?: string;
-  placeholder?: string;
-  className?: string;
-}) {
-  const [localValue, setLocalValue] = useState(initialValue);
-
-  useEffect(() => {
-    setLocalValue(initialValue);
-  }, [initialValue]);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      onSearch(localValue.toLowerCase());
-    }, 200);
-    return () => clearTimeout(timer);
-  }, [localValue, onSearch]);
-
-  return (
-    <input
-      type="text"
-      value={localValue}
-      onChange={(e) => setLocalValue(e.target.value)}
-      placeholder={placeholder}
-      className={className}
-    />
-  );
-}
-
 // Explain IUCN Red List criteria codes
 // See: https://www.iucnredlist.org/resources/categories-and-criteria
 function explainCriteria(criteria: string): string {
@@ -371,7 +335,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     selectedGrowthForms, setSelectedGrowthForms,
     selectedAssessors, setSelectedAssessors,
     selectedReviewers, setSelectedReviewers,
-    searchFilter, setSearchFilter,
+    searchFilter,
     exactFilters, setExactFilters,
     sortField, sortDirection, setSort,
     mapViewMode, mapSortKey, mapSortDirection, setMapViewMode, setMapSort,
@@ -604,11 +568,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     );
     if (!stillSelected) setExpandedThreat(null);
   }, [selectedThreats, expandedThreat]);
-
-  // Stable callback for debounced search input
-  const handleSearch = useCallback((value: string) => {
-    setSearchFilter(value);
-  }, [setSearchFilter]);
 
   // Pagination
   const [currentPage, setCurrentPage] = useState(1);
@@ -2570,22 +2529,326 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       ) : (
       <div className="space-y-3">
 
+          {/* Applied filters — every currently-active filter shown as a
+              removable pill, plus Clear-all/Starred/species-count/Not-Evaluated
+              shortcut. Sits directly below TaxaSummary's breadcrumb table and
+              above the taxon-focus stat card so active filters are visible
+              before its numbers. (The free-text species search box that used
+              to live in this row was removed — SpeciesSearchBar in the page
+              header covers taxon/species lookup instead.) */}
+          <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 md:p-4">
+            <div className="flex flex-wrap items-center gap-2 md:gap-4">
+            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
+              <button
+                onClick={() => { clearAllFilters(); setSelectedTaxa(new Set()); setSelectedSubgroups(new Set()); setSelectedObsRanges(new Set()); setSelectedSystems(new Set()); setEndemicsOnly(false); setSelectedGrowthForms(new Set()); setSelectedPopulationTrends(new Set()); setSelectedMovementPatterns(new Set()); setSelectedThreats(new Set()); setExpandedThreat(null); setSelectedAssessors(new Set()); setSelectedReviewers(new Set()); setShowOnlyStarred(false); }}
+                title="Reset all filters and taxa"
+                className="px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
+              >
+                <svg className="w-3.5 h-3.5 md:w-4 md:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                <span className="hidden sm:inline">Clear all</span>
+              </button>
+            )}
+            {pinnedSpecies.length > 0 && (
+              <>
+                <button
+                  onClick={() => setShowOnlyStarred(!showOnlyStarred)}
+                  className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
+                    showOnlyStarred
+                      ? "bg-amber-500 text-white"
+                      : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
+                  }`}
+                >
+                  <svg className="w-4 h-4" fill={showOnlyStarred ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+                  </svg>
+                  <span className="hidden sm:inline">Starred</span> ({pinnedSpecies.length})
+                </button>
+              </>
+            )}
+            {Array.from(selectedTaxa).map(taxonId => (
+              <button
+                key={taxonId}
+                onClick={() => setSelectedTaxa(prev => { const next = new Set(prev); next.delete(taxonId); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80"
+                style={{ backgroundColor: (TAXA_BY_ID[taxonId]?.color || "#666") + "20", color: TAXA_BY_ID[taxonId]?.color || "#666" }}
+              >
+                {TAXA_BY_ID[taxonId]?.name || taxonId}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {Array.from(selectedSubgroups).map(sgId => {
+              const sgInfo = getNodeDef(sgId);
+              return (
+                <button
+                  key={sgId}
+                  onClick={() => setSelectedSubgroups(prev => { const next = new Set(prev); next.delete(sgId); return next; })}
+                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+                >
+                  {sgInfo?.node.name ?? dynamicNodeDisplayName(sgId)}
+                  <span className="text-xs">×</span>
+                </button>
+              );
+            })}
+            {breakdownFilter && selectedSubgroups.has(breakdownFilter.nodeId) && (
+              <button
+                onClick={() => setBreakdownFilter(null)}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {breakdownDisplayName(breakdownFilter.rank, breakdownFilter.name)}
+                {breakdownFilter.onlyIds?.length ? " — No CoL Match" : breakdownFilter.excludeIds?.length ? " — CoL Match" : ""}
+                <span className="text-xs">×</span>
+              </button>
+            )}
+            {!isNewAssessments && Array.from(selectedCategories).filter(cat => cat !== "NE").map(cat => (
+              <button
+                key={cat}
+                onClick={() => setSelectedCategories(prev => { const next = new Set(prev); next.delete(cat); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80"
+                style={{ backgroundColor: CATEGORY_COLORS[cat] + "20", color: CATEGORY_COLORS[cat] }}
+              >
+                {cat}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedYearRanges).map(range => (
+              <button
+                key={range}
+                onClick={() => setSelectedYearRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {range}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedAssessmentYears).sort((a, b) => Number(b) - Number(a)).map(year => (
+              <button
+                key={`ay-${year}`}
+                onClick={() => setSelectedAssessmentYears(prev => { const next = new Set(prev); next.delete(year); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
+              >
+                Assessed {year}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {isNewAssessments && Array.from(selectedDescribedYears).map(range => (
+              <button
+                key={`dy-${range}`}
+                onClick={() => setSelectedDescribedYears(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+              >
+                Described {range}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {Array.from(selectedObsRanges).map(range => (
+              <button
+                key={range}
+                onClick={() => setSelectedObsRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {range} obs
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {(() => {
+              if (selectedCountries.size === 0) return null;
+              // Check if selected countries exactly match a single IUCN region
+              const regions = new Set<string>();
+              selectedCountries.forEach(c => regions.add(countryToIucnRegion(c)));
+              if (regions.size === 1) {
+                const region = [...regions][0];
+                if (region !== "Other") {
+                  const regionCodes = iucnRegionCountries(region);
+                  if (regionCodes.length === selectedCountries.size && regionCodes.every(c => selectedCountries.has(c))) {
+                    return (
+                      <button
+                        onClick={() => setSelectedCountries(new Set())}
+                        className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
+                      >
+                        {region}
+                        <span className="text-xs">×</span>
+                      </button>
+                    );
+                  }
+                }
+              }
+              // Otherwise show individual country pills
+              return Array.from(selectedCountries).map(code => (
+                <button
+                  key={code}
+                  onClick={() => setSelectedCountries(prev => { const next = new Set(prev); next.delete(code); return next; })}
+                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
+                >
+                  {getCountryName(code)}
+                  <span className="text-xs">×</span>
+                </button>
+              ));
+            })()}
+            {Array.from(selectedGrowthForms).map(gf => (
+              <button
+                key={`gf-${gf}`}
+                onClick={() => setSelectedGrowthForms(prev => { const next = new Set(prev); next.delete(gf); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-lime-100 text-lime-600 dark:bg-lime-900/30 dark:text-lime-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {gf}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {endemicsOnly && (
+              <button
+                onClick={() => setEndemicsOnly(false)}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
+              >
+                Endemics only
+                <span className="text-xs">×</span>
+              </button>
+            )}
+            {Array.from(selectedPopulationTrends).map(trend => (
+              <button
+                key={`trend-${trend}`}
+                onClick={() => setSelectedPopulationTrends(prev => { const next = new Set(prev); next.delete(trend); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {trend}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {Array.from(selectedMovementPatterns).map(pattern => (
+              <button
+                key={`mov-${pattern}`}
+                onClick={() => setSelectedMovementPatterns(prev => { const next = new Set(prev); next.delete(pattern); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {pattern}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {Array.from(selectedThreats).map(code => {
+              const cat = THREAT_CATEGORIES.find(c => c.code === code);
+              const sub = !cat ? THREAT_CATEGORIES.flatMap(c => c.children).find(c => c.code === code) : null;
+              const label = cat?.label || sub?.label || code;
+              return (
+                <button
+                  key={`threat-${code}`}
+                  onClick={() => setSelectedThreats(prev => { const next = new Set(prev); next.delete(code); return next; })}
+                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-rose-100 text-rose-600 dark:bg-rose-900/30 dark:text-rose-400 flex items-center gap-1 hover:opacity-80"
+                >
+                  {label}
+                  <span className="text-xs">×</span>
+                </button>
+              );
+            })}
+            {Array.from(selectedSystems).map(system => (
+              <button
+                key={system}
+                onClick={() => setSelectedSystems(prev => { const next = new Set(prev); next.delete(system); return next; })}
+                className={`px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80 ${
+                  system === "Terrestrial" ? "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
+                  : system === "Freshwater" ? "bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400"
+                  : "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
+                }`}
+              >
+                {system}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedAssessors).map(name => (
+              <button
+                key={`a-${name}`}
+                onClick={() => setSelectedAssessors(prev => { const next = new Set(prev); next.delete(name); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {name} <span className="text-[10px] opacity-60">(assessor)</span>
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedReviewers).map(name => (
+              <button
+                key={`r-${name}`}
+                onClick={() => setSelectedReviewers(prev => { const next = new Set(prev); next.delete(name); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-fuchsia-100 text-fuchsia-600 dark:bg-fuchsia-900/30 dark:text-fuchsia-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {name} <span className="text-[10px] opacity-60">(reviewer)</span>
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {/* Exact URL-only filters (typically arrive via an agent/MCP dashboard
+                link). Shown as chips so a human can see and clear them. */}
+            {(() => {
+              const ef = exactFilters;
+              const chips: { key: keyof typeof ef; label: string }[] = [];
+              if (ef.outdated) chips.push({ key: "outdated", label: ef.outdated === "yes" ? "Outdated (>10 yrs)" : "Current (≤10 yrs)" });
+              if (ef.minObs != null) chips.push({ key: "minObs", label: `≥ ${ef.minObs.toLocaleString()} obs` });
+              if (ef.maxObs != null) chips.push({ key: "maxObs", label: `≤ ${ef.maxObs.toLocaleString()} obs` });
+              if (ef.minAssessmentYear != null) chips.push({ key: "minAssessmentYear", label: `Assessed ≥ ${ef.minAssessmentYear}` });
+              if (ef.maxAssessmentYear != null) chips.push({ key: "maxAssessmentYear", label: `Assessed ≤ ${ef.maxAssessmentYear}` });
+              if (ef.minDescribedYear != null) chips.push({ key: "minDescribedYear", label: `Described ≥ ${ef.minDescribedYear}` });
+              if (ef.maxDescribedYear != null) chips.push({ key: "maxDescribedYear", label: `Described ≤ ${ef.maxDescribedYear}` });
+              return chips.map(c => (
+                <button
+                  key={`ef-${c.key}`}
+                  onClick={() => setExactFilters({ [c.key]: null })}
+                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300 flex items-center gap-1 hover:opacity-80"
+                >
+                  {c.label}
+                  <span className="text-xs">×</span>
+                </button>
+              ));
+            })()}
+            <span className="ml-auto text-sm md:text-base font-semibold text-zinc-700 dark:text-zinc-300 tabular-nums flex items-center gap-2">
+              {speciesLoading && totalFiltered === 0 && !singleSpeciesPreview ? (
+                <Spinner className="h-4 w-4" />
+              ) : (
+                <>{totalFiltered.toLocaleString()} species</>
+              )}
+            </span>
+            {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
+              <button
+                disabled={neBlockedForAll}
+                onClick={() => {
+                  if (neBlockedForAll) return;
+                  setSelectedCategories(prev => {
+                    const next = new Set(prev);
+                    if (next.has("NE")) {
+                      next.delete("NE");
+                    } else {
+                      next.add("NE");
+                    }
+                    return next;
+                  });
+                }}
+                className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
+                  neBlockedForAll
+                    ? "bg-white text-zinc-400 border border-zinc-200 opacity-60 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500 dark:border-zinc-700"
+                    : selectedCategories.has("NE")
+                    ? "bg-zinc-500 text-white"
+                    : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
+                }`}
+                title={neBlockedForAll ? "Not Evaluated species must be loaded per taxon group — too many to load for All Species at once" : "Show Not Evaluated species from GBIF"}
+              >
+                Not Evaluated
+                {!neBlockedForAll && <span className="text-[10px] opacity-70">({neCount.toLocaleString()})</span>}
+              </button>
+            )}
+            </div>
+          </div>
+
           {/* Taxon-focus header — any single selected taxon: a top-level taxon
               (selectedTopLevelTaxon, e.g. Mammals, or "All Species" itself), a
               sub-group row drilled into via TaxaSummary's own tree
               (selectedSubgroupTaxon: dynamic order/family/genus, or a static SSC
               group), or a non-curated arbitrary rank reached via search
               (arbitraryTaxon). Two stat cards: the taxon (name + rank) and the
-              matched-species count (mirrors the table's totalFiltered) — the
-              latter also carries the Assessed/Not Evaluated view-mode toggle
-              (previously a page-header control, moved here since this is where
-              the mode actually changes what's shown). TaxaSummary's own
-              breadcrumb table above already shows the tree branch that led here
-              (Mammals → Rodentia → Heteromyidae → ...) when applicable — this is
-              purely an additional, more prominent summary, not a replacement
-              for it. */}
+              matched-species count (mirrors the table's totalFiltered). The
+              Assessed/Not Evaluated view-mode toggle lives in the page header
+              now, not here. TaxaSummary's own breadcrumb table above already
+              shows the tree branch that led here (Mammals → Rodentia →
+              Heteromyidae → ...) when applicable — this is purely an
+              additional, more prominent summary, not a replacement for it. */}
           {focusedTaxonCard && !isSingleSpecies && (
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
                 <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
                   {focusedTaxonCard.rank ?? "Taxon"}
@@ -2594,43 +2857,15 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   {focusedTaxonCard.name}
                 </div>
               </div>
-              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex items-center justify-between gap-3">
-                <div>
-                  <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                    {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
-                  </div>
-                  <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                    {speciesLoading && assessedSpecies.length === 0
-                      ? <Spinner className="h-6 w-6" />
-                      : totalFiltered.toLocaleString()}
-                  </div>
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
+                <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                  {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
                 </div>
-                {onViewModeChange && (
-                  <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
-                    <button
-                      type="button"
-                      onClick={() => onViewModeChange("reassessments")}
-                      className={`px-2 py-1 font-medium transition-colors ${
-                        !isNewAssessments
-                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                      }`}
-                    >
-                      Assessed
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => onViewModeChange("new-assessments")}
-                      className={`px-2 py-1 font-medium transition-colors ${
-                        isNewAssessments
-                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                      }`}
-                    >
-                      Not Evaluated
-                    </button>
-                  </div>
-                )}
+                <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                  {speciesLoading && assessedSpecies.length === 0
+                    ? <Spinner className="h-6 w-6" />
+                    : totalFiltered.toLocaleString()}
+                </div>
               </div>
             </div>
           )}
@@ -3137,11 +3372,12 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             })()}
           </div>
 
-          {/* More Filters (collapsible) - hidden for New Assessments */}
-          {!isNewAssessments && <div>
+          {/* More Filters — a full-width collapsible card row, consistent with
+              the other cards on the page (hidden for New Assessments) */}
+          {!isNewAssessments && <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl">
             <button
               onClick={() => setMoreFiltersOpen(prev => !prev)}
-              className="flex items-center gap-1.5 text-xs font-medium text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+              className="w-full flex items-center gap-1.5 px-3 md:px-4 py-2.5 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 rounded-t-xl transition-colors"
             >
               <svg className={`w-3.5 h-3.5 transition-transform ${moreFiltersOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
@@ -3154,7 +3390,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               )}
             </button>
             {moreFiltersOpen && (
-              <div className="mt-3 flex flex-col gap-3">
+              <div className="px-3 md:px-4 pb-3 md:pb-4 pt-1 border-t border-zinc-200 dark:border-zinc-800 flex flex-col gap-3">
                 {/* Realm */}
                 <div className="flex items-center gap-2">
                   <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0 w-16">Realm</span>
@@ -3366,324 +3602,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             )}
           </div>}
 
-      {/* Search and Species Table */}
+      {/* Species Table */}
       <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl">
-        {/* Search bar */}
-        <div className="p-3 md:p-4 border-b border-zinc-200 dark:border-zinc-800 rounded-t-xl">
-          <div className="flex flex-wrap items-center gap-2 md:gap-4">
-            <div className="relative flex-1 min-w-[140px] max-w-md">
-              <DebouncedSearchInput
-                onSearch={handleSearch}
-                initialValue={searchFilter}
-                placeholder="Search species..."
-                className="w-full px-3 md:px-4 py-2 pl-9 md:pl-10 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
-              />
-              <svg
-                className="absolute left-2.5 md:left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-400 pointer-events-none"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
-            </div>
-            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
-              <button
-                onClick={() => { clearAllFilters(); setSelectedTaxa(new Set()); setSelectedSubgroups(new Set()); setSelectedObsRanges(new Set()); setSelectedSystems(new Set()); setEndemicsOnly(false); setSelectedGrowthForms(new Set()); setSelectedPopulationTrends(new Set()); setSelectedMovementPatterns(new Set()); setSelectedThreats(new Set()); setExpandedThreat(null); setSelectedAssessors(new Set()); setSelectedReviewers(new Set()); setShowOnlyStarred(false); }}
-                title="Reset all filters and taxa"
-                className="px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
-              >
-                <svg className="w-3.5 h-3.5 md:w-4 md:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-                <span className="hidden sm:inline">Clear all</span>
-              </button>
-            )}
-            {pinnedSpecies.length > 0 && (
-              <>
-                <button
-                  onClick={() => setShowOnlyStarred(!showOnlyStarred)}
-                  className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
-                    showOnlyStarred
-                      ? "bg-amber-500 text-white"
-                      : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
-                  }`}
-                >
-                  <svg className="w-4 h-4" fill={showOnlyStarred ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-                  </svg>
-                  <span className="hidden sm:inline">Starred</span> ({pinnedSpecies.length})
-                </button>
-              </>
-            )}
-            {Array.from(selectedTaxa).map(taxonId => (
-              <button
-                key={taxonId}
-                onClick={() => setSelectedTaxa(prev => { const next = new Set(prev); next.delete(taxonId); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80"
-                style={{ backgroundColor: (TAXA_BY_ID[taxonId]?.color || "#666") + "20", color: TAXA_BY_ID[taxonId]?.color || "#666" }}
-              >
-                {TAXA_BY_ID[taxonId]?.name || taxonId}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {Array.from(selectedSubgroups).map(sgId => {
-              const sgInfo = getNodeDef(sgId);
-              return (
-                <button
-                  key={sgId}
-                  onClick={() => setSelectedSubgroups(prev => { const next = new Set(prev); next.delete(sgId); return next; })}
-                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-                >
-                  {sgInfo?.node.name ?? dynamicNodeDisplayName(sgId)}
-                  <span className="text-xs">×</span>
-                </button>
-              );
-            })}
-            {breakdownFilter && selectedSubgroups.has(breakdownFilter.nodeId) && (
-              <button
-                onClick={() => setBreakdownFilter(null)}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {breakdownDisplayName(breakdownFilter.rank, breakdownFilter.name)}
-                {breakdownFilter.onlyIds?.length ? " — No CoL Match" : breakdownFilter.excludeIds?.length ? " — CoL Match" : ""}
-                <span className="text-xs">×</span>
-              </button>
-            )}
-            {!isNewAssessments && Array.from(selectedCategories).filter(cat => cat !== "NE").map(cat => (
-              <button
-                key={cat}
-                onClick={() => setSelectedCategories(prev => { const next = new Set(prev); next.delete(cat); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80"
-                style={{ backgroundColor: CATEGORY_COLORS[cat] + "20", color: CATEGORY_COLORS[cat] }}
-              >
-                {cat}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedYearRanges).map(range => (
-              <button
-                key={range}
-                onClick={() => setSelectedYearRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {range}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedAssessmentYears).sort((a, b) => Number(b) - Number(a)).map(year => (
-              <button
-                key={`ay-${year}`}
-                onClick={() => setSelectedAssessmentYears(prev => { const next = new Set(prev); next.delete(year); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
-              >
-                Assessed {year}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {isNewAssessments && Array.from(selectedDescribedYears).map(range => (
-              <button
-                key={`dy-${range}`}
-                onClick={() => setSelectedDescribedYears(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-              >
-                Described {range}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {Array.from(selectedObsRanges).map(range => (
-              <button
-                key={range}
-                onClick={() => setSelectedObsRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {range} obs
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {(() => {
-              if (selectedCountries.size === 0) return null;
-              // Check if selected countries exactly match a single IUCN region
-              const regions = new Set<string>();
-              selectedCountries.forEach(c => regions.add(countryToIucnRegion(c)));
-              if (regions.size === 1) {
-                const region = [...regions][0];
-                if (region !== "Other") {
-                  const regionCodes = iucnRegionCountries(region);
-                  if (regionCodes.length === selectedCountries.size && regionCodes.every(c => selectedCountries.has(c))) {
-                    return (
-                      <button
-                        onClick={() => setSelectedCountries(new Set())}
-                        className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
-                      >
-                        {region}
-                        <span className="text-xs">×</span>
-                      </button>
-                    );
-                  }
-                }
-              }
-              // Otherwise show individual country pills
-              return Array.from(selectedCountries).map(code => (
-                <button
-                  key={code}
-                  onClick={() => setSelectedCountries(prev => { const next = new Set(prev); next.delete(code); return next; })}
-                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
-                >
-                  {getCountryName(code)}
-                  <span className="text-xs">×</span>
-                </button>
-              ));
-            })()}
-            {Array.from(selectedGrowthForms).map(gf => (
-              <button
-                key={`gf-${gf}`}
-                onClick={() => setSelectedGrowthForms(prev => { const next = new Set(prev); next.delete(gf); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-lime-100 text-lime-600 dark:bg-lime-900/30 dark:text-lime-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {gf}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {endemicsOnly && (
-              <button
-                onClick={() => setEndemicsOnly(false)}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
-              >
-                Endemics only
-                <span className="text-xs">×</span>
-              </button>
-            )}
-            {Array.from(selectedPopulationTrends).map(trend => (
-              <button
-                key={`trend-${trend}`}
-                onClick={() => setSelectedPopulationTrends(prev => { const next = new Set(prev); next.delete(trend); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {trend}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {Array.from(selectedMovementPatterns).map(pattern => (
-              <button
-                key={`mov-${pattern}`}
-                onClick={() => setSelectedMovementPatterns(prev => { const next = new Set(prev); next.delete(pattern); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {pattern}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {Array.from(selectedThreats).map(code => {
-              const cat = THREAT_CATEGORIES.find(c => c.code === code);
-              const sub = !cat ? THREAT_CATEGORIES.flatMap(c => c.children).find(c => c.code === code) : null;
-              const label = cat?.label || sub?.label || code;
-              return (
-                <button
-                  key={`threat-${code}`}
-                  onClick={() => setSelectedThreats(prev => { const next = new Set(prev); next.delete(code); return next; })}
-                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-rose-100 text-rose-600 dark:bg-rose-900/30 dark:text-rose-400 flex items-center gap-1 hover:opacity-80"
-                >
-                  {label}
-                  <span className="text-xs">×</span>
-                </button>
-              );
-            })}
-            {Array.from(selectedSystems).map(system => (
-              <button
-                key={system}
-                onClick={() => setSelectedSystems(prev => { const next = new Set(prev); next.delete(system); return next; })}
-                className={`px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80 ${
-                  system === "Terrestrial" ? "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
-                  : system === "Freshwater" ? "bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400"
-                  : "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
-                }`}
-              >
-                {system}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedAssessors).map(name => (
-              <button
-                key={`a-${name}`}
-                onClick={() => setSelectedAssessors(prev => { const next = new Set(prev); next.delete(name); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {name} <span className="text-[10px] opacity-60">(assessor)</span>
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedReviewers).map(name => (
-              <button
-                key={`r-${name}`}
-                onClick={() => setSelectedReviewers(prev => { const next = new Set(prev); next.delete(name); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-fuchsia-100 text-fuchsia-600 dark:bg-fuchsia-900/30 dark:text-fuchsia-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {name} <span className="text-[10px] opacity-60">(reviewer)</span>
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {/* Exact URL-only filters (typically arrive via an agent/MCP dashboard
-                link). Shown as chips so a human can see and clear them. */}
-            {(() => {
-              const ef = exactFilters;
-              const chips: { key: keyof typeof ef; label: string }[] = [];
-              if (ef.outdated) chips.push({ key: "outdated", label: ef.outdated === "yes" ? "Outdated (>10 yrs)" : "Current (≤10 yrs)" });
-              if (ef.minObs != null) chips.push({ key: "minObs", label: `≥ ${ef.minObs.toLocaleString()} obs` });
-              if (ef.maxObs != null) chips.push({ key: "maxObs", label: `≤ ${ef.maxObs.toLocaleString()} obs` });
-              if (ef.minAssessmentYear != null) chips.push({ key: "minAssessmentYear", label: `Assessed ≥ ${ef.minAssessmentYear}` });
-              if (ef.maxAssessmentYear != null) chips.push({ key: "maxAssessmentYear", label: `Assessed ≤ ${ef.maxAssessmentYear}` });
-              if (ef.minDescribedYear != null) chips.push({ key: "minDescribedYear", label: `Described ≥ ${ef.minDescribedYear}` });
-              if (ef.maxDescribedYear != null) chips.push({ key: "maxDescribedYear", label: `Described ≤ ${ef.maxDescribedYear}` });
-              return chips.map(c => (
-                <button
-                  key={`ef-${c.key}`}
-                  onClick={() => setExactFilters({ [c.key]: null })}
-                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300 flex items-center gap-1 hover:opacity-80"
-                >
-                  {c.label}
-                  <span className="text-xs">×</span>
-                </button>
-              ));
-            })()}
-            <span className="ml-auto text-sm md:text-base font-semibold text-zinc-700 dark:text-zinc-300 tabular-nums flex items-center gap-2">
-              {speciesLoading && totalFiltered === 0 && !singleSpeciesPreview ? (
-                <Spinner className="h-4 w-4" />
-              ) : (
-                <>{totalFiltered.toLocaleString()} species</>
-              )}
-            </span>
-            {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
-              <button
-                disabled={neBlockedForAll}
-                onClick={() => {
-                  if (neBlockedForAll) return;
-                  setSelectedCategories(prev => {
-                    const next = new Set(prev);
-                    if (next.has("NE")) {
-                      next.delete("NE");
-                    } else {
-                      next.add("NE");
-                    }
-                    return next;
-                  });
-                }}
-                className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
-                  neBlockedForAll
-                    ? "bg-white text-zinc-400 border border-zinc-200 opacity-60 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500 dark:border-zinc-700"
-                    : selectedCategories.has("NE")
-                    ? "bg-zinc-500 text-white"
-                    : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
-                }`}
-                title={neBlockedForAll ? "Not Evaluated species must be loaded per taxon group — too many to load for All Species at once" : "Show Not Evaluated species from GBIF"}
-              >
-                Not Evaluated
-                {!neBlockedForAll && <span className="text-[10px] opacity-70">({neCount.toLocaleString()})</span>}
-              </button>
-            )}
-          </div>
-        </div>
-
         {/* Species table */}
         {speciesLoading && assessedSpecies.length === 0 && !singleSpeciesPreview ? (
           <div className="flex items-center justify-center py-12">

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2575,11 +2575,11 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               <button
                 key={taxonId}
                 onClick={() => setSelectedTaxa(prev => { const next = new Set(prev); next.delete(taxonId); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80"
+                className="px-3 py-1.5 text-sm font-medium rounded-full flex items-center gap-1 hover:opacity-80"
                 style={{ backgroundColor: (TAXA_BY_ID[taxonId]?.color || "#666") + "20", color: TAXA_BY_ID[taxonId]?.color || "#666" }}
               >
                 {TAXA_BY_ID[taxonId]?.name || taxonId}
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             ))}
             {Array.from(selectedSubgroups).map(sgId => {
@@ -2588,72 +2588,72 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 <button
                   key={sgId}
                   onClick={() => setSelectedSubgroups(prev => { const next = new Set(prev); next.delete(sgId); return next; })}
-                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+                  className="px-3 py-1.5 text-sm font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
                 >
                   {sgInfo?.node.name ?? dynamicNodeDisplayName(sgId)}
-                  <span className="text-xs">×</span>
+                  <span className="text-sm">×</span>
                 </button>
               );
             })}
             {breakdownFilter && selectedSubgroups.has(breakdownFilter.nodeId) && (
               <button
                 onClick={() => setBreakdownFilter(null)}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
               >
                 {breakdownDisplayName(breakdownFilter.rank, breakdownFilter.name)}
                 {breakdownFilter.onlyIds?.length ? " — No CoL Match" : breakdownFilter.excludeIds?.length ? " — CoL Match" : ""}
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             )}
             {!isNewAssessments && Array.from(selectedCategories).filter(cat => cat !== "NE").map(cat => (
               <button
                 key={cat}
                 onClick={() => setSelectedCategories(prev => { const next = new Set(prev); next.delete(cat); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80"
+                className="px-3 py-1.5 text-sm font-medium rounded-full flex items-center gap-1 hover:opacity-80"
                 style={{ backgroundColor: CATEGORY_COLORS[cat] + "20", color: CATEGORY_COLORS[cat] }}
               >
                 {cat}
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             ))}
             {!isNewAssessments && Array.from(selectedYearRanges).map(range => (
               <button
                 key={range}
                 onClick={() => setSelectedYearRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
               >
                 {range}
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             ))}
             {!isNewAssessments && Array.from(selectedAssessmentYears).sort((a, b) => Number(b) - Number(a)).map(year => (
               <button
                 key={`ay-${year}`}
                 onClick={() => setSelectedAssessmentYears(prev => { const next = new Set(prev); next.delete(year); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
               >
                 Assessed {year}
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             ))}
             {isNewAssessments && Array.from(selectedDescribedYears).map(range => (
               <button
                 key={`dy-${range}`}
                 onClick={() => setSelectedDescribedYears(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
               >
                 Described {range}
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             ))}
             {Array.from(selectedObsRanges).map(range => (
               <button
                 key={range}
                 onClick={() => setSelectedObsRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400 flex items-center gap-1 hover:opacity-80"
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400 flex items-center gap-1 hover:opacity-80"
               >
                 {range} obs
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             ))}
             {(() => {
@@ -2669,10 +2669,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                     return (
                       <button
                         onClick={() => setSelectedCountries(new Set())}
-                        className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
+                        className="px-3 py-1.5 text-sm font-medium rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
                       >
                         {region}
-                        <span className="text-xs">×</span>
+                        <span className="text-sm">×</span>
                       </button>
                     );
                   }
@@ -2683,10 +2683,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 <button
                   key={code}
                   onClick={() => setSelectedCountries(prev => { const next = new Set(prev); next.delete(code); return next; })}
-                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
+                  className="px-3 py-1.5 text-sm font-medium rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
                 >
                   {getCountryName(code)}
-                  <span className="text-xs">×</span>
+                  <span className="text-sm">×</span>
                 </button>
               ));
             })()}
@@ -2694,39 +2694,39 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               <button
                 key={`gf-${gf}`}
                 onClick={() => setSelectedGrowthForms(prev => { const next = new Set(prev); next.delete(gf); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-lime-100 text-lime-600 dark:bg-lime-900/30 dark:text-lime-400 flex items-center gap-1 hover:opacity-80"
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-lime-100 text-lime-600 dark:bg-lime-900/30 dark:text-lime-400 flex items-center gap-1 hover:opacity-80"
               >
                 {gf}
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             ))}
             {endemicsOnly && (
               <button
                 onClick={() => setEndemicsOnly(false)}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
               >
                 Endemics only
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             )}
             {Array.from(selectedPopulationTrends).map(trend => (
               <button
                 key={`trend-${trend}`}
                 onClick={() => setSelectedPopulationTrends(prev => { const next = new Set(prev); next.delete(trend); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400 flex items-center gap-1 hover:opacity-80"
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400 flex items-center gap-1 hover:opacity-80"
               >
                 {trend}
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             ))}
             {Array.from(selectedMovementPatterns).map(pattern => (
               <button
                 key={`mov-${pattern}`}
                 onClick={() => setSelectedMovementPatterns(prev => { const next = new Set(prev); next.delete(pattern); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
               >
                 {pattern}
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             ))}
             {Array.from(selectedThreats).map(code => {
@@ -2737,10 +2737,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 <button
                   key={`threat-${code}`}
                   onClick={() => setSelectedThreats(prev => { const next = new Set(prev); next.delete(code); return next; })}
-                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-rose-100 text-rose-600 dark:bg-rose-900/30 dark:text-rose-400 flex items-center gap-1 hover:opacity-80"
+                  className="px-3 py-1.5 text-sm font-medium rounded-full bg-rose-100 text-rose-600 dark:bg-rose-900/30 dark:text-rose-400 flex items-center gap-1 hover:opacity-80"
                 >
                   {label}
-                  <span className="text-xs">×</span>
+                  <span className="text-sm">×</span>
                 </button>
               );
             })}
@@ -2748,34 +2748,34 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               <button
                 key={system}
                 onClick={() => setSelectedSystems(prev => { const next = new Set(prev); next.delete(system); return next; })}
-                className={`px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80 ${
+                className={`px-3 py-1.5 text-sm font-medium rounded-full flex items-center gap-1 hover:opacity-80 ${
                   system === "Terrestrial" ? "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
                   : system === "Freshwater" ? "bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400"
                   : "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
                 }`}
               >
                 {system}
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             ))}
             {!isNewAssessments && Array.from(selectedAssessors).map(name => (
               <button
                 key={`a-${name}`}
                 onClick={() => setSelectedAssessors(prev => { const next = new Set(prev); next.delete(name); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
               >
                 {name} <span className="text-[10px] opacity-60">(assessor)</span>
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             ))}
             {!isNewAssessments && Array.from(selectedReviewers).map(name => (
               <button
                 key={`r-${name}`}
                 onClick={() => setSelectedReviewers(prev => { const next = new Set(prev); next.delete(name); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-fuchsia-100 text-fuchsia-600 dark:bg-fuchsia-900/30 dark:text-fuchsia-400 flex items-center gap-1 hover:opacity-80"
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-fuchsia-100 text-fuchsia-600 dark:bg-fuchsia-900/30 dark:text-fuchsia-400 flex items-center gap-1 hover:opacity-80"
               >
                 {name} <span className="text-[10px] opacity-60">(reviewer)</span>
-                <span className="text-xs">×</span>
+                <span className="text-sm">×</span>
               </button>
             ))}
             {/* Exact URL-only filters (typically arrive via an agent/MCP dashboard
@@ -2794,20 +2794,18 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 <button
                   key={`ef-${c.key}`}
                   onClick={() => setExactFilters({ [c.key]: null })}
-                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300 flex items-center gap-1 hover:opacity-80"
+                  className="px-3 py-1.5 text-sm font-medium rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300 flex items-center gap-1 hover:opacity-80"
                 >
                   {c.label}
-                  <span className="text-xs">×</span>
+                  <span className="text-sm">×</span>
                 </button>
               ));
             })()}
-            <span className="ml-auto text-sm md:text-base font-semibold text-zinc-700 dark:text-zinc-300 tabular-nums flex items-center gap-2">
-              {speciesLoading && totalFiltered === 0 && !singleSpeciesPreview ? (
-                <Spinner className="h-4 w-4" />
-              ) : (
-                <>{totalFiltered.toLocaleString()} species</>
-              )}
-            </span>
+            {/* No standalone species-count readout here anymore — the taxon-focus
+                stat card below shows it (with "of Y" once a filter narrows it),
+                so this row would just be a redundant second copy of the same
+                number. ml-auto moved to the Not Evaluated button so the pills
+                still hug the left and this stays right-aligned. */}
             {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
               <button
                 disabled={neBlockedForAll}
@@ -2823,7 +2821,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                     return next;
                   });
                 }}
-                className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
+                className={`ml-auto px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
                   neBlockedForAll
                     ? "bg-white text-zinc-400 border border-zinc-200 opacity-60 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500 dark:border-zinc-700"
                     : selectedCategories.has("NE")
@@ -2869,10 +2867,25 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
                     {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
                   </div>
-                  <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                    {speciesLoading && assessedSpecies.length === 0
-                      ? <Spinner className="h-6 w-6" />
-                      : totalFiltered.toLocaleString()}
+                  <div className="mt-0.5 flex items-baseline gap-1.5">
+                    {speciesLoading && assessedSpecies.length === 0 ? (
+                      <Spinner className="h-6 w-6" />
+                    ) : (
+                      <>
+                        <span className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                          {totalFiltered.toLocaleString()}
+                        </span>
+                        {/* Only show "of Y" once a filter has actually narrowed the
+                            count below the taxon's own total (taxaFilteredSpeciesBase —
+                            taxon/subgroup only, no pill filters) — otherwise the two
+                            numbers are identical and the qualifier is just noise. */}
+                        {totalFiltered !== taxaFilteredSpeciesBase.length && (
+                          <span className="text-sm font-medium text-zinc-400 dark:text-zinc-500">
+                            of {taxaFilteredSpeciesBase.length.toLocaleString()}
+                          </span>
+                        )}
+                      </>
+                    )}
                   </div>
                 </div>
                 {onViewModeChange && (

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -143,42 +143,6 @@ interface SpeciesDetails {
 }
 
 
-// Debounced search input - manages own state for instant typing, debounces parent updates
-function DebouncedSearchInput({
-  onSearch,
-  initialValue = "",
-  placeholder = "Search species...",
-  className,
-}: {
-  onSearch: (value: string) => void;
-  initialValue?: string;
-  placeholder?: string;
-  className?: string;
-}) {
-  const [localValue, setLocalValue] = useState(initialValue);
-
-  useEffect(() => {
-    setLocalValue(initialValue);
-  }, [initialValue]);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      onSearch(localValue.toLowerCase());
-    }, 200);
-    return () => clearTimeout(timer);
-  }, [localValue, onSearch]);
-
-  return (
-    <input
-      type="text"
-      value={localValue}
-      onChange={(e) => setLocalValue(e.target.value)}
-      placeholder={placeholder}
-      className={className}
-    />
-  );
-}
-
 // Explain IUCN Red List criteria codes
 // See: https://www.iucnredlist.org/resources/categories-and-criteria
 function explainCriteria(criteria: string): string {
@@ -315,12 +279,9 @@ interface RedListViewProps {
   sharedSubgroups?: Set<string>;
   onTaxaChange?: (taxa: Set<string>) => void;
   onSubgroupsChange?: (subgroups: Set<string>) => void;
-  /** DOM node (owned by page.tsx's persistent header) that TaxaSummary
-   * portals its View-by selector into — see TaxaSummary's own doc comment. */
-  viewSelectorSlotEl?: HTMLDivElement | null;
 }
 
-export default function RedListView({ viewMode = "reassessments", onViewModeChange, sharedTaxa, sharedSubgroups, onTaxaChange, onSubgroupsChange, viewSelectorSlotEl }: RedListViewProps = {}) {
+export default function RedListView({ viewMode = "reassessments", onViewModeChange, sharedTaxa, sharedSubgroups, onTaxaChange, onSubgroupsChange }: RedListViewProps = {}) {
   const isNewAssessments = viewMode === "new-assessments";
   // Every species/truncation cache below is keyed by (mode, taxonId), not taxonId
   // alone — a taxon's Assessed and Not Evaluated species lists are entirely
@@ -374,7 +335,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     selectedGrowthForms, setSelectedGrowthForms,
     selectedAssessors, setSelectedAssessors,
     selectedReviewers, setSelectedReviewers,
-    searchFilter, setSearchFilter,
+    searchFilter,
     exactFilters, setExactFilters,
     sortField, sortDirection, setSort,
     mapViewMode, mapSortKey, mapSortDirection, setMapViewMode, setMapSort,
@@ -607,11 +568,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     );
     if (!stillSelected) setExpandedThreat(null);
   }, [selectedThreats, expandedThreat]);
-
-  // Stable callback for debounced search input
-  const handleSearch = useCallback((value: string) => {
-    setSearchFilter(value);
-  }, [setSearchFilter]);
 
   // Pagination
   const [currentPage, setCurrentPage] = useState(1);
@@ -2505,7 +2461,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
         viewMode={viewMode}
         layoutMode={layoutMode}
         onLayoutModeChange={setLayoutMode}
-        viewSelectorSlotEl={viewSelectorSlotEl}
         countryModeContent={countryModeContent}
         countryPillsContent={countryPillsContent}
         countryScope={countryScope}
@@ -2574,19 +2529,321 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       ) : (
       <div className="space-y-3">
 
+          {/* Applied filters — every currently-active filter shown as a
+              removable pill, plus Clear-all/Starred/species-count/Not-Evaluated
+              shortcut. Sits directly below TaxaSummary's breadcrumb table and
+              above the taxon-focus stat card so active filters are visible
+              before its numbers. (The free-text species search box that used
+              to live in this row was removed — SpeciesSearchBar in the page
+              header covers taxon/species lookup instead.) */}
+          <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 md:p-4">
+            <div className="flex flex-wrap items-center gap-2 md:gap-4">
+            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
+              <button
+                onClick={() => { clearAllFilters(); setSelectedTaxa(new Set()); setSelectedSubgroups(new Set()); setSelectedObsRanges(new Set()); setSelectedSystems(new Set()); setEndemicsOnly(false); setSelectedGrowthForms(new Set()); setSelectedPopulationTrends(new Set()); setSelectedMovementPatterns(new Set()); setSelectedThreats(new Set()); setExpandedThreat(null); setSelectedAssessors(new Set()); setSelectedReviewers(new Set()); setShowOnlyStarred(false); }}
+                title="Reset all filters and taxa"
+                className="px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
+              >
+                <svg className="w-3.5 h-3.5 md:w-4 md:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                <span className="hidden sm:inline">Clear all</span>
+              </button>
+            )}
+            {pinnedSpecies.length > 0 && (
+              <>
+                <button
+                  onClick={() => setShowOnlyStarred(!showOnlyStarred)}
+                  className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
+                    showOnlyStarred
+                      ? "bg-amber-500 text-white"
+                      : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
+                  }`}
+                >
+                  <svg className="w-4 h-4" fill={showOnlyStarred ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+                  </svg>
+                  <span className="hidden sm:inline">Starred</span> ({pinnedSpecies.length})
+                </button>
+              </>
+            )}
+            {Array.from(selectedTaxa).map(taxonId => (
+              <button
+                key={taxonId}
+                onClick={() => setSelectedTaxa(prev => { const next = new Set(prev); next.delete(taxonId); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80"
+                style={{ backgroundColor: (TAXA_BY_ID[taxonId]?.color || "#666") + "20", color: TAXA_BY_ID[taxonId]?.color || "#666" }}
+              >
+                {TAXA_BY_ID[taxonId]?.name || taxonId}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {Array.from(selectedSubgroups).map(sgId => {
+              const sgInfo = getNodeDef(sgId);
+              return (
+                <button
+                  key={sgId}
+                  onClick={() => setSelectedSubgroups(prev => { const next = new Set(prev); next.delete(sgId); return next; })}
+                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+                >
+                  {sgInfo?.node.name ?? dynamicNodeDisplayName(sgId)}
+                  <span className="text-xs">×</span>
+                </button>
+              );
+            })}
+            {breakdownFilter && selectedSubgroups.has(breakdownFilter.nodeId) && (
+              <button
+                onClick={() => setBreakdownFilter(null)}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {breakdownDisplayName(breakdownFilter.rank, breakdownFilter.name)}
+                {breakdownFilter.onlyIds?.length ? " — No CoL Match" : breakdownFilter.excludeIds?.length ? " — CoL Match" : ""}
+                <span className="text-xs">×</span>
+              </button>
+            )}
+            {!isNewAssessments && Array.from(selectedCategories).filter(cat => cat !== "NE").map(cat => (
+              <button
+                key={cat}
+                onClick={() => setSelectedCategories(prev => { const next = new Set(prev); next.delete(cat); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80"
+                style={{ backgroundColor: CATEGORY_COLORS[cat] + "20", color: CATEGORY_COLORS[cat] }}
+              >
+                {cat}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedYearRanges).map(range => (
+              <button
+                key={range}
+                onClick={() => setSelectedYearRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {range}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedAssessmentYears).sort((a, b) => Number(b) - Number(a)).map(year => (
+              <button
+                key={`ay-${year}`}
+                onClick={() => setSelectedAssessmentYears(prev => { const next = new Set(prev); next.delete(year); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
+              >
+                Assessed {year}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {isNewAssessments && Array.from(selectedDescribedYears).map(range => (
+              <button
+                key={`dy-${range}`}
+                onClick={() => setSelectedDescribedYears(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+              >
+                Described {range}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {Array.from(selectedObsRanges).map(range => (
+              <button
+                key={range}
+                onClick={() => setSelectedObsRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {range} obs
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {(() => {
+              if (selectedCountries.size === 0) return null;
+              // Check if selected countries exactly match a single IUCN region
+              const regions = new Set<string>();
+              selectedCountries.forEach(c => regions.add(countryToIucnRegion(c)));
+              if (regions.size === 1) {
+                const region = [...regions][0];
+                if (region !== "Other") {
+                  const regionCodes = iucnRegionCountries(region);
+                  if (regionCodes.length === selectedCountries.size && regionCodes.every(c => selectedCountries.has(c))) {
+                    return (
+                      <button
+                        onClick={() => setSelectedCountries(new Set())}
+                        className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
+                      >
+                        {region}
+                        <span className="text-xs">×</span>
+                      </button>
+                    );
+                  }
+                }
+              }
+              // Otherwise show individual country pills
+              return Array.from(selectedCountries).map(code => (
+                <button
+                  key={code}
+                  onClick={() => setSelectedCountries(prev => { const next = new Set(prev); next.delete(code); return next; })}
+                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
+                >
+                  {getCountryName(code)}
+                  <span className="text-xs">×</span>
+                </button>
+              ));
+            })()}
+            {Array.from(selectedGrowthForms).map(gf => (
+              <button
+                key={`gf-${gf}`}
+                onClick={() => setSelectedGrowthForms(prev => { const next = new Set(prev); next.delete(gf); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-lime-100 text-lime-600 dark:bg-lime-900/30 dark:text-lime-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {gf}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {endemicsOnly && (
+              <button
+                onClick={() => setEndemicsOnly(false)}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
+              >
+                Endemics only
+                <span className="text-xs">×</span>
+              </button>
+            )}
+            {Array.from(selectedPopulationTrends).map(trend => (
+              <button
+                key={`trend-${trend}`}
+                onClick={() => setSelectedPopulationTrends(prev => { const next = new Set(prev); next.delete(trend); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {trend}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {Array.from(selectedMovementPatterns).map(pattern => (
+              <button
+                key={`mov-${pattern}`}
+                onClick={() => setSelectedMovementPatterns(prev => { const next = new Set(prev); next.delete(pattern); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {pattern}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {Array.from(selectedThreats).map(code => {
+              const cat = THREAT_CATEGORIES.find(c => c.code === code);
+              const sub = !cat ? THREAT_CATEGORIES.flatMap(c => c.children).find(c => c.code === code) : null;
+              const label = cat?.label || sub?.label || code;
+              return (
+                <button
+                  key={`threat-${code}`}
+                  onClick={() => setSelectedThreats(prev => { const next = new Set(prev); next.delete(code); return next; })}
+                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-rose-100 text-rose-600 dark:bg-rose-900/30 dark:text-rose-400 flex items-center gap-1 hover:opacity-80"
+                >
+                  {label}
+                  <span className="text-xs">×</span>
+                </button>
+              );
+            })}
+            {Array.from(selectedSystems).map(system => (
+              <button
+                key={system}
+                onClick={() => setSelectedSystems(prev => { const next = new Set(prev); next.delete(system); return next; })}
+                className={`px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80 ${
+                  system === "Terrestrial" ? "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
+                  : system === "Freshwater" ? "bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400"
+                  : "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
+                }`}
+              >
+                {system}
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedAssessors).map(name => (
+              <button
+                key={`a-${name}`}
+                onClick={() => setSelectedAssessors(prev => { const next = new Set(prev); next.delete(name); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {name} <span className="text-[10px] opacity-60">(assessor)</span>
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedReviewers).map(name => (
+              <button
+                key={`r-${name}`}
+                onClick={() => setSelectedReviewers(prev => { const next = new Set(prev); next.delete(name); return next; })}
+                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-fuchsia-100 text-fuchsia-600 dark:bg-fuchsia-900/30 dark:text-fuchsia-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {name} <span className="text-[10px] opacity-60">(reviewer)</span>
+                <span className="text-xs">×</span>
+              </button>
+            ))}
+            {/* Exact URL-only filters (typically arrive via an agent/MCP dashboard
+                link). Shown as chips so a human can see and clear them. */}
+            {(() => {
+              const ef = exactFilters;
+              const chips: { key: keyof typeof ef; label: string }[] = [];
+              if (ef.outdated) chips.push({ key: "outdated", label: ef.outdated === "yes" ? "Outdated (>10 yrs)" : "Current (≤10 yrs)" });
+              if (ef.minObs != null) chips.push({ key: "minObs", label: `≥ ${ef.minObs.toLocaleString()} obs` });
+              if (ef.maxObs != null) chips.push({ key: "maxObs", label: `≤ ${ef.maxObs.toLocaleString()} obs` });
+              if (ef.minAssessmentYear != null) chips.push({ key: "minAssessmentYear", label: `Assessed ≥ ${ef.minAssessmentYear}` });
+              if (ef.maxAssessmentYear != null) chips.push({ key: "maxAssessmentYear", label: `Assessed ≤ ${ef.maxAssessmentYear}` });
+              if (ef.minDescribedYear != null) chips.push({ key: "minDescribedYear", label: `Described ≥ ${ef.minDescribedYear}` });
+              if (ef.maxDescribedYear != null) chips.push({ key: "maxDescribedYear", label: `Described ≤ ${ef.maxDescribedYear}` });
+              return chips.map(c => (
+                <button
+                  key={`ef-${c.key}`}
+                  onClick={() => setExactFilters({ [c.key]: null })}
+                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300 flex items-center gap-1 hover:opacity-80"
+                >
+                  {c.label}
+                  <span className="text-xs">×</span>
+                </button>
+              ));
+            })()}
+            <span className="ml-auto text-sm md:text-base font-semibold text-zinc-700 dark:text-zinc-300 tabular-nums flex items-center gap-2">
+              {speciesLoading && totalFiltered === 0 && !singleSpeciesPreview ? (
+                <Spinner className="h-4 w-4" />
+              ) : (
+                <>{totalFiltered.toLocaleString()} species</>
+              )}
+            </span>
+            {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
+              <button
+                disabled={neBlockedForAll}
+                onClick={() => {
+                  if (neBlockedForAll) return;
+                  setSelectedCategories(prev => {
+                    const next = new Set(prev);
+                    if (next.has("NE")) {
+                      next.delete("NE");
+                    } else {
+                      next.add("NE");
+                    }
+                    return next;
+                  });
+                }}
+                className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
+                  neBlockedForAll
+                    ? "bg-white text-zinc-400 border border-zinc-200 opacity-60 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500 dark:border-zinc-700"
+                    : selectedCategories.has("NE")
+                    ? "bg-zinc-500 text-white"
+                    : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
+                }`}
+                title={neBlockedForAll ? "Not Evaluated species must be loaded per taxon group — too many to load for All Species at once" : "Show Not Evaluated species from GBIF"}
+              >
+                Not Evaluated
+                {!neBlockedForAll && <span className="text-[10px] opacity-70">({neCount.toLocaleString()})</span>}
+              </button>
+            )}
+            </div>
+          </div>
+
           {/* Taxon-focus header — any single selected taxon: a top-level taxon
               (selectedTopLevelTaxon, e.g. Mammals, or "All Species" itself), a
               sub-group row drilled into via TaxaSummary's own tree
               (selectedSubgroupTaxon: dynamic order/family/genus, or a static SSC
               group), or a non-curated arbitrary rank reached via search
               (arbitraryTaxon). Two stat cards: the taxon (name + rank) and the
-              taxon's total species count — deliberately taxaFilteredSpeciesBase
-              (taxon/subgroup only, no pill filters applied), NOT totalFiltered,
-              so this stays a fixed "how big is this taxon" reference point even
-              while the table below is narrowed by category/country/year/etc.
-              pills. The latter also carries the Assessed/Not Evaluated
-              view-mode toggle, since this is where the mode actually changes
-              what's shown. TaxaSummary's own breadcrumb table above already
+              matched-species count (mirrors the table's totalFiltered). The
+              Assessed/Not Evaluated view-mode toggle lives in the page header
+              now, not here. TaxaSummary's own breadcrumb table above already
               shows the tree branch that led here (Mammals → Rodentia →
               Heteromyidae → ...) when applicable — this is purely an
               additional, more prominent summary, not a replacement for it. */}
@@ -2600,43 +2857,15 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   {focusedTaxonCard.name}
                 </div>
               </div>
-              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex items-center justify-between gap-3 flex-wrap">
-                <div>
-                  <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                    {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
-                  </div>
-                  <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                    {speciesLoading && assessedSpecies.length === 0
-                      ? <Spinner className="h-6 w-6" />
-                      : taxaFilteredSpeciesBase.length.toLocaleString()}
-                  </div>
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
+                <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                  {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
                 </div>
-                {onViewModeChange && (
-                  <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
-                    <button
-                      type="button"
-                      onClick={() => onViewModeChange("reassessments")}
-                      className={`px-2 py-1 font-medium transition-colors ${
-                        !isNewAssessments
-                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                      }`}
-                    >
-                      Assessed
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => onViewModeChange("new-assessments")}
-                      className={`px-2 py-1 font-medium transition-colors ${
-                        isNewAssessments
-                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                      }`}
-                    >
-                      Not Evaluated
-                    </button>
-                  </div>
-                )}
+                <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                  {speciesLoading && assessedSpecies.length === 0
+                    ? <Spinner className="h-6 w-6" />
+                    : totalFiltered.toLocaleString()}
+                </div>
               </div>
             </div>
           )}
@@ -3143,11 +3372,12 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             })()}
           </div>
 
-          {/* More Filters (collapsible) - hidden for New Assessments */}
-          {!isNewAssessments && <div>
+          {/* More Filters — a full-width collapsible card row, consistent with
+              the other cards on the page (hidden for New Assessments) */}
+          {!isNewAssessments && <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl">
             <button
               onClick={() => setMoreFiltersOpen(prev => !prev)}
-              className="flex items-center gap-1.5 text-xs font-medium text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+              className="w-full flex items-center gap-1.5 px-3 md:px-4 py-2.5 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 rounded-t-xl transition-colors"
             >
               <svg className={`w-3.5 h-3.5 transition-transform ${moreFiltersOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
@@ -3160,7 +3390,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               )}
             </button>
             {moreFiltersOpen && (
-              <div className="mt-3 flex flex-col gap-3">
+              <div className="px-3 md:px-4 pb-3 md:pb-4 pt-1 border-t border-zinc-200 dark:border-zinc-800 flex flex-col gap-3">
                 {/* Realm */}
                 <div className="flex items-center gap-2">
                   <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0 w-16">Realm</span>
@@ -3372,324 +3602,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             )}
           </div>}
 
-      {/* Search and Species Table */}
+      {/* Species Table */}
       <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl">
-        {/* Search bar */}
-        <div className="p-3 md:p-4 border-b border-zinc-200 dark:border-zinc-800 rounded-t-xl">
-          <div className="flex flex-wrap items-center gap-2 md:gap-4">
-            <div className="relative flex-1 min-w-[140px] max-w-md">
-              <DebouncedSearchInput
-                onSearch={handleSearch}
-                initialValue={searchFilter}
-                placeholder="Search species..."
-                className="w-full px-3 md:px-4 py-2 pl-9 md:pl-10 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
-              />
-              <svg
-                className="absolute left-2.5 md:left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-400 pointer-events-none"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-              </svg>
-            </div>
-            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
-              <button
-                onClick={() => { clearAllFilters(); setSelectedTaxa(new Set()); setSelectedSubgroups(new Set()); setSelectedObsRanges(new Set()); setSelectedSystems(new Set()); setEndemicsOnly(false); setSelectedGrowthForms(new Set()); setSelectedPopulationTrends(new Set()); setSelectedMovementPatterns(new Set()); setSelectedThreats(new Set()); setExpandedThreat(null); setSelectedAssessors(new Set()); setSelectedReviewers(new Set()); setShowOnlyStarred(false); }}
-                title="Reset all filters and taxa"
-                className="px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
-              >
-                <svg className="w-3.5 h-3.5 md:w-4 md:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-                <span className="hidden sm:inline">Clear all</span>
-              </button>
-            )}
-            {pinnedSpecies.length > 0 && (
-              <>
-                <button
-                  onClick={() => setShowOnlyStarred(!showOnlyStarred)}
-                  className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
-                    showOnlyStarred
-                      ? "bg-amber-500 text-white"
-                      : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
-                  }`}
-                >
-                  <svg className="w-4 h-4" fill={showOnlyStarred ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-                  </svg>
-                  <span className="hidden sm:inline">Starred</span> ({pinnedSpecies.length})
-                </button>
-              </>
-            )}
-            {Array.from(selectedTaxa).map(taxonId => (
-              <button
-                key={taxonId}
-                onClick={() => setSelectedTaxa(prev => { const next = new Set(prev); next.delete(taxonId); return next; })}
-                className="px-3 py-1.5 text-sm rounded-full flex items-center gap-1 hover:opacity-80"
-                style={{ backgroundColor: (TAXA_BY_ID[taxonId]?.color || "#666") + "20", color: TAXA_BY_ID[taxonId]?.color || "#666" }}
-              >
-                {TAXA_BY_ID[taxonId]?.name || taxonId}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {Array.from(selectedSubgroups).map(sgId => {
-              const sgInfo = getNodeDef(sgId);
-              return (
-                <button
-                  key={sgId}
-                  onClick={() => setSelectedSubgroups(prev => { const next = new Set(prev); next.delete(sgId); return next; })}
-                  className="px-3 py-1.5 text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-                >
-                  {sgInfo?.node.name ?? dynamicNodeDisplayName(sgId)}
-                  <span className="text-sm">×</span>
-                </button>
-              );
-            })}
-            {breakdownFilter && selectedSubgroups.has(breakdownFilter.nodeId) && (
-              <button
-                onClick={() => setBreakdownFilter(null)}
-                className="px-3 py-1.5 text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {breakdownDisplayName(breakdownFilter.rank, breakdownFilter.name)}
-                {breakdownFilter.onlyIds?.length ? " — No CoL Match" : breakdownFilter.excludeIds?.length ? " — CoL Match" : ""}
-                <span className="text-sm">×</span>
-              </button>
-            )}
-            {!isNewAssessments && Array.from(selectedCategories).filter(cat => cat !== "NE").map(cat => (
-              <button
-                key={cat}
-                onClick={() => setSelectedCategories(prev => { const next = new Set(prev); next.delete(cat); return next; })}
-                className="px-3 py-1.5 text-sm rounded-full flex items-center gap-1 hover:opacity-80"
-                style={{ backgroundColor: CATEGORY_COLORS[cat] + "20", color: CATEGORY_COLORS[cat] }}
-              >
-                {cat}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedYearRanges).map(range => (
-              <button
-                key={range}
-                onClick={() => setSelectedYearRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-3 py-1.5 text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {range}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedAssessmentYears).sort((a, b) => Number(b) - Number(a)).map(year => (
-              <button
-                key={`ay-${year}`}
-                onClick={() => setSelectedAssessmentYears(prev => { const next = new Set(prev); next.delete(year); return next; })}
-                className="px-3 py-1.5 text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
-              >
-                Assessed {year}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {isNewAssessments && Array.from(selectedDescribedYears).map(range => (
-              <button
-                key={`dy-${range}`}
-                onClick={() => setSelectedDescribedYears(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-3 py-1.5 text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-              >
-                Described {range}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {Array.from(selectedObsRanges).map(range => (
-              <button
-                key={range}
-                onClick={() => setSelectedObsRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-3 py-1.5 text-sm rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {range} obs
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {(() => {
-              if (selectedCountries.size === 0) return null;
-              // Check if selected countries exactly match a single IUCN region
-              const regions = new Set<string>();
-              selectedCountries.forEach(c => regions.add(countryToIucnRegion(c)));
-              if (regions.size === 1) {
-                const region = [...regions][0];
-                if (region !== "Other") {
-                  const regionCodes = iucnRegionCountries(region);
-                  if (regionCodes.length === selectedCountries.size && regionCodes.every(c => selectedCountries.has(c))) {
-                    return (
-                      <button
-                        onClick={() => setSelectedCountries(new Set())}
-                        className="px-3 py-1.5 text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
-                      >
-                        {region}
-                        <span className="text-sm">×</span>
-                      </button>
-                    );
-                  }
-                }
-              }
-              // Otherwise show individual country pills
-              return Array.from(selectedCountries).map(code => (
-                <button
-                  key={code}
-                  onClick={() => setSelectedCountries(prev => { const next = new Set(prev); next.delete(code); return next; })}
-                  className="px-3 py-1.5 text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
-                >
-                  {getCountryName(code)}
-                  <span className="text-sm">×</span>
-                </button>
-              ));
-            })()}
-            {Array.from(selectedGrowthForms).map(gf => (
-              <button
-                key={`gf-${gf}`}
-                onClick={() => setSelectedGrowthForms(prev => { const next = new Set(prev); next.delete(gf); return next; })}
-                className="px-3 py-1.5 text-sm rounded-full bg-lime-100 text-lime-600 dark:bg-lime-900/30 dark:text-lime-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {gf}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {endemicsOnly && (
-              <button
-                onClick={() => setEndemicsOnly(false)}
-                className="px-3 py-1.5 text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
-              >
-                Endemics only
-                <span className="text-sm">×</span>
-              </button>
-            )}
-            {Array.from(selectedPopulationTrends).map(trend => (
-              <button
-                key={`trend-${trend}`}
-                onClick={() => setSelectedPopulationTrends(prev => { const next = new Set(prev); next.delete(trend); return next; })}
-                className="px-3 py-1.5 text-sm rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {trend}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {Array.from(selectedMovementPatterns).map(pattern => (
-              <button
-                key={`mov-${pattern}`}
-                onClick={() => setSelectedMovementPatterns(prev => { const next = new Set(prev); next.delete(pattern); return next; })}
-                className="px-3 py-1.5 text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {pattern}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {Array.from(selectedThreats).map(code => {
-              const cat = THREAT_CATEGORIES.find(c => c.code === code);
-              const sub = !cat ? THREAT_CATEGORIES.flatMap(c => c.children).find(c => c.code === code) : null;
-              const label = cat?.label || sub?.label || code;
-              return (
-                <button
-                  key={`threat-${code}`}
-                  onClick={() => setSelectedThreats(prev => { const next = new Set(prev); next.delete(code); return next; })}
-                  className="px-3 py-1.5 text-sm rounded-full bg-rose-100 text-rose-600 dark:bg-rose-900/30 dark:text-rose-400 flex items-center gap-1 hover:opacity-80"
-                >
-                  {label}
-                  <span className="text-sm">×</span>
-                </button>
-              );
-            })}
-            {Array.from(selectedSystems).map(system => (
-              <button
-                key={system}
-                onClick={() => setSelectedSystems(prev => { const next = new Set(prev); next.delete(system); return next; })}
-                className={`px-3 py-1.5 text-sm rounded-full flex items-center gap-1 hover:opacity-80 ${
-                  system === "Terrestrial" ? "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
-                  : system === "Freshwater" ? "bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400"
-                  : "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
-                }`}
-              >
-                {system}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedAssessors).map(name => (
-              <button
-                key={`a-${name}`}
-                onClick={() => setSelectedAssessors(prev => { const next = new Set(prev); next.delete(name); return next; })}
-                className="px-3 py-1.5 text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {name} <span className="text-[10px] opacity-60">(assessor)</span>
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedReviewers).map(name => (
-              <button
-                key={`r-${name}`}
-                onClick={() => setSelectedReviewers(prev => { const next = new Set(prev); next.delete(name); return next; })}
-                className="px-3 py-1.5 text-sm rounded-full bg-fuchsia-100 text-fuchsia-600 dark:bg-fuchsia-900/30 dark:text-fuchsia-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {name} <span className="text-[10px] opacity-60">(reviewer)</span>
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {/* Exact URL-only filters (typically arrive via an agent/MCP dashboard
-                link). Shown as chips so a human can see and clear them. */}
-            {(() => {
-              const ef = exactFilters;
-              const chips: { key: keyof typeof ef; label: string }[] = [];
-              if (ef.outdated) chips.push({ key: "outdated", label: ef.outdated === "yes" ? "Outdated (>10 yrs)" : "Current (≤10 yrs)" });
-              if (ef.minObs != null) chips.push({ key: "minObs", label: `≥ ${ef.minObs.toLocaleString()} obs` });
-              if (ef.maxObs != null) chips.push({ key: "maxObs", label: `≤ ${ef.maxObs.toLocaleString()} obs` });
-              if (ef.minAssessmentYear != null) chips.push({ key: "minAssessmentYear", label: `Assessed ≥ ${ef.minAssessmentYear}` });
-              if (ef.maxAssessmentYear != null) chips.push({ key: "maxAssessmentYear", label: `Assessed ≤ ${ef.maxAssessmentYear}` });
-              if (ef.minDescribedYear != null) chips.push({ key: "minDescribedYear", label: `Described ≥ ${ef.minDescribedYear}` });
-              if (ef.maxDescribedYear != null) chips.push({ key: "maxDescribedYear", label: `Described ≤ ${ef.maxDescribedYear}` });
-              return chips.map(c => (
-                <button
-                  key={`ef-${c.key}`}
-                  onClick={() => setExactFilters({ [c.key]: null })}
-                  className="px-3 py-1.5 text-sm rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300 flex items-center gap-1 hover:opacity-80"
-                >
-                  {c.label}
-                  <span className="text-sm">×</span>
-                </button>
-              ));
-            })()}
-            <span className="ml-auto text-sm md:text-base font-semibold text-zinc-700 dark:text-zinc-300 tabular-nums flex items-center gap-2">
-              {speciesLoading && totalFiltered === 0 && !singleSpeciesPreview ? (
-                <Spinner className="h-4 w-4" />
-              ) : (
-                <>{totalFiltered.toLocaleString()} species</>
-              )}
-            </span>
-            {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
-              <button
-                disabled={neBlockedForAll}
-                onClick={() => {
-                  if (neBlockedForAll) return;
-                  setSelectedCategories(prev => {
-                    const next = new Set(prev);
-                    if (next.has("NE")) {
-                      next.delete("NE");
-                    } else {
-                      next.add("NE");
-                    }
-                    return next;
-                  });
-                }}
-                className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
-                  neBlockedForAll
-                    ? "bg-white text-zinc-400 border border-zinc-200 opacity-60 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500 dark:border-zinc-700"
-                    : selectedCategories.has("NE")
-                    ? "bg-zinc-500 text-white"
-                    : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
-                }`}
-                title={neBlockedForAll ? "Not Evaluated species must be loaded per taxon group — too many to load for All Species at once" : "Show Not Evaluated species from GBIF"}
-              >
-                Not Evaluated
-                {!neBlockedForAll && <span className="text-[10px] opacity-70">({neCount.toLocaleString()})</span>}
-              </button>
-            )}
-          </div>
-        </div>
-
         {/* Species table */}
         {speciesLoading && assessedSpecies.length === 0 && !singleSpeciesPreview ? (
           <div className="flex items-center justify-center py-12">

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2539,364 +2539,365 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               sub-group row drilled into via TaxaSummary's own tree
               (selectedSubgroupTaxon: dynamic order/family/genus, or a static SSC
               group), or a non-curated arbitrary rank reached via search
-              (arbitraryTaxon). Two stat cards: the taxon (name + rank) and the
-              Species card. The Species card's header is a plain "Species"
-              label with the Assessed/Not Evaluated toggle to its right (not
-              as the header itself — that read as too clever/unclear); the
-              toggle lives here rather than the landing-only row alongside the
-              View selector so it's usable at any drill-down depth (Assessed/
-              Not Evaluated scope matters just as much in single-taxon view as
-              on the landing page, unlike View-by, which is about browsing mode
-              and stops mattering once you've committed to a taxon). The number
-              is totalFiltered (live, reacts to pill filters) with a qualifier
-              once a filter narrows it below the taxon's own total
-              (taxaFilteredSpeciesBase): "matching filters (of Y assessed/not
-              evaluated total)" — naming the total's own metric explicitly
-              avoids the earlier "of Y" ambiguity (could otherwise read as a
-              completely different ratio, e.g. assessed-of-described). Applied
-              filters (Clear all/Starred/chips/Not Evaluated shortcut) live
-              inside this same card below the number, instead of a separate
-              row — deliberately excludes selectedTaxa/selectedSubgroups/
-              breakdownFilter from both the chip list and Clear all, since
-              those are taxonomy navigation, not filters; Home is what clears
-              them. TaxaSummary's own breadcrumb table above already shows the
-              tree branch that led here (Mammals → Rodentia → Heteromyidae →
-              ...) when applicable — this is purely an additional, more
-              prominent summary, not a replacement for it. */}
+              (arbitraryTaxon). Two stat cards: the taxon (name + rank, plus
+              applied filters in its top-right corner — see below) and the
+              Species card (label + Assessed/Not Evaluated toggle, vertically
+              centered against the whole card like the original pre-redesign
+              layout). The toggle lives here rather than the landing-only row
+              alongside the View selector so it's usable at any drill-down
+              depth (Assessed/Not Evaluated scope matters just as much in
+              single-taxon view as on the landing page, unlike View-by, which
+              is about browsing mode and stops mattering once you've committed
+              to a taxon). The number is totalFiltered (live, reacts to pill
+              filters) with a qualifier once a filter narrows it below the
+              taxon's own total (taxaFilteredSpeciesBase): "matching filters
+              (of Y assessed/not evaluated total)" — naming the total's own
+              metric explicitly avoids the earlier "of Y" ambiguity (could
+              otherwise read as a completely different ratio, e.g. assessed-
+              of-described).
+
+              Applied filters (Clear all/Starred/chips/Not Evaluated shortcut)
+              sit in the TAXON card's top-right corner, not the Species card —
+              small and wrapping there, so the row doesn't visibly grow the
+              instant a single filter is added (it still grows once enough
+              chips wrap to a second line, which is fine — that's an actual
+              size increase, not a false one). Deliberately excludes
+              selectedTaxa/selectedSubgroups/breakdownFilter from both the chip
+              list and Clear all, since those are taxonomy navigation, not
+              filters; Home is what clears them. TaxaSummary's own breadcrumb
+              table above already shows the tree branch that led here (Mammals
+              → Rodentia → Heteromyidae → ...) when applicable — this is
+              purely an additional, more prominent summary, not a replacement
+              for it. */}
           {focusedTaxonCard && !isSingleSpecies && (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
-                <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                  {focusedTaxonCard.rank ?? "Taxon"}
+                <div className="flex items-start justify-between gap-2">
+                  <span className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400 shrink-0">
+                    {focusedTaxonCard.rank ?? "Taxon"}
+                  </span>
+                  {(hasActiveFilters || pinnedSpecies.length > 0 || (!isNewAssessments && (neCount > 0 || neBlockedForAll))) && (
+                    <div className="flex flex-wrap items-center justify-end gap-1">
+                      {hasActiveFilters && (
+                        <button
+                          onClick={() => {
+                            setSelectedCategories(new Set());
+                            setSelectedYearRanges(new Set());
+                            setSelectedAssessmentYears(new Set());
+                            setSelectedDescribedYears(new Set());
+                            setSelectedObsRanges(new Set());
+                            setSelectedCountries(new Set());
+                            setSelectedSystems(new Set());
+                            setEndemicsOnly(false);
+                            setSelectedGrowthForms(new Set());
+                            setSelectedPopulationTrends(new Set());
+                            setSelectedMovementPatterns(new Set());
+                            setSelectedThreats(new Set());
+                            setExpandedThreat(null);
+                            setSelectedAssessors(new Set());
+                            setSelectedReviewers(new Set());
+                            setShowOnlyStarred(false);
+                            setExactFilters(EMPTY_EXACT_FILTERS);
+                          }}
+                          title="Reset all filters (taxon selection stays — use Home to clear that)"
+                          className="px-1.5 py-0.5 rounded-md text-[11px] font-medium transition-colors flex items-center gap-1 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
+                        >
+                          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                          </svg>
+                          Clear all
+                        </button>
+                      )}
+                      {pinnedSpecies.length > 0 && (
+                        <button
+                          onClick={() => setShowOnlyStarred(!showOnlyStarred)}
+                          className={`px-1.5 py-0.5 rounded-md text-[11px] font-medium transition-colors flex items-center gap-1 ${
+                            showOnlyStarred
+                              ? "bg-amber-500 text-white"
+                              : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
+                          }`}
+                        >
+                          <svg className="w-3 h-3" fill={showOnlyStarred ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+                          </svg>
+                          {pinnedSpecies.length}
+                        </button>
+                      )}
+                      {!isNewAssessments && Array.from(selectedCategories).filter(cat => cat !== "NE").map(cat => (
+                        <button
+                          key={cat}
+                          onClick={() => setSelectedCategories(prev => { const next = new Set(prev); next.delete(cat); return next; })}
+                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full flex items-center gap-0.5 hover:opacity-80"
+                          style={{ backgroundColor: CATEGORY_COLORS[cat] + "20", color: CATEGORY_COLORS[cat] }}
+                        >
+                          {cat}
+                          <span className="text-[11px]">×</span>
+                        </button>
+                      ))}
+                      {!isNewAssessments && Array.from(selectedYearRanges).map(range => (
+                        <button
+                          key={range}
+                          onClick={() => setSelectedYearRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-0.5 hover:opacity-80"
+                        >
+                          {range}
+                          <span className="text-[11px]">×</span>
+                        </button>
+                      ))}
+                      {!isNewAssessments && Array.from(selectedAssessmentYears).sort((a, b) => Number(b) - Number(a)).map(year => (
+                        <button
+                          key={`ay-${year}`}
+                          onClick={() => setSelectedAssessmentYears(prev => { const next = new Set(prev); next.delete(year); return next; })}
+                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-0.5 hover:opacity-80"
+                        >
+                          Assessed {year}
+                          <span className="text-[11px]">×</span>
+                        </button>
+                      ))}
+                      {isNewAssessments && Array.from(selectedDescribedYears).map(range => (
+                        <button
+                          key={`dy-${range}`}
+                          onClick={() => setSelectedDescribedYears(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-0.5 hover:opacity-80"
+                        >
+                          Described {range}
+                          <span className="text-[11px]">×</span>
+                        </button>
+                      ))}
+                      {Array.from(selectedObsRanges).map(range => (
+                        <button
+                          key={range}
+                          onClick={() => setSelectedObsRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400 flex items-center gap-0.5 hover:opacity-80"
+                        >
+                          {range} obs
+                          <span className="text-[11px]">×</span>
+                        </button>
+                      ))}
+                      {(() => {
+                        if (selectedCountries.size === 0) return null;
+                        // Check if selected countries exactly match a single IUCN region
+                        const regions = new Set<string>();
+                        selectedCountries.forEach(c => regions.add(countryToIucnRegion(c)));
+                        if (regions.size === 1) {
+                          const region = [...regions][0];
+                          if (region !== "Other") {
+                            const regionCodes = iucnRegionCountries(region);
+                            if (regionCodes.length === selectedCountries.size && regionCodes.every(c => selectedCountries.has(c))) {
+                              return (
+                                <button
+                                  onClick={() => setSelectedCountries(new Set())}
+                                  className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-0.5 hover:opacity-80"
+                                >
+                                  {region}
+                                  <span className="text-[11px]">×</span>
+                                </button>
+                              );
+                            }
+                          }
+                        }
+                        // Otherwise show individual country pills
+                        return Array.from(selectedCountries).map(code => (
+                          <button
+                            key={code}
+                            onClick={() => setSelectedCountries(prev => { const next = new Set(prev); next.delete(code); return next; })}
+                            className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-0.5 hover:opacity-80"
+                          >
+                            {getCountryName(code)}
+                            <span className="text-[11px]">×</span>
+                          </button>
+                        ));
+                      })()}
+                      {Array.from(selectedGrowthForms).map(gf => (
+                        <button
+                          key={`gf-${gf}`}
+                          onClick={() => setSelectedGrowthForms(prev => { const next = new Set(prev); next.delete(gf); return next; })}
+                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-lime-100 text-lime-600 dark:bg-lime-900/30 dark:text-lime-400 flex items-center gap-0.5 hover:opacity-80"
+                        >
+                          {gf}
+                          <span className="text-[11px]">×</span>
+                        </button>
+                      ))}
+                      {endemicsOnly && (
+                        <button
+                          onClick={() => setEndemicsOnly(false)}
+                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-0.5 hover:opacity-80"
+                        >
+                          Endemics only
+                          <span className="text-[11px]">×</span>
+                        </button>
+                      )}
+                      {Array.from(selectedPopulationTrends).map(trend => (
+                        <button
+                          key={`trend-${trend}`}
+                          onClick={() => setSelectedPopulationTrends(prev => { const next = new Set(prev); next.delete(trend); return next; })}
+                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400 flex items-center gap-0.5 hover:opacity-80"
+                        >
+                          {trend}
+                          <span className="text-[11px]">×</span>
+                        </button>
+                      ))}
+                      {Array.from(selectedMovementPatterns).map(pattern => (
+                        <button
+                          key={`mov-${pattern}`}
+                          onClick={() => setSelectedMovementPatterns(prev => { const next = new Set(prev); next.delete(pattern); return next; })}
+                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-0.5 hover:opacity-80"
+                        >
+                          {pattern}
+                          <span className="text-[11px]">×</span>
+                        </button>
+                      ))}
+                      {Array.from(selectedThreats).map(code => {
+                        const cat = THREAT_CATEGORIES.find(c => c.code === code);
+                        const sub = !cat ? THREAT_CATEGORIES.flatMap(c => c.children).find(c => c.code === code) : null;
+                        const label = cat?.label || sub?.label || code;
+                        return (
+                          <button
+                            key={`threat-${code}`}
+                            onClick={() => setSelectedThreats(prev => { const next = new Set(prev); next.delete(code); return next; })}
+                            className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-rose-100 text-rose-600 dark:bg-rose-900/30 dark:text-rose-400 flex items-center gap-0.5 hover:opacity-80"
+                          >
+                            {label}
+                            <span className="text-[11px]">×</span>
+                          </button>
+                        );
+                      })}
+                      {Array.from(selectedSystems).map(system => (
+                        <button
+                          key={system}
+                          onClick={() => setSelectedSystems(prev => { const next = new Set(prev); next.delete(system); return next; })}
+                          className={`px-1.5 py-0.5 text-[11px] font-medium rounded-full flex items-center gap-0.5 hover:opacity-80 ${
+                            system === "Terrestrial" ? "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
+                            : system === "Freshwater" ? "bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400"
+                            : "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
+                          }`}
+                        >
+                          {system}
+                          <span className="text-[11px]">×</span>
+                        </button>
+                      ))}
+                      {!isNewAssessments && Array.from(selectedAssessors).map(name => (
+                        <button
+                          key={`a-${name}`}
+                          onClick={() => setSelectedAssessors(prev => { const next = new Set(prev); next.delete(name); return next; })}
+                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-0.5 hover:opacity-80"
+                        >
+                          {name}
+                          <span className="text-[11px]">×</span>
+                        </button>
+                      ))}
+                      {!isNewAssessments && Array.from(selectedReviewers).map(name => (
+                        <button
+                          key={`r-${name}`}
+                          onClick={() => setSelectedReviewers(prev => { const next = new Set(prev); next.delete(name); return next; })}
+                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-fuchsia-100 text-fuchsia-600 dark:bg-fuchsia-900/30 dark:text-fuchsia-400 flex items-center gap-0.5 hover:opacity-80"
+                        >
+                          {name}
+                          <span className="text-[11px]">×</span>
+                        </button>
+                      ))}
+                      {(() => {
+                        const ef = exactFilters;
+                        const chips: { key: keyof typeof ef; label: string }[] = [];
+                        if (ef.outdated) chips.push({ key: "outdated", label: ef.outdated === "yes" ? "Outdated (>10 yrs)" : "Current (≤10 yrs)" });
+                        if (ef.minObs != null) chips.push({ key: "minObs", label: `≥ ${ef.minObs.toLocaleString()} obs` });
+                        if (ef.maxObs != null) chips.push({ key: "maxObs", label: `≤ ${ef.maxObs.toLocaleString()} obs` });
+                        if (ef.minAssessmentYear != null) chips.push({ key: "minAssessmentYear", label: `Assessed ≥ ${ef.minAssessmentYear}` });
+                        if (ef.maxAssessmentYear != null) chips.push({ key: "maxAssessmentYear", label: `Assessed ≤ ${ef.maxAssessmentYear}` });
+                        if (ef.minDescribedYear != null) chips.push({ key: "minDescribedYear", label: `Described ≥ ${ef.minDescribedYear}` });
+                        if (ef.maxDescribedYear != null) chips.push({ key: "maxDescribedYear", label: `Described ≤ ${ef.maxDescribedYear}` });
+                        return chips.map(c => (
+                          <button
+                            key={`ef-${c.key}`}
+                            onClick={() => setExactFilters({ [c.key]: null })}
+                            className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300 flex items-center gap-0.5 hover:opacity-80"
+                          >
+                            {c.label}
+                            <span className="text-[11px]">×</span>
+                          </button>
+                        ));
+                      })()}
+                      {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
+                        <button
+                          disabled={neBlockedForAll}
+                          onClick={() => {
+                            if (neBlockedForAll) return;
+                            setSelectedCategories(prev => {
+                              const next = new Set(prev);
+                              if (next.has("NE")) {
+                                next.delete("NE");
+                              } else {
+                                next.add("NE");
+                              }
+                              return next;
+                            });
+                          }}
+                          className={`px-1.5 py-0.5 rounded-md text-[11px] font-medium transition-colors flex items-center gap-1 ${
+                            neBlockedForAll
+                              ? "bg-white text-zinc-400 border border-zinc-200 opacity-60 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500 dark:border-zinc-700"
+                              : selectedCategories.has("NE")
+                              ? "bg-zinc-500 text-white"
+                              : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
+                          }`}
+                          title={neBlockedForAll ? "Not Evaluated species must be loaded per taxon group — too many to load for All Species at once" : "Show Not Evaluated species from GBIF"}
+                        >
+                          NE{!neBlockedForAll && ` (${neCount.toLocaleString()})`}
+                        </button>
+                      )}
+                    </div>
+                  )}
                 </div>
                 <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
                   {focusedTaxonCard.name}
                 </div>
               </div>
-              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                    Species
-                  </span>
-                  {onViewModeChange && (
-                    <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
-                      <button
-                        type="button"
-                        onClick={() => onViewModeChange("reassessments")}
-                        className={`px-2 py-1 font-medium transition-colors ${
-                          !isNewAssessments
-                            ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                            : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                        }`}
-                      >
-                        Assessed
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onViewModeChange("new-assessments")}
-                        className={`px-2 py-1 font-medium transition-colors ${
-                          isNewAssessments
-                            ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                            : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                        }`}
-                      >
-                        Not Evaluated
-                      </button>
-                    </div>
-                  )}
-                </div>
-                <div className="mt-1 flex items-baseline gap-1.5 flex-wrap">
-                  {speciesLoading && assessedSpecies.length === 0 ? (
-                    <Spinner className="h-6 w-6" />
-                  ) : (
-                    <>
-                      <span className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                        {totalFiltered.toLocaleString()}
-                      </span>
-                      {totalFiltered !== taxaFilteredSpeciesBase.length && (
-                        <span className="text-sm font-medium text-zinc-400 dark:text-zinc-500">
-                          matching filters (of {taxaFilteredSpeciesBase.length.toLocaleString()} {isNewAssessments ? "not evaluated" : "assessed"} total)
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                    {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
+                  </div>
+                  <div className="mt-0.5 flex items-baseline gap-1.5 flex-wrap">
+                    {speciesLoading && assessedSpecies.length === 0 ? (
+                      <Spinner className="h-6 w-6" />
+                    ) : (
+                      <>
+                        <span className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                          {totalFiltered.toLocaleString()}
                         </span>
-                      )}
-                    </>
-                  )}
+                        {totalFiltered !== taxaFilteredSpeciesBase.length && (
+                          <span className="text-sm font-medium text-zinc-400 dark:text-zinc-500">
+                            matching filters (of {taxaFilteredSpeciesBase.length.toLocaleString()} {isNewAssessments ? "not evaluated" : "assessed"} total)
+                          </span>
+                        )}
+                      </>
+                    )}
+                  </div>
                 </div>
-                {(hasActiveFilters || pinnedSpecies.length > 0 || (!isNewAssessments && (neCount > 0 || neBlockedForAll))) && (
-              <div className="mt-3 pt-3 border-t border-zinc-100 dark:border-zinc-800 flex flex-wrap items-center gap-2 md:gap-4">
-              {hasActiveFilters && (
-                <button
-                  onClick={() => {
-                    setSelectedCategories(new Set());
-                    setSelectedYearRanges(new Set());
-                    setSelectedAssessmentYears(new Set());
-                    setSelectedDescribedYears(new Set());
-                    setSelectedObsRanges(new Set());
-                    setSelectedCountries(new Set());
-                    setSelectedSystems(new Set());
-                    setEndemicsOnly(false);
-                    setSelectedGrowthForms(new Set());
-                    setSelectedPopulationTrends(new Set());
-                    setSelectedMovementPatterns(new Set());
-                    setSelectedThreats(new Set());
-                    setExpandedThreat(null);
-                    setSelectedAssessors(new Set());
-                    setSelectedReviewers(new Set());
-                    setShowOnlyStarred(false);
-                    setExactFilters(EMPTY_EXACT_FILTERS);
-                  }}
-                  title="Reset all filters (taxon selection stays — use Home to clear that)"
-                  className="px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
-                >
-                  <svg className="w-3.5 h-3.5 md:w-4 md:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                  <span className="hidden sm:inline">Clear all</span>
-                </button>
-              )}
-              {pinnedSpecies.length > 0 && (
-                <button
-                  onClick={() => setShowOnlyStarred(!showOnlyStarred)}
-                  className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
-                    showOnlyStarred
-                      ? "bg-amber-500 text-white"
-                      : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
-                  }`}
-                >
-                  <svg className="w-4 h-4" fill={showOnlyStarred ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-                  </svg>
-                  <span className="hidden sm:inline">Starred</span> ({pinnedSpecies.length})
-                </button>
-              )}
-              {!isNewAssessments && Array.from(selectedCategories).filter(cat => cat !== "NE").map(cat => (
-                <button
-                  key={cat}
-                onClick={() => setSelectedCategories(prev => { const next = new Set(prev); next.delete(cat); return next; })}
-                className="px-3 py-1.5 text-sm font-medium rounded-full flex items-center gap-1 hover:opacity-80"
-                style={{ backgroundColor: CATEGORY_COLORS[cat] + "20", color: CATEGORY_COLORS[cat] }}
-              >
-                {cat}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedYearRanges).map(range => (
-              <button
-                key={range}
-                onClick={() => setSelectedYearRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-3 py-1.5 text-sm font-medium rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {range}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedAssessmentYears).sort((a, b) => Number(b) - Number(a)).map(year => (
-              <button
-                key={`ay-${year}`}
-                onClick={() => setSelectedAssessmentYears(prev => { const next = new Set(prev); next.delete(year); return next; })}
-                className="px-3 py-1.5 text-sm font-medium rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
-              >
-                Assessed {year}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {isNewAssessments && Array.from(selectedDescribedYears).map(range => (
-              <button
-                key={`dy-${range}`}
-                onClick={() => setSelectedDescribedYears(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-3 py-1.5 text-sm font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-              >
-                Described {range}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {Array.from(selectedObsRanges).map(range => (
-              <button
-                key={range}
-                onClick={() => setSelectedObsRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-3 py-1.5 text-sm font-medium rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {range} obs
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {(() => {
-              if (selectedCountries.size === 0) return null;
-              // Check if selected countries exactly match a single IUCN region
-              const regions = new Set<string>();
-              selectedCountries.forEach(c => regions.add(countryToIucnRegion(c)));
-              if (regions.size === 1) {
-                const region = [...regions][0];
-                if (region !== "Other") {
-                  const regionCodes = iucnRegionCountries(region);
-                  if (regionCodes.length === selectedCountries.size && regionCodes.every(c => selectedCountries.has(c))) {
-                    return (
-                      <button
-                        onClick={() => setSelectedCountries(new Set())}
-                        className="px-3 py-1.5 text-sm font-medium rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
-                      >
-                        {region}
-                        <span className="text-sm">×</span>
-                      </button>
-                    );
-                  }
-                }
-              }
-              // Otherwise show individual country pills
-              return Array.from(selectedCountries).map(code => (
-                <button
-                  key={code}
-                  onClick={() => setSelectedCountries(prev => { const next = new Set(prev); next.delete(code); return next; })}
-                  className="px-3 py-1.5 text-sm font-medium rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
-                >
-                  {getCountryName(code)}
-                  <span className="text-sm">×</span>
-                </button>
-              ));
-            })()}
-            {Array.from(selectedGrowthForms).map(gf => (
-              <button
-                key={`gf-${gf}`}
-                onClick={() => setSelectedGrowthForms(prev => { const next = new Set(prev); next.delete(gf); return next; })}
-                className="px-3 py-1.5 text-sm font-medium rounded-full bg-lime-100 text-lime-600 dark:bg-lime-900/30 dark:text-lime-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {gf}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {endemicsOnly && (
-              <button
-                onClick={() => setEndemicsOnly(false)}
-                className="px-3 py-1.5 text-sm font-medium rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
-              >
-                Endemics only
-                <span className="text-sm">×</span>
-              </button>
-            )}
-            {Array.from(selectedPopulationTrends).map(trend => (
-              <button
-                key={`trend-${trend}`}
-                onClick={() => setSelectedPopulationTrends(prev => { const next = new Set(prev); next.delete(trend); return next; })}
-                className="px-3 py-1.5 text-sm font-medium rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {trend}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {Array.from(selectedMovementPatterns).map(pattern => (
-              <button
-                key={`mov-${pattern}`}
-                onClick={() => setSelectedMovementPatterns(prev => { const next = new Set(prev); next.delete(pattern); return next; })}
-                className="px-3 py-1.5 text-sm font-medium rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {pattern}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {Array.from(selectedThreats).map(code => {
-              const cat = THREAT_CATEGORIES.find(c => c.code === code);
-              const sub = !cat ? THREAT_CATEGORIES.flatMap(c => c.children).find(c => c.code === code) : null;
-              const label = cat?.label || sub?.label || code;
-              return (
-                <button
-                  key={`threat-${code}`}
-                  onClick={() => setSelectedThreats(prev => { const next = new Set(prev); next.delete(code); return next; })}
-                  className="px-3 py-1.5 text-sm font-medium rounded-full bg-rose-100 text-rose-600 dark:bg-rose-900/30 dark:text-rose-400 flex items-center gap-1 hover:opacity-80"
-                >
-                  {label}
-                  <span className="text-sm">×</span>
-                </button>
-              );
-            })}
-            {Array.from(selectedSystems).map(system => (
-              <button
-                key={system}
-                onClick={() => setSelectedSystems(prev => { const next = new Set(prev); next.delete(system); return next; })}
-                className={`px-3 py-1.5 text-sm font-medium rounded-full flex items-center gap-1 hover:opacity-80 ${
-                  system === "Terrestrial" ? "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
-                  : system === "Freshwater" ? "bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400"
-                  : "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
-                }`}
-              >
-                {system}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedAssessors).map(name => (
-              <button
-                key={`a-${name}`}
-                onClick={() => setSelectedAssessors(prev => { const next = new Set(prev); next.delete(name); return next; })}
-                className="px-3 py-1.5 text-sm font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {name} <span className="text-[10px] opacity-60">(assessor)</span>
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedReviewers).map(name => (
-              <button
-                key={`r-${name}`}
-                onClick={() => setSelectedReviewers(prev => { const next = new Set(prev); next.delete(name); return next; })}
-                className="px-3 py-1.5 text-sm font-medium rounded-full bg-fuchsia-100 text-fuchsia-600 dark:bg-fuchsia-900/30 dark:text-fuchsia-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {name} <span className="text-[10px] opacity-60">(reviewer)</span>
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {/* Exact URL-only filters (typically arrive via an agent/MCP dashboard
-                link). Shown as chips so a human can see and clear them. */}
-            {(() => {
-              const ef = exactFilters;
-              const chips: { key: keyof typeof ef; label: string }[] = [];
-              if (ef.outdated) chips.push({ key: "outdated", label: ef.outdated === "yes" ? "Outdated (>10 yrs)" : "Current (≤10 yrs)" });
-              if (ef.minObs != null) chips.push({ key: "minObs", label: `≥ ${ef.minObs.toLocaleString()} obs` });
-              if (ef.maxObs != null) chips.push({ key: "maxObs", label: `≤ ${ef.maxObs.toLocaleString()} obs` });
-              if (ef.minAssessmentYear != null) chips.push({ key: "minAssessmentYear", label: `Assessed ≥ ${ef.minAssessmentYear}` });
-              if (ef.maxAssessmentYear != null) chips.push({ key: "maxAssessmentYear", label: `Assessed ≤ ${ef.maxAssessmentYear}` });
-              if (ef.minDescribedYear != null) chips.push({ key: "minDescribedYear", label: `Described ≥ ${ef.minDescribedYear}` });
-              if (ef.maxDescribedYear != null) chips.push({ key: "maxDescribedYear", label: `Described ≤ ${ef.maxDescribedYear}` });
-              return chips.map(c => (
-                <button
-                  key={`ef-${c.key}`}
-                  onClick={() => setExactFilters({ [c.key]: null })}
-                  className="px-3 py-1.5 text-sm font-medium rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300 flex items-center gap-1 hover:opacity-80"
-                >
-                  {c.label}
-                  <span className="text-sm">×</span>
-                </button>
-              ));
-            })()}
-            {/* No standalone species-count readout here — the number above
-                already states it (with the "matching filters" qualifier).
-                ml-auto on the Not Evaluated button below keeps it right-
-                aligned while the rest of the pills hug the left. */}
-            {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
-              <button
-                disabled={neBlockedForAll}
-                onClick={() => {
-                  if (neBlockedForAll) return;
-                  setSelectedCategories(prev => {
-                    const next = new Set(prev);
-                    if (next.has("NE")) {
-                      next.delete("NE");
-                    } else {
-                      next.add("NE");
-                    }
-                    return next;
-                  });
-                }}
-                className={`ml-auto px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
-                  neBlockedForAll
-                    ? "bg-white text-zinc-400 border border-zinc-200 opacity-60 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500 dark:border-zinc-700"
-                    : selectedCategories.has("NE")
-                    ? "bg-zinc-500 text-white"
-                    : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
-                }`}
-                title={neBlockedForAll ? "Not Evaluated species must be loaded per taxon group — too many to load for All Species at once" : "Show Not Evaluated species from GBIF"}
-              >
-                Not Evaluated
-                {!neBlockedForAll && <span className="text-[10px] opacity-70">({neCount.toLocaleString()})</span>}
-              </button>
-            )}
-              </div>
+                {onViewModeChange && (
+                  <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => onViewModeChange("reassessments")}
+                      className={`px-2 py-1 font-medium transition-colors ${
+                        !isNewAssessments
+                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                      }`}
+                    >
+                      Assessed
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onViewModeChange("new-assessments")}
+                      className={`px-2 py-1 font-medium transition-colors ${
+                        isNewAssessments
+                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                      }`}
+                    >
+                      Not Evaluated
+                    </button>
+                  </div>
                 )}
               </div>
             </div>

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -12,12 +12,12 @@ import EolSummary from "../EolSummary";
 import TaxaIcon from "../TaxaIcon";
 import { ALPHA2_TO_NAME, type CountryStats } from "../WorldMap";
 import { CATEGORY_COLORS, TAXA_BY_ID, THREATENED_CATEGORIES } from "@/config/taxa";
-import { speciesMatchesNode, getViewRootForNode, findNode, matchesBreakdownName, primaryFilterRank } from "@/lib/taxonomy-utils";
+import { speciesMatchesNode, getNodeDef, getViewRootForNode, findNode, matchesBreakdownName, breakdownDisplayName, primaryFilterRank } from "@/lib/taxonomy-utils";
 import { dynamicNodeDisplayName, isDynamicNodeId, dynamicNodeRankInfo } from "@/lib/dynamic-taxon";
 import ReviewerChart from "./ReviewerChart";
 import { parseAssessors } from "@/lib/parseAssessors";
 import { iucnRegionCountries, countryToIucnRegion } from "@/lib/regions";
-import { useFilterParams, EMPTY_EXACT_FILTERS } from "@/hooks/useFilterParams";
+import { useFilterParams } from "@/hooks/useFilterParams";
 import { type RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
 import { isOutdated, outdatedCutoffDate } from "@/lib/outdated";
 
@@ -330,7 +330,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     selectedPopulationTrends, setSelectedPopulationTrends,
     selectedMovementPatterns, setSelectedMovementPatterns,
     selectedThreats, setSelectedThreats,
-    breakdownFilter,
+    breakdownFilter, setBreakdownFilter,
     endemicsOnly, setEndemicsOnly,
     selectedGrowthForms, setSelectedGrowthForms,
     selectedAssessors, setSelectedAssessors,
@@ -340,6 +340,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     sortField, sortDirection, setSort,
     mapViewMode, mapSortKey, mapSortDirection, setMapViewMode, setMapSort,
     clearAllFilters,
+    clearAllFiltersAndTaxa,
     setViewMode: setUrlViewMode,
     species: urlSpecies, tab: urlTab,
     setSpeciesParam, setTabParam,
@@ -2450,12 +2451,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     </div>
   );
 
-  // Whether any real filter (category/year/country/growth-form/etc.) is
-  // active — deliberately excludes selectedTaxa/selectedSubgroups/
-  // breakdownFilter, which are taxonomy navigation, not filters: clearing
-  // those is what Home is for, not the Matching Filters card's Clear all.
-  const hasActiveFilters = selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null;
-
   return (
     <div className="space-y-4 min-w-0">
       {/* Always show Taxa Summary table */}
@@ -2539,313 +2534,24 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               sub-group row drilled into via TaxaSummary's own tree
               (selectedSubgroupTaxon: dynamic order/family/genus, or a static SSC
               group), or a non-curated arbitrary rank reached via search
-              (arbitraryTaxon). Two stat cards: the taxon (name + rank, plus
-              applied filters in its top-right corner — see below) and the
-              Species card (label + Assessed/Not Evaluated toggle, vertically
-              centered against the whole card like the original pre-redesign
-              layout). The toggle lives here rather than the landing-only row
-              alongside the View selector so it's usable at any drill-down
-              depth (Assessed/Not Evaluated scope matters just as much in
-              single-taxon view as on the landing page, unlike View-by, which
-              is about browsing mode and stops mattering once you've committed
-              to a taxon). The number is totalFiltered (live, reacts to pill
-              filters) with a qualifier once a filter narrows it below the
-              taxon's own total (taxaFilteredSpeciesBase): "matching filters
-              (of Y assessed/not evaluated total)" — naming the total's own
-              metric explicitly avoids the earlier "of Y" ambiguity (could
-              otherwise read as a completely different ratio, e.g. assessed-
-              of-described).
-
-              Applied filters (Clear all/Starred/chips/Not Evaluated shortcut)
-              sit in the TAXON card's top-right corner, not the Species card —
-              small and wrapping there, so the row doesn't visibly grow the
-              instant a single filter is added (it still grows once enough
-              chips wrap to a second line, which is fine — that's an actual
-              size increase, not a false one). Deliberately excludes
-              selectedTaxa/selectedSubgroups/breakdownFilter from both the chip
-              list and Clear all, since those are taxonomy navigation, not
-              filters; Home is what clears them. TaxaSummary's own breadcrumb
-              table above already shows the tree branch that led here (Mammals
-              → Rodentia → Heteromyidae → ...) when applicable — this is
-              purely an additional, more prominent summary, not a replacement
-              for it. */}
+              (arbitraryTaxon). Two fixed stat cards — the taxon (name + rank)
+              and its total species count (taxaFilteredSpeciesBase) — neither
+              reacts to pill filters, so this row never grows/changes as
+              filters are added; the applied-filters row below (right above
+              the species table) is what shows the live, filtered picture.
+              The Species card's Assessed/Not Evaluated toggle sits to the
+              right of its label, vertically centered against the whole card;
+              it lives here (not the landing-only row with the View selector)
+              so it's usable at any drill-down depth. TaxaSummary's own
+              breadcrumb table above already shows the tree branch that led
+              here (Mammals → Rodentia → Heteromyidae → ...) when applicable —
+              this is purely an additional, more prominent summary, not a
+              replacement for it. */}
           {focusedTaxonCard && !isSingleSpecies && (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
-                <div className="flex items-start justify-between gap-2">
-                  <span className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400 shrink-0">
-                    {focusedTaxonCard.rank ?? "Taxon"}
-                  </span>
-                  {(hasActiveFilters || pinnedSpecies.length > 0 || (!isNewAssessments && (neCount > 0 || neBlockedForAll))) && (
-                    <div className="flex flex-wrap items-center justify-end gap-1">
-                      {hasActiveFilters && (
-                        <button
-                          onClick={() => {
-                            setSelectedCategories(new Set());
-                            setSelectedYearRanges(new Set());
-                            setSelectedAssessmentYears(new Set());
-                            setSelectedDescribedYears(new Set());
-                            setSelectedObsRanges(new Set());
-                            setSelectedCountries(new Set());
-                            setSelectedSystems(new Set());
-                            setEndemicsOnly(false);
-                            setSelectedGrowthForms(new Set());
-                            setSelectedPopulationTrends(new Set());
-                            setSelectedMovementPatterns(new Set());
-                            setSelectedThreats(new Set());
-                            setExpandedThreat(null);
-                            setSelectedAssessors(new Set());
-                            setSelectedReviewers(new Set());
-                            setShowOnlyStarred(false);
-                            setExactFilters(EMPTY_EXACT_FILTERS);
-                          }}
-                          title="Reset all filters (taxon selection stays — use Home to clear that)"
-                          className="px-1.5 py-0.5 rounded-md text-[11px] font-medium transition-colors flex items-center gap-1 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
-                        >
-                          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                          </svg>
-                          Clear all
-                        </button>
-                      )}
-                      {pinnedSpecies.length > 0 && (
-                        <button
-                          onClick={() => setShowOnlyStarred(!showOnlyStarred)}
-                          className={`px-1.5 py-0.5 rounded-md text-[11px] font-medium transition-colors flex items-center gap-1 ${
-                            showOnlyStarred
-                              ? "bg-amber-500 text-white"
-                              : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
-                          }`}
-                        >
-                          <svg className="w-3 h-3" fill={showOnlyStarred ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-                          </svg>
-                          {pinnedSpecies.length}
-                        </button>
-                      )}
-                      {!isNewAssessments && Array.from(selectedCategories).filter(cat => cat !== "NE").map(cat => (
-                        <button
-                          key={cat}
-                          onClick={() => setSelectedCategories(prev => { const next = new Set(prev); next.delete(cat); return next; })}
-                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full flex items-center gap-0.5 hover:opacity-80"
-                          style={{ backgroundColor: CATEGORY_COLORS[cat] + "20", color: CATEGORY_COLORS[cat] }}
-                        >
-                          {cat}
-                          <span className="text-[11px]">×</span>
-                        </button>
-                      ))}
-                      {!isNewAssessments && Array.from(selectedYearRanges).map(range => (
-                        <button
-                          key={range}
-                          onClick={() => setSelectedYearRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-0.5 hover:opacity-80"
-                        >
-                          {range}
-                          <span className="text-[11px]">×</span>
-                        </button>
-                      ))}
-                      {!isNewAssessments && Array.from(selectedAssessmentYears).sort((a, b) => Number(b) - Number(a)).map(year => (
-                        <button
-                          key={`ay-${year}`}
-                          onClick={() => setSelectedAssessmentYears(prev => { const next = new Set(prev); next.delete(year); return next; })}
-                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-0.5 hover:opacity-80"
-                        >
-                          Assessed {year}
-                          <span className="text-[11px]">×</span>
-                        </button>
-                      ))}
-                      {isNewAssessments && Array.from(selectedDescribedYears).map(range => (
-                        <button
-                          key={`dy-${range}`}
-                          onClick={() => setSelectedDescribedYears(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-0.5 hover:opacity-80"
-                        >
-                          Described {range}
-                          <span className="text-[11px]">×</span>
-                        </button>
-                      ))}
-                      {Array.from(selectedObsRanges).map(range => (
-                        <button
-                          key={range}
-                          onClick={() => setSelectedObsRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400 flex items-center gap-0.5 hover:opacity-80"
-                        >
-                          {range} obs
-                          <span className="text-[11px]">×</span>
-                        </button>
-                      ))}
-                      {(() => {
-                        if (selectedCountries.size === 0) return null;
-                        // Check if selected countries exactly match a single IUCN region
-                        const regions = new Set<string>();
-                        selectedCountries.forEach(c => regions.add(countryToIucnRegion(c)));
-                        if (regions.size === 1) {
-                          const region = [...regions][0];
-                          if (region !== "Other") {
-                            const regionCodes = iucnRegionCountries(region);
-                            if (regionCodes.length === selectedCountries.size && regionCodes.every(c => selectedCountries.has(c))) {
-                              return (
-                                <button
-                                  onClick={() => setSelectedCountries(new Set())}
-                                  className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-0.5 hover:opacity-80"
-                                >
-                                  {region}
-                                  <span className="text-[11px]">×</span>
-                                </button>
-                              );
-                            }
-                          }
-                        }
-                        // Otherwise show individual country pills
-                        return Array.from(selectedCountries).map(code => (
-                          <button
-                            key={code}
-                            onClick={() => setSelectedCountries(prev => { const next = new Set(prev); next.delete(code); return next; })}
-                            className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-0.5 hover:opacity-80"
-                          >
-                            {getCountryName(code)}
-                            <span className="text-[11px]">×</span>
-                          </button>
-                        ));
-                      })()}
-                      {Array.from(selectedGrowthForms).map(gf => (
-                        <button
-                          key={`gf-${gf}`}
-                          onClick={() => setSelectedGrowthForms(prev => { const next = new Set(prev); next.delete(gf); return next; })}
-                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-lime-100 text-lime-600 dark:bg-lime-900/30 dark:text-lime-400 flex items-center gap-0.5 hover:opacity-80"
-                        >
-                          {gf}
-                          <span className="text-[11px]">×</span>
-                        </button>
-                      ))}
-                      {endemicsOnly && (
-                        <button
-                          onClick={() => setEndemicsOnly(false)}
-                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-0.5 hover:opacity-80"
-                        >
-                          Endemics only
-                          <span className="text-[11px]">×</span>
-                        </button>
-                      )}
-                      {Array.from(selectedPopulationTrends).map(trend => (
-                        <button
-                          key={`trend-${trend}`}
-                          onClick={() => setSelectedPopulationTrends(prev => { const next = new Set(prev); next.delete(trend); return next; })}
-                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400 flex items-center gap-0.5 hover:opacity-80"
-                        >
-                          {trend}
-                          <span className="text-[11px]">×</span>
-                        </button>
-                      ))}
-                      {Array.from(selectedMovementPatterns).map(pattern => (
-                        <button
-                          key={`mov-${pattern}`}
-                          onClick={() => setSelectedMovementPatterns(prev => { const next = new Set(prev); next.delete(pattern); return next; })}
-                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-0.5 hover:opacity-80"
-                        >
-                          {pattern}
-                          <span className="text-[11px]">×</span>
-                        </button>
-                      ))}
-                      {Array.from(selectedThreats).map(code => {
-                        const cat = THREAT_CATEGORIES.find(c => c.code === code);
-                        const sub = !cat ? THREAT_CATEGORIES.flatMap(c => c.children).find(c => c.code === code) : null;
-                        const label = cat?.label || sub?.label || code;
-                        return (
-                          <button
-                            key={`threat-${code}`}
-                            onClick={() => setSelectedThreats(prev => { const next = new Set(prev); next.delete(code); return next; })}
-                            className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-rose-100 text-rose-600 dark:bg-rose-900/30 dark:text-rose-400 flex items-center gap-0.5 hover:opacity-80"
-                          >
-                            {label}
-                            <span className="text-[11px]">×</span>
-                          </button>
-                        );
-                      })}
-                      {Array.from(selectedSystems).map(system => (
-                        <button
-                          key={system}
-                          onClick={() => setSelectedSystems(prev => { const next = new Set(prev); next.delete(system); return next; })}
-                          className={`px-1.5 py-0.5 text-[11px] font-medium rounded-full flex items-center gap-0.5 hover:opacity-80 ${
-                            system === "Terrestrial" ? "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
-                            : system === "Freshwater" ? "bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400"
-                            : "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
-                          }`}
-                        >
-                          {system}
-                          <span className="text-[11px]">×</span>
-                        </button>
-                      ))}
-                      {!isNewAssessments && Array.from(selectedAssessors).map(name => (
-                        <button
-                          key={`a-${name}`}
-                          onClick={() => setSelectedAssessors(prev => { const next = new Set(prev); next.delete(name); return next; })}
-                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-0.5 hover:opacity-80"
-                        >
-                          {name}
-                          <span className="text-[11px]">×</span>
-                        </button>
-                      ))}
-                      {!isNewAssessments && Array.from(selectedReviewers).map(name => (
-                        <button
-                          key={`r-${name}`}
-                          onClick={() => setSelectedReviewers(prev => { const next = new Set(prev); next.delete(name); return next; })}
-                          className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-fuchsia-100 text-fuchsia-600 dark:bg-fuchsia-900/30 dark:text-fuchsia-400 flex items-center gap-0.5 hover:opacity-80"
-                        >
-                          {name}
-                          <span className="text-[11px]">×</span>
-                        </button>
-                      ))}
-                      {(() => {
-                        const ef = exactFilters;
-                        const chips: { key: keyof typeof ef; label: string }[] = [];
-                        if (ef.outdated) chips.push({ key: "outdated", label: ef.outdated === "yes" ? "Outdated (>10 yrs)" : "Current (≤10 yrs)" });
-                        if (ef.minObs != null) chips.push({ key: "minObs", label: `≥ ${ef.minObs.toLocaleString()} obs` });
-                        if (ef.maxObs != null) chips.push({ key: "maxObs", label: `≤ ${ef.maxObs.toLocaleString()} obs` });
-                        if (ef.minAssessmentYear != null) chips.push({ key: "minAssessmentYear", label: `Assessed ≥ ${ef.minAssessmentYear}` });
-                        if (ef.maxAssessmentYear != null) chips.push({ key: "maxAssessmentYear", label: `Assessed ≤ ${ef.maxAssessmentYear}` });
-                        if (ef.minDescribedYear != null) chips.push({ key: "minDescribedYear", label: `Described ≥ ${ef.minDescribedYear}` });
-                        if (ef.maxDescribedYear != null) chips.push({ key: "maxDescribedYear", label: `Described ≤ ${ef.maxDescribedYear}` });
-                        return chips.map(c => (
-                          <button
-                            key={`ef-${c.key}`}
-                            onClick={() => setExactFilters({ [c.key]: null })}
-                            className="px-1.5 py-0.5 text-[11px] font-medium rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300 flex items-center gap-0.5 hover:opacity-80"
-                          >
-                            {c.label}
-                            <span className="text-[11px]">×</span>
-                          </button>
-                        ));
-                      })()}
-                      {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
-                        <button
-                          disabled={neBlockedForAll}
-                          onClick={() => {
-                            if (neBlockedForAll) return;
-                            setSelectedCategories(prev => {
-                              const next = new Set(prev);
-                              if (next.has("NE")) {
-                                next.delete("NE");
-                              } else {
-                                next.add("NE");
-                              }
-                              return next;
-                            });
-                          }}
-                          className={`px-1.5 py-0.5 rounded-md text-[11px] font-medium transition-colors flex items-center gap-1 ${
-                            neBlockedForAll
-                              ? "bg-white text-zinc-400 border border-zinc-200 opacity-60 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500 dark:border-zinc-700"
-                              : selectedCategories.has("NE")
-                              ? "bg-zinc-500 text-white"
-                              : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
-                          }`}
-                          title={neBlockedForAll ? "Not Evaluated species must be loaded per taxon group — too many to load for All Species at once" : "Show Not Evaluated species from GBIF"}
-                        >
-                          NE{!neBlockedForAll && ` (${neCount.toLocaleString()})`}
-                        </button>
-                      )}
-                    </div>
-                  )}
+                <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                  {focusedTaxonCard.rank ?? "Taxon"}
                 </div>
                 <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
                   {focusedTaxonCard.name}
@@ -2856,21 +2562,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
                     {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
                   </div>
-                  <div className="mt-0.5 flex items-baseline gap-1.5 flex-wrap">
-                    {speciesLoading && assessedSpecies.length === 0 ? (
-                      <Spinner className="h-6 w-6" />
-                    ) : (
-                      <>
-                        <span className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                          {totalFiltered.toLocaleString()}
-                        </span>
-                        {totalFiltered !== taxaFilteredSpeciesBase.length && (
-                          <span className="text-sm font-medium text-zinc-400 dark:text-zinc-500">
-                            matching filters (of {taxaFilteredSpeciesBase.length.toLocaleString()} {isNewAssessments ? "not evaluated" : "assessed"} total)
-                          </span>
-                        )}
-                      </>
-                    )}
+                  <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                    {speciesLoading && assessedSpecies.length === 0
+                      ? <Spinner className="h-6 w-6" />
+                      : taxaFilteredSpeciesBase.length.toLocaleString()}
                   </div>
                 </div>
                 {onViewModeChange && (
@@ -3637,6 +3332,313 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
 
       {/* Species Table */}
       <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl">
+        {/* Applied filters — every currently-active filter (including the
+            selected taxon/subgroup/breakdown-name) as a removable pill,
+            directly above the table they filter. Clear all resets everything
+            here, taxon/subgroup included — Home is for the "go back to
+            nothing selected at all" case; this is for "same taxon, different
+            filters". */}
+        <div className="p-3 md:p-4 border-b border-zinc-200 dark:border-zinc-800 rounded-t-xl">
+          <div className="flex flex-wrap items-center gap-2 md:gap-4">
+            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
+              <button
+                onClick={() => {
+                  clearAllFiltersAndTaxa();
+                  setShowOnlyStarred(false);
+                  setExpandedThreat(null);
+                }}
+                title="Reset all filters and the selected taxon"
+                className="px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
+              >
+                <svg className="w-3.5 h-3.5 md:w-4 md:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                <span className="hidden sm:inline">Clear all</span>
+              </button>
+            )}
+            {pinnedSpecies.length > 0 && (
+              <button
+                onClick={() => setShowOnlyStarred(!showOnlyStarred)}
+                className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
+                  showOnlyStarred
+                    ? "bg-amber-500 text-white"
+                    : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
+                }`}
+              >
+                <svg className="w-4 h-4" fill={showOnlyStarred ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+                </svg>
+                <span className="hidden sm:inline">Starred</span> ({pinnedSpecies.length})
+              </button>
+            )}
+            {Array.from(selectedTaxa).map(taxonId => (
+              <button
+                key={taxonId}
+                onClick={() => setSelectedTaxa(prev => { const next = new Set(prev); next.delete(taxonId); return next; })}
+                className="px-3 py-1.5 text-sm font-medium rounded-full flex items-center gap-1 hover:opacity-80"
+                style={{ backgroundColor: (TAXA_BY_ID[taxonId]?.color || "#666") + "20", color: TAXA_BY_ID[taxonId]?.color || "#666" }}
+              >
+                {TAXA_BY_ID[taxonId]?.name || taxonId}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {Array.from(selectedSubgroups).map(sgId => {
+              const sgInfo = getNodeDef(sgId);
+              return (
+                <button
+                  key={sgId}
+                  onClick={() => setSelectedSubgroups(prev => { const next = new Set(prev); next.delete(sgId); return next; })}
+                  className="px-3 py-1.5 text-sm font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+                >
+                  {sgInfo?.node.name ?? dynamicNodeDisplayName(sgId)}
+                  <span className="text-sm">×</span>
+                </button>
+              );
+            })}
+            {breakdownFilter && selectedSubgroups.has(breakdownFilter.nodeId) && (
+              <button
+                onClick={() => setBreakdownFilter(null)}
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {breakdownDisplayName(breakdownFilter.rank, breakdownFilter.name)}
+                {breakdownFilter.onlyIds?.length ? " — No CoL Match" : breakdownFilter.excludeIds?.length ? " — CoL Match" : ""}
+                <span className="text-sm">×</span>
+              </button>
+            )}
+            {!isNewAssessments && Array.from(selectedCategories).filter(cat => cat !== "NE").map(cat => (
+              <button
+                key={cat}
+                onClick={() => setSelectedCategories(prev => { const next = new Set(prev); next.delete(cat); return next; })}
+                className="px-3 py-1.5 text-sm font-medium rounded-full flex items-center gap-1 hover:opacity-80"
+                style={{ backgroundColor: CATEGORY_COLORS[cat] + "20", color: CATEGORY_COLORS[cat] }}
+              >
+                {cat}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedYearRanges).map(range => (
+              <button
+                key={range}
+                onClick={() => setSelectedYearRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {range}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedAssessmentYears).sort((a, b) => Number(b) - Number(a)).map(year => (
+              <button
+                key={`ay-${year}`}
+                onClick={() => setSelectedAssessmentYears(prev => { const next = new Set(prev); next.delete(year); return next; })}
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
+              >
+                Assessed {year}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {isNewAssessments && Array.from(selectedDescribedYears).map(range => (
+              <button
+                key={`dy-${range}`}
+                onClick={() => setSelectedDescribedYears(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+              >
+                Described {range}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {Array.from(selectedObsRanges).map(range => (
+              <button
+                key={range}
+                onClick={() => setSelectedObsRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {range} obs
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {(() => {
+              if (selectedCountries.size === 0) return null;
+              // Check if selected countries exactly match a single IUCN region
+              const regions = new Set<string>();
+              selectedCountries.forEach(c => regions.add(countryToIucnRegion(c)));
+              if (regions.size === 1) {
+                const region = [...regions][0];
+                if (region !== "Other") {
+                  const regionCodes = iucnRegionCountries(region);
+                  if (regionCodes.length === selectedCountries.size && regionCodes.every(c => selectedCountries.has(c))) {
+                    return (
+                      <button
+                        onClick={() => setSelectedCountries(new Set())}
+                        className="px-3 py-1.5 text-sm font-medium rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
+                      >
+                        {region}
+                        <span className="text-sm">×</span>
+                      </button>
+                    );
+                  }
+                }
+              }
+              // Otherwise show individual country pills
+              return Array.from(selectedCountries).map(code => (
+                <button
+                  key={code}
+                  onClick={() => setSelectedCountries(prev => { const next = new Set(prev); next.delete(code); return next; })}
+                  className="px-3 py-1.5 text-sm font-medium rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
+                >
+                  {getCountryName(code)}
+                  <span className="text-sm">×</span>
+                </button>
+              ));
+            })()}
+            {Array.from(selectedGrowthForms).map(gf => (
+              <button
+                key={`gf-${gf}`}
+                onClick={() => setSelectedGrowthForms(prev => { const next = new Set(prev); next.delete(gf); return next; })}
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-lime-100 text-lime-600 dark:bg-lime-900/30 dark:text-lime-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {gf}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {endemicsOnly && (
+              <button
+                onClick={() => setEndemicsOnly(false)}
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
+              >
+                Endemics only
+                <span className="text-sm">×</span>
+              </button>
+            )}
+            {Array.from(selectedPopulationTrends).map(trend => (
+              <button
+                key={`trend-${trend}`}
+                onClick={() => setSelectedPopulationTrends(prev => { const next = new Set(prev); next.delete(trend); return next; })}
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {trend}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {Array.from(selectedMovementPatterns).map(pattern => (
+              <button
+                key={`mov-${pattern}`}
+                onClick={() => setSelectedMovementPatterns(prev => { const next = new Set(prev); next.delete(pattern); return next; })}
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {pattern}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {Array.from(selectedThreats).map(code => {
+              const cat = THREAT_CATEGORIES.find(c => c.code === code);
+              const sub = !cat ? THREAT_CATEGORIES.flatMap(c => c.children).find(c => c.code === code) : null;
+              const label = cat?.label || sub?.label || code;
+              return (
+                <button
+                  key={`threat-${code}`}
+                  onClick={() => setSelectedThreats(prev => { const next = new Set(prev); next.delete(code); return next; })}
+                  className="px-3 py-1.5 text-sm font-medium rounded-full bg-rose-100 text-rose-600 dark:bg-rose-900/30 dark:text-rose-400 flex items-center gap-1 hover:opacity-80"
+                >
+                  {label}
+                  <span className="text-sm">×</span>
+                </button>
+              );
+            })}
+            {Array.from(selectedSystems).map(system => (
+              <button
+                key={system}
+                onClick={() => setSelectedSystems(prev => { const next = new Set(prev); next.delete(system); return next; })}
+                className={`px-3 py-1.5 text-sm font-medium rounded-full flex items-center gap-1 hover:opacity-80 ${
+                  system === "Terrestrial" ? "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
+                  : system === "Freshwater" ? "bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400"
+                  : "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
+                }`}
+              >
+                {system}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedAssessors).map(name => (
+              <button
+                key={`a-${name}`}
+                onClick={() => setSelectedAssessors(prev => { const next = new Set(prev); next.delete(name); return next; })}
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {name} <span className="text-[10px] opacity-60">(assessor)</span>
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedReviewers).map(name => (
+              <button
+                key={`r-${name}`}
+                onClick={() => setSelectedReviewers(prev => { const next = new Set(prev); next.delete(name); return next; })}
+                className="px-3 py-1.5 text-sm font-medium rounded-full bg-fuchsia-100 text-fuchsia-600 dark:bg-fuchsia-900/30 dark:text-fuchsia-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {name} <span className="text-[10px] opacity-60">(reviewer)</span>
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {/* Exact URL-only filters (typically arrive via an agent/MCP dashboard
+                link). Shown as chips so a human can see and clear them. */}
+            {(() => {
+              const ef = exactFilters;
+              const chips: { key: keyof typeof ef; label: string }[] = [];
+              if (ef.outdated) chips.push({ key: "outdated", label: ef.outdated === "yes" ? "Outdated (>10 yrs)" : "Current (≤10 yrs)" });
+              if (ef.minObs != null) chips.push({ key: "minObs", label: `≥ ${ef.minObs.toLocaleString()} obs` });
+              if (ef.maxObs != null) chips.push({ key: "maxObs", label: `≤ ${ef.maxObs.toLocaleString()} obs` });
+              if (ef.minAssessmentYear != null) chips.push({ key: "minAssessmentYear", label: `Assessed ≥ ${ef.minAssessmentYear}` });
+              if (ef.maxAssessmentYear != null) chips.push({ key: "maxAssessmentYear", label: `Assessed ≤ ${ef.maxAssessmentYear}` });
+              if (ef.minDescribedYear != null) chips.push({ key: "minDescribedYear", label: `Described ≥ ${ef.minDescribedYear}` });
+              if (ef.maxDescribedYear != null) chips.push({ key: "maxDescribedYear", label: `Described ≤ ${ef.maxDescribedYear}` });
+              return chips.map(c => (
+                <button
+                  key={`ef-${c.key}`}
+                  onClick={() => setExactFilters({ [c.key]: null })}
+                  className="px-3 py-1.5 text-sm font-medium rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300 flex items-center gap-1 hover:opacity-80"
+                >
+                  {c.label}
+                  <span className="text-sm">×</span>
+                </button>
+              ));
+            })()}
+            <span className="ml-auto text-sm md:text-base font-semibold text-zinc-700 dark:text-zinc-300 tabular-nums flex items-center gap-2">
+              {speciesLoading && totalFiltered === 0 && !singleSpeciesPreview ? (
+                <Spinner className="h-4 w-4" />
+              ) : (
+                <>{totalFiltered.toLocaleString()} species</>
+              )}
+            </span>
+            {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
+              <button
+                disabled={neBlockedForAll}
+                onClick={() => {
+                  if (neBlockedForAll) return;
+                  setSelectedCategories(prev => {
+                    const next = new Set(prev);
+                    if (next.has("NE")) {
+                      next.delete("NE");
+                    } else {
+                      next.add("NE");
+                    }
+                    return next;
+                  });
+                }}
+                className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
+                  neBlockedForAll
+                    ? "bg-white text-zinc-400 border border-zinc-200 opacity-60 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500 dark:border-zinc-700"
+                    : selectedCategories.has("NE")
+                    ? "bg-zinc-500 text-white"
+                    : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
+                }`}
+                title={neBlockedForAll ? "Not Evaluated species must be loaded per taxon group — too many to load for All Species at once" : "Show Not Evaluated species from GBIF"}
+              >
+                Not Evaluated
+                {!neBlockedForAll && <span className="text-[10px] opacity-70">({neCount.toLocaleString()})</span>}
+              </button>
+            )}
+          </div>
+        </div>
+
         {/* Species table */}
         {speciesLoading && assessedSpecies.length === 0 && !singleSpeciesPreview ? (
           <div className="flex items-center justify-center py-12">

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -143,6 +143,47 @@ interface SpeciesDetails {
 }
 
 
+// Debounced search input — manages own state for instant typing, debounces parent updates.
+// Filters the currently-visible species table by name in place, composing with whatever
+// pill filters are already active (e.g. Mammals + EN + Mexico, then narrow to "mouse") —
+// distinct from the page header's SpeciesSearchBar, which navigates to a taxon/species
+// instead of narrowing the current view. Placeholder text keeps the two from reading as
+// duplicates of each other.
+function DebouncedSearchInput({
+  onSearch,
+  initialValue = "",
+  placeholder = "Filter by name...",
+  className,
+}: {
+  onSearch: (value: string) => void;
+  initialValue?: string;
+  placeholder?: string;
+  className?: string;
+}) {
+  const [localValue, setLocalValue] = useState(initialValue);
+
+  useEffect(() => {
+    setLocalValue(initialValue);
+  }, [initialValue]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onSearch(localValue.toLowerCase());
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [localValue, onSearch]);
+
+  return (
+    <input
+      type="text"
+      value={localValue}
+      onChange={(e) => setLocalValue(e.target.value)}
+      placeholder={placeholder}
+      className={className}
+    />
+  );
+}
+
 // Explain IUCN Red List criteria codes
 // See: https://www.iucnredlist.org/resources/categories-and-criteria
 function explainCriteria(criteria: string): string {
@@ -335,7 +376,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     selectedGrowthForms, setSelectedGrowthForms,
     selectedAssessors, setSelectedAssessors,
     selectedReviewers, setSelectedReviewers,
-    searchFilter,
+    searchFilter, setSearchFilter,
     exactFilters, setExactFilters,
     sortField, sortDirection, setSort,
     mapViewMode, mapSortKey, mapSortDirection, setMapViewMode, setMapSort,
@@ -569,6 +610,11 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     );
     if (!stillSelected) setExpandedThreat(null);
   }, [selectedThreats, expandedThreat]);
+
+  // Stable callback for debounced search input
+  const handleSearch = useCallback((value: string) => {
+    setSearchFilter(value);
+  }, [setSearchFilter]);
 
   // Pagination
   const [currentPage, setCurrentPage] = useState(1);
@@ -3337,9 +3383,27 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             directly above the table they filter. Clear all resets everything
             here, taxon/subgroup included — Home is for the "go back to
             nothing selected at all" case; this is for "same taxon, different
-            filters". */}
+            filters". The free-text box narrows the visible table by name in
+            place, composing with the pills beside it — distinct from the page
+            header's SpeciesSearchBar, which navigates elsewhere instead of
+            narrowing here (see DebouncedSearchInput's own doc comment). */}
         <div className="p-3 md:p-4 border-b border-zinc-200 dark:border-zinc-800 rounded-t-xl">
           <div className="flex flex-wrap items-center gap-2 md:gap-4">
+            <div className="relative flex-1 min-w-[140px] max-w-md">
+              <DebouncedSearchInput
+                onSearch={handleSearch}
+                initialValue={searchFilter}
+                className="w-full px-3 md:px-4 py-2 pl-9 md:pl-10 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
+              />
+              <svg
+                className="absolute left-2.5 md:left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-400 pointer-events-none"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+            </div>
             {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
               <button
                 onClick={() => {

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2539,22 +2539,30 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               sub-group row drilled into via TaxaSummary's own tree
               (selectedSubgroupTaxon: dynamic order/family/genus, or a static SSC
               group), or a non-curated arbitrary rank reached via search
-              (arbitraryTaxon). Two fixed-fact stat cards — the taxon (name +
-              rank) and its total species count (taxaFilteredSpeciesBase, NOT
-              totalFiltered) — neither reacts to pill filters; the Matching
-              Filters row below is what shows the filtered/live numbers. The
-              second card's header IS the Assessed/Not Evaluated toggle rather
-              than a plain caption: the toggle's own button labels already say
-              "Assessed"/"Not Evaluated", so a separate caption saying the same
-              thing would be redundant, and this keeps the toggle visible at
-              both the landing page and single-taxon drill-down (unlike the
-              View selector, which is landing-only — browsing mode stops
-              mattering once you've committed to a taxon, but Assessed/Not
-              Evaluated scope matters just as much here as there). TaxaSummary's
-              own breadcrumb table above already shows the tree branch that led
-              here (Mammals → Rodentia → Heteromyidae → ...) when applicable —
-              this is purely an additional, more prominent summary, not a
-              replacement for it. */}
+              (arbitraryTaxon). Two stat cards: the taxon (name + rank) and the
+              Species card. The Species card's header is a plain "Species"
+              label with the Assessed/Not Evaluated toggle to its right (not
+              as the header itself — that read as too clever/unclear); the
+              toggle lives here rather than the landing-only row alongside the
+              View selector so it's usable at any drill-down depth (Assessed/
+              Not Evaluated scope matters just as much in single-taxon view as
+              on the landing page, unlike View-by, which is about browsing mode
+              and stops mattering once you've committed to a taxon). The number
+              is totalFiltered (live, reacts to pill filters) with a qualifier
+              once a filter narrows it below the taxon's own total
+              (taxaFilteredSpeciesBase): "matching filters (of Y assessed/not
+              evaluated total)" — naming the total's own metric explicitly
+              avoids the earlier "of Y" ambiguity (could otherwise read as a
+              completely different ratio, e.g. assessed-of-described). Applied
+              filters (Clear all/Starred/chips/Not Evaluated shortcut) live
+              inside this same card below the number, instead of a separate
+              row — deliberately excludes selectedTaxa/selectedSubgroups/
+              breakdownFilter from both the chip list and Clear all, since
+              those are taxonomy navigation, not filters; Home is what clears
+              them. TaxaSummary's own breadcrumb table above already shows the
+              tree branch that led here (Mammals → Rodentia → Heteromyidae →
+              ...) when applicable — this is purely an additional, more
+              prominent summary, not a replacement for it. */}
           {focusedTaxonCard && !isSingleSpecies && (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
@@ -2566,63 +2574,55 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 </div>
               </div>
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
-                {onViewModeChange ? (
-                  <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs w-fit">
-                    <button
-                      type="button"
-                      onClick={() => onViewModeChange("reassessments")}
-                      className={`px-2 py-1 font-medium transition-colors ${
-                        !isNewAssessments
-                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                      }`}
-                    >
-                      Assessed
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => onViewModeChange("new-assessments")}
-                      className={`px-2 py-1 font-medium transition-colors ${
-                        isNewAssessments
-                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                      }`}
-                    >
-                      Not Evaluated
-                    </button>
-                  </div>
-                ) : (
-                  <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                    {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
-                  </div>
-                )}
-                <div className="mt-1 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                  {speciesLoading && assessedSpecies.length === 0
-                    ? <Spinner className="h-6 w-6" />
-                    : taxaFilteredSpeciesBase.length.toLocaleString()}
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                    Species
+                  </span>
+                  {onViewModeChange && (
+                    <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
+                      <button
+                        type="button"
+                        onClick={() => onViewModeChange("reassessments")}
+                        className={`px-2 py-1 font-medium transition-colors ${
+                          !isNewAssessments
+                            ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                            : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                        }`}
+                      >
+                        Assessed
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onViewModeChange("new-assessments")}
+                        className={`px-2 py-1 font-medium transition-colors ${
+                          isNewAssessments
+                            ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                            : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                        }`}
+                      >
+                        Not Evaluated
+                      </button>
+                    </div>
+                  )}
                 </div>
-              </div>
-            </div>
-          )}
-
-          {/* Active Filters / Matched Species — two cards mirroring the Taxon/
-              Assessed-Species row above (same grid pattern: a fixed-fact card
-              on the left, a live-number card on the right), shown only when
-              there's something to display: an active filter (hasActiveFilters),
-              a Starred toggle (pinnedSpecies.length > 0), or the Not Evaluated
-              shortcut. Deliberately excludes selectedTaxa/selectedSubgroups/
-              breakdownFilter from both the chip list and Clear all — those are
-              taxonomy navigation, not filters; Home is what clears them.
-              Matched Species (right) only renders once hasActiveFilters is
-              true — with no active filter it would just repeat the taxon's own
-              fixed total already shown in the card above, so the left card
-              spans full width by itself instead (className below has no grid
-              classes in that case, so it's just a plain block). */}
-          {(hasActiveFilters || pinnedSpecies.length > 0 || (!isNewAssessments && (neCount > 0 || neBlockedForAll))) && (
-            <div className={hasActiveFilters ? "grid grid-cols-1 sm:grid-cols-2 gap-4" : ""}>
-              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 md:p-4">
-              <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-2">Active Filters</div>
-              <div className="flex flex-wrap items-center gap-2 md:gap-4">
+                <div className="mt-1 flex items-baseline gap-1.5 flex-wrap">
+                  {speciesLoading && assessedSpecies.length === 0 ? (
+                    <Spinner className="h-6 w-6" />
+                  ) : (
+                    <>
+                      <span className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                        {totalFiltered.toLocaleString()}
+                      </span>
+                      {totalFiltered !== taxaFilteredSpeciesBase.length && (
+                        <span className="text-sm font-medium text-zinc-400 dark:text-zinc-500">
+                          matching filters (of {taxaFilteredSpeciesBase.length.toLocaleString()} {isNewAssessments ? "not evaluated" : "assessed"} total)
+                        </span>
+                      )}
+                    </>
+                  )}
+                </div>
+                {(hasActiveFilters || pinnedSpecies.length > 0 || (!isNewAssessments && (neCount > 0 || neBlockedForAll))) && (
+              <div className="mt-3 pt-3 border-t border-zinc-100 dark:border-zinc-800 flex flex-wrap items-center gap-2 md:gap-4">
               {hasActiveFilters && (
                 <button
                   onClick={() => {
@@ -2864,10 +2864,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 </button>
               ));
             })()}
-            {/* No standalone species-count readout here anymore — the "N Matching
-                Filters" heading above already states it. ml-auto moved to the
-                Not Evaluated button so the pills still hug the left and this
-                stays right-aligned. */}
+            {/* No standalone species-count readout here — the number above
+                already states it (with the "matching filters" qualifier).
+                ml-auto on the Not Evaluated button below keeps it right-
+                aligned while the rest of the pills hug the left. */}
             {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
               <button
                 disabled={neBlockedForAll}
@@ -2897,19 +2897,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               </button>
             )}
               </div>
+                )}
               </div>
-              {hasActiveFilters && (
-                <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 md:p-4">
-                  <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                    Matched Species
-                  </div>
-                  <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                    {speciesLoading && totalFiltered === 0 && !singleSpeciesPreview
-                      ? <Spinner className="h-6 w-6" />
-                      : totalFiltered.toLocaleString()}
-                  </div>
-                </div>
-              )}
             </div>
           )}
 

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3435,10 +3435,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               )}
             </button>
             {moreFiltersOpen && (
-              <div className="px-3 md:px-4 pb-3 md:pb-4 pt-1 border-t border-zinc-200 dark:border-zinc-800 flex flex-col gap-3">
+              <div className="px-3 md:px-4 pb-3 md:pb-4 pt-3 md:pt-4 border-t border-zinc-200 dark:border-zinc-800 flex flex-col gap-3">
                 {/* Realm */}
                 <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
-                  <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0 w-16">Realm</span>
+                  <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Realm</span>
                   <div className="flex flex-wrap gap-1.5">
                     {(["Terrestrial", "Freshwater", "Marine"] as const).map(system => {
                       const isSelected = selectedSystems.has(system);
@@ -3497,7 +3497,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   if (sorted.length === 0) return null;
                   return (
                     <div className="flex items-start gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
-                      <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0 w-16 pt-1">Growth</span>
+                      <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20 pt-1">Growth</span>
                       <div className="flex flex-wrap gap-1.5">
                         {sorted.map(([gf, count]) => {
                           const isSelected = selectedGrowthForms.has(gf);
@@ -3529,7 +3529,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
 
                 {/* Trend */}
                 <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
-                    <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0 w-16">Trend</span>
+                    <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Trend</span>
                     <div className="flex flex-wrap gap-1.5">
                       {(["Increasing", "Stable", "Decreasing", "Unknown"] as const).map(trend => {
                         const isSelected = selectedPopulationTrends.has(trend);
@@ -3561,7 +3561,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 {/* Movement Patterns */}
                 {!isNewAssessments && (
                   <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
-                    <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0 w-16">Movement</span>
+                    <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Movement</span>
                       <div className="flex flex-wrap gap-1.5">
                         {(["Full Migrant", "Altitudinal Migrant", "Nomadic", "Not a Migrant", "Unknown"] as const).map(pattern => {
                           const isSelected = selectedMovementPatterns.has(pattern);

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -143,6 +143,42 @@ interface SpeciesDetails {
 }
 
 
+// Debounced search input - manages own state for instant typing, debounces parent updates
+function DebouncedSearchInput({
+  onSearch,
+  initialValue = "",
+  placeholder = "Search species...",
+  className,
+}: {
+  onSearch: (value: string) => void;
+  initialValue?: string;
+  placeholder?: string;
+  className?: string;
+}) {
+  const [localValue, setLocalValue] = useState(initialValue);
+
+  useEffect(() => {
+    setLocalValue(initialValue);
+  }, [initialValue]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onSearch(localValue.toLowerCase());
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [localValue, onSearch]);
+
+  return (
+    <input
+      type="text"
+      value={localValue}
+      onChange={(e) => setLocalValue(e.target.value)}
+      placeholder={placeholder}
+      className={className}
+    />
+  );
+}
+
 // Explain IUCN Red List criteria codes
 // See: https://www.iucnredlist.org/resources/categories-and-criteria
 function explainCriteria(criteria: string): string {
@@ -279,9 +315,12 @@ interface RedListViewProps {
   sharedSubgroups?: Set<string>;
   onTaxaChange?: (taxa: Set<string>) => void;
   onSubgroupsChange?: (subgroups: Set<string>) => void;
+  /** DOM node (owned by page.tsx's persistent header) that TaxaSummary
+   * portals its View-by selector into — see TaxaSummary's own doc comment. */
+  viewSelectorSlotEl?: HTMLDivElement | null;
 }
 
-export default function RedListView({ viewMode = "reassessments", onViewModeChange, sharedTaxa, sharedSubgroups, onTaxaChange, onSubgroupsChange }: RedListViewProps = {}) {
+export default function RedListView({ viewMode = "reassessments", onViewModeChange, sharedTaxa, sharedSubgroups, onTaxaChange, onSubgroupsChange, viewSelectorSlotEl }: RedListViewProps = {}) {
   const isNewAssessments = viewMode === "new-assessments";
   // Every species/truncation cache below is keyed by (mode, taxonId), not taxonId
   // alone — a taxon's Assessed and Not Evaluated species lists are entirely
@@ -335,7 +374,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     selectedGrowthForms, setSelectedGrowthForms,
     selectedAssessors, setSelectedAssessors,
     selectedReviewers, setSelectedReviewers,
-    searchFilter,
+    searchFilter, setSearchFilter,
     exactFilters, setExactFilters,
     sortField, sortDirection, setSort,
     mapViewMode, mapSortKey, mapSortDirection, setMapViewMode, setMapSort,
@@ -568,6 +607,11 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     );
     if (!stillSelected) setExpandedThreat(null);
   }, [selectedThreats, expandedThreat]);
+
+  // Stable callback for debounced search input
+  const handleSearch = useCallback((value: string) => {
+    setSearchFilter(value);
+  }, [setSearchFilter]);
 
   // Pagination
   const [currentPage, setCurrentPage] = useState(1);
@@ -2461,6 +2505,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
         viewMode={viewMode}
         layoutMode={layoutMode}
         onLayoutModeChange={setLayoutMode}
+        viewSelectorSlotEl={viewSelectorSlotEl}
         countryModeContent={countryModeContent}
         countryPillsContent={countryPillsContent}
         countryScope={countryScope}
@@ -2529,321 +2574,19 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       ) : (
       <div className="space-y-3">
 
-          {/* Applied filters — every currently-active filter shown as a
-              removable pill, plus Clear-all/Starred/species-count/Not-Evaluated
-              shortcut. Sits directly below TaxaSummary's breadcrumb table and
-              above the taxon-focus stat card so active filters are visible
-              before its numbers. (The free-text species search box that used
-              to live in this row was removed — SpeciesSearchBar in the page
-              header covers taxon/species lookup instead.) */}
-          <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 md:p-4">
-            <div className="flex flex-wrap items-center gap-2 md:gap-4">
-            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
-              <button
-                onClick={() => { clearAllFilters(); setSelectedTaxa(new Set()); setSelectedSubgroups(new Set()); setSelectedObsRanges(new Set()); setSelectedSystems(new Set()); setEndemicsOnly(false); setSelectedGrowthForms(new Set()); setSelectedPopulationTrends(new Set()); setSelectedMovementPatterns(new Set()); setSelectedThreats(new Set()); setExpandedThreat(null); setSelectedAssessors(new Set()); setSelectedReviewers(new Set()); setShowOnlyStarred(false); }}
-                title="Reset all filters and taxa"
-                className="px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
-              >
-                <svg className="w-3.5 h-3.5 md:w-4 md:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-                <span className="hidden sm:inline">Clear all</span>
-              </button>
-            )}
-            {pinnedSpecies.length > 0 && (
-              <>
-                <button
-                  onClick={() => setShowOnlyStarred(!showOnlyStarred)}
-                  className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
-                    showOnlyStarred
-                      ? "bg-amber-500 text-white"
-                      : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
-                  }`}
-                >
-                  <svg className="w-4 h-4" fill={showOnlyStarred ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
-                  </svg>
-                  <span className="hidden sm:inline">Starred</span> ({pinnedSpecies.length})
-                </button>
-              </>
-            )}
-            {Array.from(selectedTaxa).map(taxonId => (
-              <button
-                key={taxonId}
-                onClick={() => setSelectedTaxa(prev => { const next = new Set(prev); next.delete(taxonId); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80"
-                style={{ backgroundColor: (TAXA_BY_ID[taxonId]?.color || "#666") + "20", color: TAXA_BY_ID[taxonId]?.color || "#666" }}
-              >
-                {TAXA_BY_ID[taxonId]?.name || taxonId}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {Array.from(selectedSubgroups).map(sgId => {
-              const sgInfo = getNodeDef(sgId);
-              return (
-                <button
-                  key={sgId}
-                  onClick={() => setSelectedSubgroups(prev => { const next = new Set(prev); next.delete(sgId); return next; })}
-                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-                >
-                  {sgInfo?.node.name ?? dynamicNodeDisplayName(sgId)}
-                  <span className="text-xs">×</span>
-                </button>
-              );
-            })}
-            {breakdownFilter && selectedSubgroups.has(breakdownFilter.nodeId) && (
-              <button
-                onClick={() => setBreakdownFilter(null)}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {breakdownDisplayName(breakdownFilter.rank, breakdownFilter.name)}
-                {breakdownFilter.onlyIds?.length ? " — No CoL Match" : breakdownFilter.excludeIds?.length ? " — CoL Match" : ""}
-                <span className="text-xs">×</span>
-              </button>
-            )}
-            {!isNewAssessments && Array.from(selectedCategories).filter(cat => cat !== "NE").map(cat => (
-              <button
-                key={cat}
-                onClick={() => setSelectedCategories(prev => { const next = new Set(prev); next.delete(cat); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80"
-                style={{ backgroundColor: CATEGORY_COLORS[cat] + "20", color: CATEGORY_COLORS[cat] }}
-              >
-                {cat}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedYearRanges).map(range => (
-              <button
-                key={range}
-                onClick={() => setSelectedYearRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {range}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedAssessmentYears).sort((a, b) => Number(b) - Number(a)).map(year => (
-              <button
-                key={`ay-${year}`}
-                onClick={() => setSelectedAssessmentYears(prev => { const next = new Set(prev); next.delete(year); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
-              >
-                Assessed {year}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {isNewAssessments && Array.from(selectedDescribedYears).map(range => (
-              <button
-                key={`dy-${range}`}
-                onClick={() => setSelectedDescribedYears(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-              >
-                Described {range}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {Array.from(selectedObsRanges).map(range => (
-              <button
-                key={range}
-                onClick={() => setSelectedObsRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {range} obs
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {(() => {
-              if (selectedCountries.size === 0) return null;
-              // Check if selected countries exactly match a single IUCN region
-              const regions = new Set<string>();
-              selectedCountries.forEach(c => regions.add(countryToIucnRegion(c)));
-              if (regions.size === 1) {
-                const region = [...regions][0];
-                if (region !== "Other") {
-                  const regionCodes = iucnRegionCountries(region);
-                  if (regionCodes.length === selectedCountries.size && regionCodes.every(c => selectedCountries.has(c))) {
-                    return (
-                      <button
-                        onClick={() => setSelectedCountries(new Set())}
-                        className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
-                      >
-                        {region}
-                        <span className="text-xs">×</span>
-                      </button>
-                    );
-                  }
-                }
-              }
-              // Otherwise show individual country pills
-              return Array.from(selectedCountries).map(code => (
-                <button
-                  key={code}
-                  onClick={() => setSelectedCountries(prev => { const next = new Set(prev); next.delete(code); return next; })}
-                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
-                >
-                  {getCountryName(code)}
-                  <span className="text-xs">×</span>
-                </button>
-              ));
-            })()}
-            {Array.from(selectedGrowthForms).map(gf => (
-              <button
-                key={`gf-${gf}`}
-                onClick={() => setSelectedGrowthForms(prev => { const next = new Set(prev); next.delete(gf); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-lime-100 text-lime-600 dark:bg-lime-900/30 dark:text-lime-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {gf}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {endemicsOnly && (
-              <button
-                onClick={() => setEndemicsOnly(false)}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
-              >
-                Endemics only
-                <span className="text-xs">×</span>
-              </button>
-            )}
-            {Array.from(selectedPopulationTrends).map(trend => (
-              <button
-                key={`trend-${trend}`}
-                onClick={() => setSelectedPopulationTrends(prev => { const next = new Set(prev); next.delete(trend); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {trend}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {Array.from(selectedMovementPatterns).map(pattern => (
-              <button
-                key={`mov-${pattern}`}
-                onClick={() => setSelectedMovementPatterns(prev => { const next = new Set(prev); next.delete(pattern); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {pattern}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {Array.from(selectedThreats).map(code => {
-              const cat = THREAT_CATEGORIES.find(c => c.code === code);
-              const sub = !cat ? THREAT_CATEGORIES.flatMap(c => c.children).find(c => c.code === code) : null;
-              const label = cat?.label || sub?.label || code;
-              return (
-                <button
-                  key={`threat-${code}`}
-                  onClick={() => setSelectedThreats(prev => { const next = new Set(prev); next.delete(code); return next; })}
-                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-rose-100 text-rose-600 dark:bg-rose-900/30 dark:text-rose-400 flex items-center gap-1 hover:opacity-80"
-                >
-                  {label}
-                  <span className="text-xs">×</span>
-                </button>
-              );
-            })}
-            {Array.from(selectedSystems).map(system => (
-              <button
-                key={system}
-                onClick={() => setSelectedSystems(prev => { const next = new Set(prev); next.delete(system); return next; })}
-                className={`px-2 md:px-3 py-1 text-xs md:text-sm rounded-full flex items-center gap-1 hover:opacity-80 ${
-                  system === "Terrestrial" ? "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
-                  : system === "Freshwater" ? "bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400"
-                  : "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
-                }`}
-              >
-                {system}
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedAssessors).map(name => (
-              <button
-                key={`a-${name}`}
-                onClick={() => setSelectedAssessors(prev => { const next = new Set(prev); next.delete(name); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {name} <span className="text-[10px] opacity-60">(assessor)</span>
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {!isNewAssessments && Array.from(selectedReviewers).map(name => (
-              <button
-                key={`r-${name}`}
-                onClick={() => setSelectedReviewers(prev => { const next = new Set(prev); next.delete(name); return next; })}
-                className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-fuchsia-100 text-fuchsia-600 dark:bg-fuchsia-900/30 dark:text-fuchsia-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {name} <span className="text-[10px] opacity-60">(reviewer)</span>
-                <span className="text-xs">×</span>
-              </button>
-            ))}
-            {/* Exact URL-only filters (typically arrive via an agent/MCP dashboard
-                link). Shown as chips so a human can see and clear them. */}
-            {(() => {
-              const ef = exactFilters;
-              const chips: { key: keyof typeof ef; label: string }[] = [];
-              if (ef.outdated) chips.push({ key: "outdated", label: ef.outdated === "yes" ? "Outdated (>10 yrs)" : "Current (≤10 yrs)" });
-              if (ef.minObs != null) chips.push({ key: "minObs", label: `≥ ${ef.minObs.toLocaleString()} obs` });
-              if (ef.maxObs != null) chips.push({ key: "maxObs", label: `≤ ${ef.maxObs.toLocaleString()} obs` });
-              if (ef.minAssessmentYear != null) chips.push({ key: "minAssessmentYear", label: `Assessed ≥ ${ef.minAssessmentYear}` });
-              if (ef.maxAssessmentYear != null) chips.push({ key: "maxAssessmentYear", label: `Assessed ≤ ${ef.maxAssessmentYear}` });
-              if (ef.minDescribedYear != null) chips.push({ key: "minDescribedYear", label: `Described ≥ ${ef.minDescribedYear}` });
-              if (ef.maxDescribedYear != null) chips.push({ key: "maxDescribedYear", label: `Described ≤ ${ef.maxDescribedYear}` });
-              return chips.map(c => (
-                <button
-                  key={`ef-${c.key}`}
-                  onClick={() => setExactFilters({ [c.key]: null })}
-                  className="px-2 md:px-3 py-1 text-xs md:text-sm rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300 flex items-center gap-1 hover:opacity-80"
-                >
-                  {c.label}
-                  <span className="text-xs">×</span>
-                </button>
-              ));
-            })()}
-            <span className="ml-auto text-sm md:text-base font-semibold text-zinc-700 dark:text-zinc-300 tabular-nums flex items-center gap-2">
-              {speciesLoading && totalFiltered === 0 && !singleSpeciesPreview ? (
-                <Spinner className="h-4 w-4" />
-              ) : (
-                <>{totalFiltered.toLocaleString()} species</>
-              )}
-            </span>
-            {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
-              <button
-                disabled={neBlockedForAll}
-                onClick={() => {
-                  if (neBlockedForAll) return;
-                  setSelectedCategories(prev => {
-                    const next = new Set(prev);
-                    if (next.has("NE")) {
-                      next.delete("NE");
-                    } else {
-                      next.add("NE");
-                    }
-                    return next;
-                  });
-                }}
-                className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
-                  neBlockedForAll
-                    ? "bg-white text-zinc-400 border border-zinc-200 opacity-60 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500 dark:border-zinc-700"
-                    : selectedCategories.has("NE")
-                    ? "bg-zinc-500 text-white"
-                    : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
-                }`}
-                title={neBlockedForAll ? "Not Evaluated species must be loaded per taxon group — too many to load for All Species at once" : "Show Not Evaluated species from GBIF"}
-              >
-                Not Evaluated
-                {!neBlockedForAll && <span className="text-[10px] opacity-70">({neCount.toLocaleString()})</span>}
-              </button>
-            )}
-            </div>
-          </div>
-
           {/* Taxon-focus header — any single selected taxon: a top-level taxon
               (selectedTopLevelTaxon, e.g. Mammals, or "All Species" itself), a
               sub-group row drilled into via TaxaSummary's own tree
               (selectedSubgroupTaxon: dynamic order/family/genus, or a static SSC
               group), or a non-curated arbitrary rank reached via search
               (arbitraryTaxon). Two stat cards: the taxon (name + rank) and the
-              matched-species count (mirrors the table's totalFiltered). The
-              Assessed/Not Evaluated view-mode toggle lives in the page header
-              now, not here. TaxaSummary's own breadcrumb table above already
+              taxon's total species count — deliberately taxaFilteredSpeciesBase
+              (taxon/subgroup only, no pill filters applied), NOT totalFiltered,
+              so this stays a fixed "how big is this taxon" reference point even
+              while the table below is narrowed by category/country/year/etc.
+              pills. The latter also carries the Assessed/Not Evaluated
+              view-mode toggle, since this is where the mode actually changes
+              what's shown. TaxaSummary's own breadcrumb table above already
               shows the tree branch that led here (Mammals → Rodentia →
               Heteromyidae → ...) when applicable — this is purely an
               additional, more prominent summary, not a replacement for it. */}
@@ -2857,15 +2600,43 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   {focusedTaxonCard.name}
                 </div>
               </div>
-              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
-                <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                  {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex items-center justify-between gap-3 flex-wrap">
+                <div>
+                  <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                    {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
+                  </div>
+                  <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                    {speciesLoading && assessedSpecies.length === 0
+                      ? <Spinner className="h-6 w-6" />
+                      : taxaFilteredSpeciesBase.length.toLocaleString()}
+                  </div>
                 </div>
-                <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                  {speciesLoading && assessedSpecies.length === 0
-                    ? <Spinner className="h-6 w-6" />
-                    : totalFiltered.toLocaleString()}
-                </div>
+                {onViewModeChange && (
+                  <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => onViewModeChange("reassessments")}
+                      className={`px-2 py-1 font-medium transition-colors ${
+                        !isNewAssessments
+                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                      }`}
+                    >
+                      Assessed
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onViewModeChange("new-assessments")}
+                      className={`px-2 py-1 font-medium transition-colors ${
+                        isNewAssessments
+                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                      }`}
+                    >
+                      Not Evaluated
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -3372,12 +3143,11 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             })()}
           </div>
 
-          {/* More Filters — a full-width collapsible card row, consistent with
-              the other cards on the page (hidden for New Assessments) */}
-          {!isNewAssessments && <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl">
+          {/* More Filters (collapsible) - hidden for New Assessments */}
+          {!isNewAssessments && <div>
             <button
               onClick={() => setMoreFiltersOpen(prev => !prev)}
-              className="w-full flex items-center gap-1.5 px-3 md:px-4 py-2.5 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800 rounded-t-xl transition-colors"
+              className="flex items-center gap-1.5 text-xs font-medium text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
             >
               <svg className={`w-3.5 h-3.5 transition-transform ${moreFiltersOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
@@ -3390,7 +3160,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               )}
             </button>
             {moreFiltersOpen && (
-              <div className="px-3 md:px-4 pb-3 md:pb-4 pt-1 border-t border-zinc-200 dark:border-zinc-800 flex flex-col gap-3">
+              <div className="mt-3 flex flex-col gap-3">
                 {/* Realm */}
                 <div className="flex items-center gap-2">
                   <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0 w-16">Realm</span>
@@ -3602,8 +3372,324 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             )}
           </div>}
 
-      {/* Species Table */}
+      {/* Search and Species Table */}
       <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl">
+        {/* Search bar */}
+        <div className="p-3 md:p-4 border-b border-zinc-200 dark:border-zinc-800 rounded-t-xl">
+          <div className="flex flex-wrap items-center gap-2 md:gap-4">
+            <div className="relative flex-1 min-w-[140px] max-w-md">
+              <DebouncedSearchInput
+                onSearch={handleSearch}
+                initialValue={searchFilter}
+                placeholder="Search species..."
+                className="w-full px-3 md:px-4 py-2 pl-9 md:pl-10 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-red-500 text-sm"
+              />
+              <svg
+                className="absolute left-2.5 md:left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-400 pointer-events-none"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+            </div>
+            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
+              <button
+                onClick={() => { clearAllFilters(); setSelectedTaxa(new Set()); setSelectedSubgroups(new Set()); setSelectedObsRanges(new Set()); setSelectedSystems(new Set()); setEndemicsOnly(false); setSelectedGrowthForms(new Set()); setSelectedPopulationTrends(new Set()); setSelectedMovementPatterns(new Set()); setSelectedThreats(new Set()); setExpandedThreat(null); setSelectedAssessors(new Set()); setSelectedReviewers(new Set()); setShowOnlyStarred(false); }}
+                title="Reset all filters and taxa"
+                className="px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
+              >
+                <svg className="w-3.5 h-3.5 md:w-4 md:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                <span className="hidden sm:inline">Clear all</span>
+              </button>
+            )}
+            {pinnedSpecies.length > 0 && (
+              <>
+                <button
+                  onClick={() => setShowOnlyStarred(!showOnlyStarred)}
+                  className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
+                    showOnlyStarred
+                      ? "bg-amber-500 text-white"
+                      : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
+                  }`}
+                >
+                  <svg className="w-4 h-4" fill={showOnlyStarred ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+                  </svg>
+                  <span className="hidden sm:inline">Starred</span> ({pinnedSpecies.length})
+                </button>
+              </>
+            )}
+            {Array.from(selectedTaxa).map(taxonId => (
+              <button
+                key={taxonId}
+                onClick={() => setSelectedTaxa(prev => { const next = new Set(prev); next.delete(taxonId); return next; })}
+                className="px-3 py-1.5 text-sm rounded-full flex items-center gap-1 hover:opacity-80"
+                style={{ backgroundColor: (TAXA_BY_ID[taxonId]?.color || "#666") + "20", color: TAXA_BY_ID[taxonId]?.color || "#666" }}
+              >
+                {TAXA_BY_ID[taxonId]?.name || taxonId}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {Array.from(selectedSubgroups).map(sgId => {
+              const sgInfo = getNodeDef(sgId);
+              return (
+                <button
+                  key={sgId}
+                  onClick={() => setSelectedSubgroups(prev => { const next = new Set(prev); next.delete(sgId); return next; })}
+                  className="px-3 py-1.5 text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+                >
+                  {sgInfo?.node.name ?? dynamicNodeDisplayName(sgId)}
+                  <span className="text-sm">×</span>
+                </button>
+              );
+            })}
+            {breakdownFilter && selectedSubgroups.has(breakdownFilter.nodeId) && (
+              <button
+                onClick={() => setBreakdownFilter(null)}
+                className="px-3 py-1.5 text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {breakdownDisplayName(breakdownFilter.rank, breakdownFilter.name)}
+                {breakdownFilter.onlyIds?.length ? " — No CoL Match" : breakdownFilter.excludeIds?.length ? " — CoL Match" : ""}
+                <span className="text-sm">×</span>
+              </button>
+            )}
+            {!isNewAssessments && Array.from(selectedCategories).filter(cat => cat !== "NE").map(cat => (
+              <button
+                key={cat}
+                onClick={() => setSelectedCategories(prev => { const next = new Set(prev); next.delete(cat); return next; })}
+                className="px-3 py-1.5 text-sm rounded-full flex items-center gap-1 hover:opacity-80"
+                style={{ backgroundColor: CATEGORY_COLORS[cat] + "20", color: CATEGORY_COLORS[cat] }}
+              >
+                {cat}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedYearRanges).map(range => (
+              <button
+                key={range}
+                onClick={() => setSelectedYearRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                className="px-3 py-1.5 text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {range}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedAssessmentYears).sort((a, b) => Number(b) - Number(a)).map(year => (
+              <button
+                key={`ay-${year}`}
+                onClick={() => setSelectedAssessmentYears(prev => { const next = new Set(prev); next.delete(year); return next; })}
+                className="px-3 py-1.5 text-sm rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1 hover:opacity-80"
+              >
+                Assessed {year}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {isNewAssessments && Array.from(selectedDescribedYears).map(range => (
+              <button
+                key={`dy-${range}`}
+                onClick={() => setSelectedDescribedYears(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                className="px-3 py-1.5 text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+              >
+                Described {range}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {Array.from(selectedObsRanges).map(range => (
+              <button
+                key={range}
+                onClick={() => setSelectedObsRanges(prev => { const next = new Set(prev); next.delete(range); return next; })}
+                className="px-3 py-1.5 text-sm rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-900/30 dark:text-emerald-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {range} obs
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {(() => {
+              if (selectedCountries.size === 0) return null;
+              // Check if selected countries exactly match a single IUCN region
+              const regions = new Set<string>();
+              selectedCountries.forEach(c => regions.add(countryToIucnRegion(c)));
+              if (regions.size === 1) {
+                const region = [...regions][0];
+                if (region !== "Other") {
+                  const regionCodes = iucnRegionCountries(region);
+                  if (regionCodes.length === selectedCountries.size && regionCodes.every(c => selectedCountries.has(c))) {
+                    return (
+                      <button
+                        onClick={() => setSelectedCountries(new Set())}
+                        className="px-3 py-1.5 text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
+                      >
+                        {region}
+                        <span className="text-sm">×</span>
+                      </button>
+                    );
+                  }
+                }
+              }
+              // Otherwise show individual country pills
+              return Array.from(selectedCountries).map(code => (
+                <button
+                  key={code}
+                  onClick={() => setSelectedCountries(prev => { const next = new Set(prev); next.delete(code); return next; })}
+                  className="px-3 py-1.5 text-sm rounded-full bg-green-100 text-green-600 dark:bg-green-900/30 dark:text-green-400 flex items-center gap-1 hover:opacity-80"
+                >
+                  {getCountryName(code)}
+                  <span className="text-sm">×</span>
+                </button>
+              ));
+            })()}
+            {Array.from(selectedGrowthForms).map(gf => (
+              <button
+                key={`gf-${gf}`}
+                onClick={() => setSelectedGrowthForms(prev => { const next = new Set(prev); next.delete(gf); return next; })}
+                className="px-3 py-1.5 text-sm rounded-full bg-lime-100 text-lime-600 dark:bg-lime-900/30 dark:text-lime-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {gf}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {endemicsOnly && (
+              <button
+                onClick={() => setEndemicsOnly(false)}
+                className="px-3 py-1.5 text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
+              >
+                Endemics only
+                <span className="text-sm">×</span>
+              </button>
+            )}
+            {Array.from(selectedPopulationTrends).map(trend => (
+              <button
+                key={`trend-${trend}`}
+                onClick={() => setSelectedPopulationTrends(prev => { const next = new Set(prev); next.delete(trend); return next; })}
+                className="px-3 py-1.5 text-sm rounded-full bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {trend}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {Array.from(selectedMovementPatterns).map(pattern => (
+              <button
+                key={`mov-${pattern}`}
+                onClick={() => setSelectedMovementPatterns(prev => { const next = new Set(prev); next.delete(pattern); return next; })}
+                className="px-3 py-1.5 text-sm rounded-full bg-teal-100 text-teal-600 dark:bg-teal-900/30 dark:text-teal-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {pattern}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {Array.from(selectedThreats).map(code => {
+              const cat = THREAT_CATEGORIES.find(c => c.code === code);
+              const sub = !cat ? THREAT_CATEGORIES.flatMap(c => c.children).find(c => c.code === code) : null;
+              const label = cat?.label || sub?.label || code;
+              return (
+                <button
+                  key={`threat-${code}`}
+                  onClick={() => setSelectedThreats(prev => { const next = new Set(prev); next.delete(code); return next; })}
+                  className="px-3 py-1.5 text-sm rounded-full bg-rose-100 text-rose-600 dark:bg-rose-900/30 dark:text-rose-400 flex items-center gap-1 hover:opacity-80"
+                >
+                  {label}
+                  <span className="text-sm">×</span>
+                </button>
+              );
+            })}
+            {Array.from(selectedSystems).map(system => (
+              <button
+                key={system}
+                onClick={() => setSelectedSystems(prev => { const next = new Set(prev); next.delete(system); return next; })}
+                className={`px-3 py-1.5 text-sm rounded-full flex items-center gap-1 hover:opacity-80 ${
+                  system === "Terrestrial" ? "bg-amber-100 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400"
+                  : system === "Freshwater" ? "bg-cyan-100 text-cyan-600 dark:bg-cyan-900/30 dark:text-cyan-400"
+                  : "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
+                }`}
+              >
+                {system}
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedAssessors).map(name => (
+              <button
+                key={`a-${name}`}
+                onClick={() => setSelectedAssessors(prev => { const next = new Set(prev); next.delete(name); return next; })}
+                className="px-3 py-1.5 text-sm rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {name} <span className="text-[10px] opacity-60">(assessor)</span>
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {!isNewAssessments && Array.from(selectedReviewers).map(name => (
+              <button
+                key={`r-${name}`}
+                onClick={() => setSelectedReviewers(prev => { const next = new Set(prev); next.delete(name); return next; })}
+                className="px-3 py-1.5 text-sm rounded-full bg-fuchsia-100 text-fuchsia-600 dark:bg-fuchsia-900/30 dark:text-fuchsia-400 flex items-center gap-1 hover:opacity-80"
+              >
+                {name} <span className="text-[10px] opacity-60">(reviewer)</span>
+                <span className="text-sm">×</span>
+              </button>
+            ))}
+            {/* Exact URL-only filters (typically arrive via an agent/MCP dashboard
+                link). Shown as chips so a human can see and clear them. */}
+            {(() => {
+              const ef = exactFilters;
+              const chips: { key: keyof typeof ef; label: string }[] = [];
+              if (ef.outdated) chips.push({ key: "outdated", label: ef.outdated === "yes" ? "Outdated (>10 yrs)" : "Current (≤10 yrs)" });
+              if (ef.minObs != null) chips.push({ key: "minObs", label: `≥ ${ef.minObs.toLocaleString()} obs` });
+              if (ef.maxObs != null) chips.push({ key: "maxObs", label: `≤ ${ef.maxObs.toLocaleString()} obs` });
+              if (ef.minAssessmentYear != null) chips.push({ key: "minAssessmentYear", label: `Assessed ≥ ${ef.minAssessmentYear}` });
+              if (ef.maxAssessmentYear != null) chips.push({ key: "maxAssessmentYear", label: `Assessed ≤ ${ef.maxAssessmentYear}` });
+              if (ef.minDescribedYear != null) chips.push({ key: "minDescribedYear", label: `Described ≥ ${ef.minDescribedYear}` });
+              if (ef.maxDescribedYear != null) chips.push({ key: "maxDescribedYear", label: `Described ≤ ${ef.maxDescribedYear}` });
+              return chips.map(c => (
+                <button
+                  key={`ef-${c.key}`}
+                  onClick={() => setExactFilters({ [c.key]: null })}
+                  className="px-3 py-1.5 text-sm rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300 flex items-center gap-1 hover:opacity-80"
+                >
+                  {c.label}
+                  <span className="text-sm">×</span>
+                </button>
+              ));
+            })()}
+            <span className="ml-auto text-sm md:text-base font-semibold text-zinc-700 dark:text-zinc-300 tabular-nums flex items-center gap-2">
+              {speciesLoading && totalFiltered === 0 && !singleSpeciesPreview ? (
+                <Spinner className="h-4 w-4" />
+              ) : (
+                <>{totalFiltered.toLocaleString()} species</>
+              )}
+            </span>
+            {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
+              <button
+                disabled={neBlockedForAll}
+                onClick={() => {
+                  if (neBlockedForAll) return;
+                  setSelectedCategories(prev => {
+                    const next = new Set(prev);
+                    if (next.has("NE")) {
+                      next.delete("NE");
+                    } else {
+                      next.add("NE");
+                    }
+                    return next;
+                  });
+                }}
+                className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
+                  neBlockedForAll
+                    ? "bg-white text-zinc-400 border border-zinc-200 opacity-60 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500 dark:border-zinc-700"
+                    : selectedCategories.has("NE")
+                    ? "bg-zinc-500 text-white"
+                    : "bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700"
+                }`}
+                title={neBlockedForAll ? "Not Evaluated species must be loaded per taxon group — too many to load for All Species at once" : "Show Not Evaluated species from GBIF"}
+              >
+                Not Evaluated
+                {!neBlockedForAll && <span className="text-[10px] opacity-70">({neCount.toLocaleString()})</span>}
+              </button>
+            )}
+          </div>
+        </div>
+
         {/* Species table */}
         {speciesLoading && assessedSpecies.length === 0 && !singleSpeciesPreview ? (
           <div className="flex items-center justify-center py-12">

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2871,13 +2871,15 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                         <span className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
                           {totalFiltered.toLocaleString()}
                         </span>
-                        {/* Only show "of Y" once a filter has actually narrowed the
-                            count below the taxon's own total (taxaFilteredSpeciesBase —
-                            taxon/subgroup only, no pill filters) — otherwise the two
-                            numbers are identical and the qualifier is just noise. */}
+                        {/* Only show this once a filter has actually narrowed the count
+                            below the taxon's own total (taxaFilteredSpeciesBase — taxon/
+                            subgroup only, no pill filters). Deliberately doesn't state the
+                            unfiltered total ("of 6,054") — that reads as ambiguous with a
+                            totally different ratio (e.g. assessed-of-described), especially
+                            since the two are often close in magnitude for a given taxon. */}
                         {totalFiltered !== taxaFilteredSpeciesBase.length && (
                           <span className="text-sm font-medium text-zinc-400 dark:text-zinc-500">
-                            of {taxaFilteredSpeciesBase.length.toLocaleString()}
+                            matching filters
                           </span>
                         )}
                       </>

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -279,12 +279,9 @@ interface RedListViewProps {
   sharedSubgroups?: Set<string>;
   onTaxaChange?: (taxa: Set<string>) => void;
   onSubgroupsChange?: (subgroups: Set<string>) => void;
-  /** DOM node (owned by page.tsx's persistent header) that TaxaSummary
-   * portals its View-by selector into — see TaxaSummary's own doc comment. */
-  viewSelectorSlotEl?: HTMLDivElement | null;
 }
 
-export default function RedListView({ viewMode = "reassessments", onViewModeChange, sharedTaxa, sharedSubgroups, onTaxaChange, onSubgroupsChange, viewSelectorSlotEl }: RedListViewProps = {}) {
+export default function RedListView({ viewMode = "reassessments", onViewModeChange, sharedTaxa, sharedSubgroups, onTaxaChange, onSubgroupsChange }: RedListViewProps = {}) {
   const isNewAssessments = viewMode === "new-assessments";
   // Every species/truncation cache below is keyed by (mode, taxonId), not taxonId
   // alone — a taxon's Assessed and Not Evaluated species lists are entirely
@@ -2464,7 +2461,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
         viewMode={viewMode}
         layoutMode={layoutMode}
         onLayoutModeChange={setLayoutMode}
-        viewSelectorSlotEl={viewSelectorSlotEl}
         countryModeContent={countryModeContent}
         countryPillsContent={countryPillsContent}
         countryScope={countryScope}
@@ -3440,7 +3436,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             {moreFiltersOpen && (
               <div className="px-3 md:px-4 pb-3 md:pb-4 pt-1 border-t border-zinc-200 dark:border-zinc-800 flex flex-col gap-3">
                 {/* Realm */}
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
                   <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0 w-16">Realm</span>
                   <div className="flex flex-wrap gap-1.5">
                     {(["Terrestrial", "Freshwater", "Marine"] as const).map(system => {
@@ -3499,7 +3495,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   const sorted = Object.entries(gfCounts).sort((a, b) => b[1] - a[1]);
                   if (sorted.length === 0) return null;
                   return (
-                    <div className="flex items-start gap-2">
+                    <div className="flex items-start gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
                       <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0 w-16 pt-1">Growth</span>
                       <div className="flex flex-wrap gap-1.5">
                         {sorted.map(([gf, count]) => {
@@ -3531,7 +3527,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 })()}
 
                 {/* Trend */}
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
                     <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0 w-16">Trend</span>
                     <div className="flex flex-wrap gap-1.5">
                       {(["Increasing", "Stable", "Decreasing", "Unknown"] as const).map(trend => {
@@ -3563,7 +3559,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
 
                 {/* Movement Patterns */}
                 {!isNewAssessments && (
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
                     <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 shrink-0 w-16">Movement</span>
                       <div className="flex flex-wrap gap-1.5">
                         {(["Full Migrant", "Altitudinal Migrant", "Nomadic", "Not a Migrant", "Unknown"] as const).map(pattern => {

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2464,7 +2464,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
         countryModeContent={countryModeContent}
         countryPillsContent={countryPillsContent}
         countryScope={countryScope}
-        onClearCountryScope={() => { setSelectedCountries(new Set()); setHoverPreviewCountry(null); }}
         onToggleSubgroup={(sgId) => {
           // Clicking a view root ancestor → clear subgroups to show its children.
           // If the currently-selected subgroup is an SSC group, we got here by

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -12,12 +12,12 @@ import EolSummary from "../EolSummary";
 import TaxaIcon from "../TaxaIcon";
 import { ALPHA2_TO_NAME, type CountryStats } from "../WorldMap";
 import { CATEGORY_COLORS, TAXA_BY_ID, THREATENED_CATEGORIES } from "@/config/taxa";
-import { speciesMatchesNode, getNodeDef, getViewRootForNode, findNode, matchesBreakdownName, breakdownDisplayName, primaryFilterRank } from "@/lib/taxonomy-utils";
+import { speciesMatchesNode, getViewRootForNode, findNode, matchesBreakdownName, primaryFilterRank } from "@/lib/taxonomy-utils";
 import { dynamicNodeDisplayName, isDynamicNodeId, dynamicNodeRankInfo } from "@/lib/dynamic-taxon";
 import ReviewerChart from "./ReviewerChart";
 import { parseAssessors } from "@/lib/parseAssessors";
 import { iucnRegionCountries, countryToIucnRegion } from "@/lib/regions";
-import { useFilterParams } from "@/hooks/useFilterParams";
+import { useFilterParams, EMPTY_EXACT_FILTERS } from "@/hooks/useFilterParams";
 import { type RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
 import { isOutdated, outdatedCutoffDate } from "@/lib/outdated";
 
@@ -330,7 +330,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     selectedPopulationTrends, setSelectedPopulationTrends,
     selectedMovementPatterns, setSelectedMovementPatterns,
     selectedThreats, setSelectedThreats,
-    breakdownFilter, setBreakdownFilter,
+    breakdownFilter,
     endemicsOnly, setEndemicsOnly,
     selectedGrowthForms, setSelectedGrowthForms,
     selectedAssessors, setSelectedAssessors,
@@ -2450,6 +2450,12 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     </div>
   );
 
+  // Whether any real filter (category/year/country/growth-form/etc.) is
+  // active — deliberately excludes selectedTaxa/selectedSubgroups/
+  // breakdownFilter, which are taxonomy navigation, not filters: clearing
+  // those is what Home is for, not the Matching Filters card's Clear all.
+  const hasActiveFilters = selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null;
+
   return (
     <div className="space-y-4 min-w-0">
       {/* Always show Taxa Summary table */}
@@ -2459,6 +2465,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
         selectedSubgroups={selectedSubgroups}
         disableAllSpecies={isNewAssessments}
         viewMode={viewMode}
+        onViewModeChange={onViewModeChange}
         layoutMode={layoutMode}
         onLayoutModeChange={setLayoutMode}
         countryModeContent={countryModeContent}
@@ -2528,29 +2535,101 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       ) : (
       <div className="space-y-3">
 
-          {/* Applied filters — every currently-active filter shown as a
-              removable pill, plus Clear-all/Starred/species-count/Not-Evaluated
-              shortcut. Sits directly below TaxaSummary's breadcrumb table and
-              above the taxon-focus stat card so active filters are visible
-              before its numbers. (The free-text species search box that used
-              to live in this row was removed — SpeciesSearchBar in the page
-              header covers taxon/species lookup instead.) */}
-          <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 md:p-4">
-            <div className="flex flex-wrap items-center gap-2 md:gap-4">
-            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
-              <button
-                onClick={() => { clearAllFilters(); setSelectedTaxa(new Set()); setSelectedSubgroups(new Set()); setSelectedObsRanges(new Set()); setSelectedSystems(new Set()); setEndemicsOnly(false); setSelectedGrowthForms(new Set()); setSelectedPopulationTrends(new Set()); setSelectedMovementPatterns(new Set()); setSelectedThreats(new Set()); setExpandedThreat(null); setSelectedAssessors(new Set()); setSelectedReviewers(new Set()); setShowOnlyStarred(false); }}
-                title="Reset all filters and taxa"
-                className="px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
-              >
-                <svg className="w-3.5 h-3.5 md:w-4 md:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-                <span className="hidden sm:inline">Clear all</span>
-              </button>
-            )}
-            {pinnedSpecies.length > 0 && (
-              <>
+          {/* Taxon-focus header — any single selected taxon: a top-level taxon
+              (selectedTopLevelTaxon, e.g. Mammals, or "All Species" itself), a
+              sub-group row drilled into via TaxaSummary's own tree
+              (selectedSubgroupTaxon: dynamic order/family/genus, or a static SSC
+              group), or a non-curated arbitrary rank reached via search
+              (arbitraryTaxon). Two stat cards: the taxon (name + rank) and the
+              matched-species count (mirrors the table's totalFiltered). The
+              Assessed/Not Evaluated toggle lives paired with the View selector
+              at the bottom-right of TaxaSummary's own table now, not here — see
+              its onViewModeChange prop. TaxaSummary's own breadcrumb table
+              above already shows the tree branch that led here (Mammals →
+              Rodentia → Heteromyidae → ...) when applicable — this is purely an
+              additional, more prominent summary, not a replacement for it. */}
+          {focusedTaxonCard && !isSingleSpecies && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
+                <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                  {focusedTaxonCard.rank ?? "Taxon"}
+                </div>
+                <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                  {focusedTaxonCard.name}
+                </div>
+              </div>
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
+                <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                  {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
+                </div>
+                <div className="mt-0.5 flex items-baseline gap-1.5">
+                  {speciesLoading && assessedSpecies.length === 0 ? (
+                    <Spinner className="h-6 w-6" />
+                  ) : (
+                    <>
+                      <span className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                        {totalFiltered.toLocaleString()}
+                      </span>
+                      {totalFiltered !== taxaFilteredSpeciesBase.length && (
+                        <span className="text-sm font-medium text-zinc-400 dark:text-zinc-500">
+                          matching filters
+                        </span>
+                      )}
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Matching Filters — replaces the old separate "applied filters" row.
+              Only rendered when there's something to show: an active filter
+              (hasActiveFilters), a Starred toggle (pinnedSpecies.length > 0), or
+              the Not Evaluated shortcut. Deliberately excludes selectedTaxa/
+              selectedSubgroups/breakdownFilter — those are taxonomy navigation,
+              not filters; Home is what clears them, not this card's Clear all.
+              The heading restates the same number as the stat card above
+              (totalFiltered) so the card is self-explanatory without having to
+              look back up — not true redundancy since they're adjacent. */}
+          {(hasActiveFilters || pinnedSpecies.length > 0 || (!isNewAssessments && (neCount > 0 || neBlockedForAll))) && (
+            <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 md:p-4">
+              {hasActiveFilters && (
+                <div className="mb-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                  {totalFiltered.toLocaleString()} Matching Filters
+                </div>
+              )}
+              <div className="flex flex-wrap items-center gap-2 md:gap-4">
+              {hasActiveFilters && (
+                <button
+                  onClick={() => {
+                    setSelectedCategories(new Set());
+                    setSelectedYearRanges(new Set());
+                    setSelectedAssessmentYears(new Set());
+                    setSelectedDescribedYears(new Set());
+                    setSelectedObsRanges(new Set());
+                    setSelectedCountries(new Set());
+                    setSelectedSystems(new Set());
+                    setEndemicsOnly(false);
+                    setSelectedGrowthForms(new Set());
+                    setSelectedPopulationTrends(new Set());
+                    setSelectedMovementPatterns(new Set());
+                    setSelectedThreats(new Set());
+                    setExpandedThreat(null);
+                    setSelectedAssessors(new Set());
+                    setSelectedReviewers(new Set());
+                    setShowOnlyStarred(false);
+                    setExactFilters(EMPTY_EXACT_FILTERS);
+                  }}
+                  title="Reset all filters (taxon selection stays — use Home to clear that)"
+                  className="px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
+                >
+                  <svg className="w-3.5 h-3.5 md:w-4 md:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                  <span className="hidden sm:inline">Clear all</span>
+                </button>
+              )}
+              {pinnedSpecies.length > 0 && (
                 <button
                   onClick={() => setShowOnlyStarred(!showOnlyStarred)}
                   className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
@@ -2564,45 +2643,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   </svg>
                   <span className="hidden sm:inline">Starred</span> ({pinnedSpecies.length})
                 </button>
-              </>
-            )}
-            {Array.from(selectedTaxa).map(taxonId => (
-              <button
-                key={taxonId}
-                onClick={() => setSelectedTaxa(prev => { const next = new Set(prev); next.delete(taxonId); return next; })}
-                className="px-3 py-1.5 text-sm font-medium rounded-full flex items-center gap-1 hover:opacity-80"
-                style={{ backgroundColor: (TAXA_BY_ID[taxonId]?.color || "#666") + "20", color: TAXA_BY_ID[taxonId]?.color || "#666" }}
-              >
-                {TAXA_BY_ID[taxonId]?.name || taxonId}
-                <span className="text-sm">×</span>
-              </button>
-            ))}
-            {Array.from(selectedSubgroups).map(sgId => {
-              const sgInfo = getNodeDef(sgId);
-              return (
+              )}
+              {!isNewAssessments && Array.from(selectedCategories).filter(cat => cat !== "NE").map(cat => (
                 <button
-                  key={sgId}
-                  onClick={() => setSelectedSubgroups(prev => { const next = new Set(prev); next.delete(sgId); return next; })}
-                  className="px-3 py-1.5 text-sm font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-                >
-                  {sgInfo?.node.name ?? dynamicNodeDisplayName(sgId)}
-                  <span className="text-sm">×</span>
-                </button>
-              );
-            })}
-            {breakdownFilter && selectedSubgroups.has(breakdownFilter.nodeId) && (
-              <button
-                onClick={() => setBreakdownFilter(null)}
-                className="px-3 py-1.5 text-sm font-medium rounded-full bg-violet-100 text-violet-600 dark:bg-violet-900/30 dark:text-violet-400 flex items-center gap-1 hover:opacity-80"
-              >
-                {breakdownDisplayName(breakdownFilter.rank, breakdownFilter.name)}
-                {breakdownFilter.onlyIds?.length ? " — No CoL Match" : breakdownFilter.excludeIds?.length ? " — CoL Match" : ""}
-                <span className="text-sm">×</span>
-              </button>
-            )}
-            {!isNewAssessments && Array.from(selectedCategories).filter(cat => cat !== "NE").map(cat => (
-              <button
-                key={cat}
+                  key={cat}
                 onClick={() => setSelectedCategories(prev => { const next = new Set(prev); next.delete(cat); return next; })}
                 className="px-3 py-1.5 text-sm font-medium rounded-full flex items-center gap-1 hover:opacity-80"
                 style={{ backgroundColor: CATEGORY_COLORS[cat] + "20", color: CATEGORY_COLORS[cat] }}
@@ -2796,11 +2840,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 </button>
               ));
             })()}
-            {/* No standalone species-count readout here anymore — the taxon-focus
-                stat card below shows it (with "of Y" once a filter narrows it),
-                so this row would just be a redundant second copy of the same
-                number. ml-auto moved to the Not Evaluated button so the pills
-                still hug the left and this stays right-aligned. */}
+            {/* No standalone species-count readout here anymore — the "N Matching
+                Filters" heading above already states it. ml-auto moved to the
+                Not Evaluated button so the pills still hug the left and this
+                stays right-aligned. */}
             {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
               <button
                 disabled={neBlockedForAll}
@@ -2829,88 +2872,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 {!neBlockedForAll && <span className="text-[10px] opacity-70">({neCount.toLocaleString()})</span>}
               </button>
             )}
-            </div>
-          </div>
-
-          {/* Taxon-focus header — any single selected taxon: a top-level taxon
-              (selectedTopLevelTaxon, e.g. Mammals, or "All Species" itself), a
-              sub-group row drilled into via TaxaSummary's own tree
-              (selectedSubgroupTaxon: dynamic order/family/genus, or a static SSC
-              group), or a non-curated arbitrary rank reached via search
-              (arbitraryTaxon). Two stat cards: the taxon (name + rank) and the
-              matched-species count (mirrors the table's totalFiltered) — the
-              latter also carries the Assessed/Not Evaluated view-mode toggle,
-              since this is where the mode actually changes what's shown.
-              grid-cols-1 sm:grid-cols-2 (not a flat grid-cols-2) plus flex-wrap
-              on the second card keep the toggle from being squeezed at phone
-              widths. TaxaSummary's own breadcrumb table above already shows the
-              tree branch that led here (Mammals → Rodentia → Heteromyidae →
-              ...) when applicable — this is purely an additional, more
-              prominent summary, not a replacement for it. */}
-          {focusedTaxonCard && !isSingleSpecies && (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
-                <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                  {focusedTaxonCard.rank ?? "Taxon"}
-                </div>
-                <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                  {focusedTaxonCard.name}
-                </div>
-              </div>
-              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex items-center justify-between gap-3 flex-wrap">
-                <div>
-                  <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                    {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
-                  </div>
-                  <div className="mt-0.5 flex items-baseline gap-1.5">
-                    {speciesLoading && assessedSpecies.length === 0 ? (
-                      <Spinner className="h-6 w-6" />
-                    ) : (
-                      <>
-                        <span className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                          {totalFiltered.toLocaleString()}
-                        </span>
-                        {/* Only show this once a filter has actually narrowed the count
-                            below the taxon's own total (taxaFilteredSpeciesBase — taxon/
-                            subgroup only, no pill filters). Deliberately doesn't state the
-                            unfiltered total ("of 6,054") — that reads as ambiguous with a
-                            totally different ratio (e.g. assessed-of-described), especially
-                            since the two are often close in magnitude for a given taxon. */}
-                        {totalFiltered !== taxaFilteredSpeciesBase.length && (
-                          <span className="text-sm font-medium text-zinc-400 dark:text-zinc-500">
-                            matching filters
-                          </span>
-                        )}
-                      </>
-                    )}
-                  </div>
-                </div>
-                {onViewModeChange && (
-                  <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
-                    <button
-                      type="button"
-                      onClick={() => onViewModeChange("reassessments")}
-                      className={`px-2 py-1 font-medium transition-colors ${
-                        !isNewAssessments
-                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                      }`}
-                    >
-                      Assessed
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => onViewModeChange("new-assessments")}
-                      className={`px-2 py-1 font-medium transition-colors ${
-                        isNewAssessments
-                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                      }`}
-                    >
-                      Not Evaluated
-                    </button>
-                  </div>
-                )}
               </div>
             </div>
           )}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -279,9 +279,12 @@ interface RedListViewProps {
   sharedSubgroups?: Set<string>;
   onTaxaChange?: (taxa: Set<string>) => void;
   onSubgroupsChange?: (subgroups: Set<string>) => void;
+  /** DOM node (owned by page.tsx's persistent header) that TaxaSummary
+   * portals its View-by selector into — see TaxaSummary's own doc comment. */
+  viewSelectorSlotEl?: HTMLDivElement | null;
 }
 
-export default function RedListView({ viewMode = "reassessments", onViewModeChange, sharedTaxa, sharedSubgroups, onTaxaChange, onSubgroupsChange }: RedListViewProps = {}) {
+export default function RedListView({ viewMode = "reassessments", onViewModeChange, sharedTaxa, sharedSubgroups, onTaxaChange, onSubgroupsChange, viewSelectorSlotEl }: RedListViewProps = {}) {
   const isNewAssessments = viewMode === "new-assessments";
   // Every species/truncation cache below is keyed by (mode, taxonId), not taxonId
   // alone — a taxon's Assessed and Not Evaluated species lists are entirely
@@ -2461,6 +2464,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
         viewMode={viewMode}
         layoutMode={layoutMode}
         onLayoutModeChange={setLayoutMode}
+        viewSelectorSlotEl={viewSelectorSlotEl}
         countryModeContent={countryModeContent}
         countryPillsContent={countryPillsContent}
         countryScope={countryScope}
@@ -2841,12 +2845,15 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               (selectedSubgroupTaxon: dynamic order/family/genus, or a static SSC
               group), or a non-curated arbitrary rank reached via search
               (arbitraryTaxon). Two stat cards: the taxon (name + rank) and the
-              matched-species count (mirrors the table's totalFiltered). The
-              Assessed/Not Evaluated view-mode toggle lives in the page header
-              now, not here. TaxaSummary's own breadcrumb table above already
-              shows the tree branch that led here (Mammals → Rodentia →
-              Heteromyidae → ...) when applicable — this is purely an
-              additional, more prominent summary, not a replacement for it. */}
+              matched-species count (mirrors the table's totalFiltered) — the
+              latter also carries the Assessed/Not Evaluated view-mode toggle,
+              since this is where the mode actually changes what's shown.
+              grid-cols-1 sm:grid-cols-2 (not a flat grid-cols-2) plus flex-wrap
+              on the second card keep the toggle from being squeezed at phone
+              widths. TaxaSummary's own breadcrumb table above already shows the
+              tree branch that led here (Mammals → Rodentia → Heteromyidae →
+              ...) when applicable — this is purely an additional, more
+              prominent summary, not a replacement for it. */}
           {focusedTaxonCard && !isSingleSpecies && (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
@@ -2857,15 +2864,43 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   {focusedTaxonCard.name}
                 </div>
               </div>
-              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
-                <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
-                  {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex items-center justify-between gap-3 flex-wrap">
+                <div>
+                  <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+                    {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
+                  </div>
+                  <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                    {speciesLoading && assessedSpecies.length === 0
+                      ? <Spinner className="h-6 w-6" />
+                      : totalFiltered.toLocaleString()}
+                  </div>
                 </div>
-                <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-                  {speciesLoading && assessedSpecies.length === 0
-                    ? <Spinner className="h-6 w-6" />
-                    : totalFiltered.toLocaleString()}
-                </div>
+                {onViewModeChange && (
+                  <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => onViewModeChange("reassessments")}
+                      className={`px-2 py-1 font-medium transition-colors ${
+                        !isNewAssessments
+                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                      }`}
+                    >
+                      Assessed
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onViewModeChange("new-assessments")}
+                      className={`px-2 py-1 font-medium transition-colors ${
+                        isNewAssessments
+                          ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                          : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                      }`}
+                    >
+                      Not Evaluated
+                    </button>
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -3336,21 +3336,18 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         </div>
       </div>
     </div>
-    {/* Bottom-right-of-table controls row: usage hint (landing-only, left)
-        + the View selector (always shown, right) — gated on perTaxa.length
-        alone (not also !loading) — perTaxa already implies data is present,
-        and also gating on loading made this row flicker away and back on
-        every country switch (loading briefly flips true again for the
-        background refetch even though perTaxa/taxa still hold the previous
-        country's data). The selector itself stays visible past the landing
-        page (unlike the hint) so it's reachable at any drill-down depth. */}
-    {perTaxa.length > 0 && (
+    {/* Bottom-right-of-table controls row: usage hint (left) + View selector
+        (right) — both landing-only, hidden once a taxon row has been clicked.
+        Gated on perTaxa.length alone (not also !loading) — perTaxa already
+        implies data is present, and also gating on loading made this row
+        flicker away and back on every country switch (loading briefly flips
+        true again for the background refetch even though perTaxa/taxa still
+        hold the previous country's data). */}
+    {perTaxa.length > 0 && selectedTaxa.size === 0 && (
       <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 mt-1.5">
-        {selectedTaxa.size === 0 && (
-          <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
-            {countryMode ? "Hover over a country, or click to lock it and multi-select." : "Click to filter, Cmd/Ctrl+click to multi-select."}
-          </span>
-        )}
+        <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
+          {countryMode ? "Hover over a country, or click to lock it and multi-select." : "Click to filter, Cmd/Ctrl+click to multi-select."}
+        </span>
         <span className="inline-flex items-center gap-1.5 ml-auto pr-3 sm:pr-0">
           {layoutModeSelect}
           {(table1aMode || sscMode) && (

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -170,6 +170,11 @@ interface Props {
    * View. Country View's own equivalent lives on the map now (see WorldMap's
    * country chips), not routed through here. */
   onClearCountryScope?: () => void;
+  /** DOM node (owned by page.tsx's persistent header) that the View-by
+   * selector portals into, so it's reachable regardless of drill-down depth
+   * instead of only appearing on the pre-selection landing page. Null until
+   * the header's ref callback has fired (first client render / SSR). */
+  viewSelectorSlotEl?: HTMLDivElement | null;
 }
 
 // Any static tree node with children is expandable — plus any node under a live
@@ -1269,7 +1274,7 @@ function DescribedInfoIcon({ nodeId, source, breakdown }: { nodeId: string; sour
   );
 }
 
-export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope, onClearCountryScope }: Props) {
+export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope, onClearCountryScope, viewSelectorSlotEl }: Props) {
   const isNewAssessments = viewMode === "new-assessments";
   const [taxa, setTaxa] = useState<TaxonSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -1477,7 +1482,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
   // assessment_locations row), so it's disabled under New Assessments.
   const layoutModeSelect = (
     <span className="inline-flex items-center gap-1.5">
-      <span className="text-xs text-zinc-400 dark:text-zinc-500">View:</span>
+      <span className="text-xs text-zinc-400 dark:text-zinc-500">View by:</span>
       <select
         value={layoutMode ?? "taxonomic"}
         onChange={(e) => {
@@ -3359,40 +3364,42 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         </div>
       </div>
     </div>
-    {/* Subtle controls: usage hint + # Described toggle + expand/table controls,
-        all landing-only — hidden once a taxon is selected. Gated on perTaxa.length
-        alone (not also !loading) — perTaxa already implies data is present, and
-        also gating on loading made this row flicker away and back on every
-        country switch (loading briefly flips true again for the background
-        refetch even though perTaxa/taxa still hold the previous country's data). */}
+    {/* Subtle usage hint — landing-only — hidden once a taxon is selected.
+        Gated on perTaxa.length alone (not also !loading) — perTaxa already
+        implies data is present, and also gating on loading made this row
+        flicker away and back on every country switch (loading briefly flips
+        true again for the background refetch even though perTaxa/taxa still
+        hold the previous country's data). The View-by selector itself lives
+        in the page header now (portaled via viewSelectorSlotEl below), not
+        here, so it's reachable at any drill-down depth. */}
     {perTaxa.length > 0 && selectedTaxa.size === 0 && (
       <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 mt-1.5">
-        {/* Usage hint — desktop only; the toggles below matter more on mobile than this prose.
-            Country View starts hover-driven, then locks to click+multi-select once a
-            country's picked (see handleCountryDrilldown), so it gets its own wording. */}
         <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
           {countryMode ? "Hover over a country, or click to lock it and multi-select." : "Click to filter, Cmd/Ctrl+click to multi-select."}
         </span>
-        <div className="flex flex-wrap items-center gap-3 pl-3 sm:pl-0">
-          {layoutModeSelect}
-          {(table1aMode || sscMode) && (
-            <span className="relative group/lm">
-              <a
-                href={table1aMode ? IUCN_SOURCE_URL : "https://iucn.org/our-union/commissions/group/1445"}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <FaInfoCircle size={10} />
-              </a>
-              <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 text-xs text-white bg-zinc-800 dark:bg-zinc-700 rounded whitespace-nowrap opacity-0 invisible group-hover/lm:opacity-100 group-hover/lm:visible z-50 shadow-lg pointer-events-none">
-                {table1aMode ? "View IUCN Red List Table 1a (PDF)" : "View IUCN SSC Specialist Groups (mammals, reptiles, fishes, invertebrates, plants & fungi)"}
-              </span>
-            </span>
-          )}
-        </div>
       </div>
+    )}
+    {viewSelectorSlotEl && createPortal(
+      <span className="inline-flex items-center gap-1.5">
+        {layoutModeSelect}
+        {(table1aMode || sscMode) && (
+          <span className="relative group/lm">
+            <a
+              href={table1aMode ? IUCN_SOURCE_URL : "https://iucn.org/our-union/commissions/group/1445"}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <FaInfoCircle size={10} />
+            </a>
+            <span className="absolute top-full right-0 mt-1 px-2 py-1 text-xs text-white bg-zinc-800 dark:bg-zinc-700 rounded whitespace-nowrap opacity-0 invisible group-hover/lm:opacity-100 group-hover/lm:visible z-50 shadow-lg pointer-events-none">
+              {table1aMode ? "View IUCN Red List Table 1a (PDF)" : "View IUCN SSC Specialist Groups (mammals, reptiles, fishes, invertebrates, plants & fungi)"}
+            </span>
+          </span>
+        )}
+      </span>,
+      viewSelectorSlotEl
     )}
     </>
   );

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -1481,15 +1481,15 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
   // location data, which Not Evaluated species don't have (no assessment means no
   // assessment_locations row), so it's disabled under New Assessments.
   const layoutModeSelect = (
-    <span className="inline-flex items-center gap-1.5">
-      <span className="text-xs text-zinc-400 dark:text-zinc-500">View by:</span>
+    <span className="inline-flex items-center gap-2">
+      <span className="text-sm font-medium text-zinc-600 dark:text-zinc-300">View</span>
       <select
         value={layoutMode ?? "taxonomic"}
         onChange={(e) => {
           const v = e.target.value;
           onLayoutModeChange(v === "taxonomic" ? null : (v as "table1a" | "ssc" | "country"));
         }}
-        className="text-xs bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md px-1.5 py-0.5 text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        className="text-sm bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md px-2 py-1 text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
       >
         <option value="taxonomic">By Taxon</option>
         <option value="country" disabled={isNewAssessments} title={isNewAssessments ? "Not available for New Assessments — Not Evaluated species have no location data" : undefined}>

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -142,6 +142,10 @@ interface Props {
   onNavigateToSubgroup?: (taxonId: string, subgroupId: string) => void;
   disableAllSpecies?: boolean;
   viewMode?: "reassessments" | "new-assessments";
+  /** Assessed/Not Evaluated mode switch — paired here with the View selector
+   * (both are page-wide "which lens am I looking through" controls) rather
+   * than living inside RedListView's own stat card. */
+  onViewModeChange?: (mode: "reassessments" | "new-assessments") => void;
   /** Table 1a mode / SSC groups mode / country-view landing page — URL-synced
    * (see useFilterParams) so it survives reload/share and the browser back
    * button can return to it. */
@@ -1262,7 +1266,7 @@ function DescribedInfoIcon({ nodeId, source, breakdown }: { nodeId: string; sour
   );
 }
 
-export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope }: Props) {
+export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", onViewModeChange, layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope }: Props) {
   const isNewAssessments = viewMode === "new-assessments";
   const [taxa, setTaxa] = useState<TaxonSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -3348,7 +3352,33 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
           {countryMode ? "Hover over a country, or click to lock it and multi-select." : "Click to filter, Cmd/Ctrl+click to multi-select."}
         </span>
-        <span className="inline-flex items-center gap-1.5 ml-auto pr-3 sm:pr-0">
+        <span className="inline-flex items-center gap-2.5 ml-auto pr-3 sm:pr-0">
+          {onViewModeChange && (
+            <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
+              <button
+                type="button"
+                onClick={() => onViewModeChange("reassessments")}
+                className={`px-2 py-1 font-medium transition-colors ${
+                  !isNewAssessments
+                    ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                    : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                }`}
+              >
+                Assessed
+              </button>
+              <button
+                type="button"
+                onClick={() => onViewModeChange("new-assessments")}
+                className={`px-2 py-1 font-medium transition-colors ${
+                  isNewAssessments
+                    ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
+                    : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
+                }`}
+              >
+                Not Evaluated
+              </button>
+            </div>
+          )}
           {layoutModeSelect}
           {(table1aMode || sscMode) && (
             <span className="relative group/lm">

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -170,6 +170,11 @@ interface Props {
    * View. Country View's own equivalent lives on the map now (see WorldMap's
    * country chips), not routed through here. */
   onClearCountryScope?: () => void;
+  /** DOM node (owned by page.tsx's persistent header) that the View-by
+   * selector portals into, so it's reachable regardless of drill-down depth
+   * instead of only appearing on the pre-selection landing page. Null until
+   * the header's ref callback has fired (first client render / SSR). */
+  viewSelectorSlotEl?: HTMLDivElement | null;
 }
 
 // Any static tree node with children is expandable — plus any node under a live
@@ -1269,7 +1274,7 @@ function DescribedInfoIcon({ nodeId, source, breakdown }: { nodeId: string; sour
   );
 }
 
-export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope, onClearCountryScope }: Props) {
+export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope, onClearCountryScope, viewSelectorSlotEl }: Props) {
   const isNewAssessments = viewMode === "new-assessments";
   const [taxa, setTaxa] = useState<TaxonSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -3359,40 +3364,42 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         </div>
       </div>
     </div>
-    {/* Subtle controls: usage hint + # Described toggle + expand/table controls,
-        all landing-only — hidden once a taxon is selected. Gated on perTaxa.length
-        alone (not also !loading) — perTaxa already implies data is present, and
-        also gating on loading made this row flicker away and back on every
-        country switch (loading briefly flips true again for the background
-        refetch even though perTaxa/taxa still hold the previous country's data). */}
+    {/* Subtle usage hint — landing-only — hidden once a taxon is selected.
+        Gated on perTaxa.length alone (not also !loading) — perTaxa already
+        implies data is present, and also gating on loading made this row
+        flicker away and back on every country switch (loading briefly flips
+        true again for the background refetch even though perTaxa/taxa still
+        hold the previous country's data). The View-by selector itself lives
+        in the page header now (portaled via viewSelectorSlotEl below), not
+        here, so it's reachable at any drill-down depth. */}
     {perTaxa.length > 0 && selectedTaxa.size === 0 && (
-      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 mt-1.5">
-        {/* Usage hint — desktop only; the toggles below matter more on mobile than this prose.
-            Country View starts hover-driven, then locks to click+multi-select once a
-            country's picked (see handleCountryDrilldown), so it gets its own wording. */}
+      <div className="mt-1.5">
         <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
           {countryMode ? "Hover over a country, or click to lock it and multi-select." : "Click to filter, Cmd/Ctrl+click to multi-select."}
         </span>
-        <div className="flex flex-wrap items-center gap-3 pl-3 sm:pl-0">
-          {layoutModeSelect}
-          {(table1aMode || sscMode) && (
-            <span className="relative group/lm">
-              <a
-                href={table1aMode ? IUCN_SOURCE_URL : "https://iucn.org/our-union/commissions/group/1445"}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <FaInfoCircle size={10} />
-              </a>
-              <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 text-xs text-white bg-zinc-800 dark:bg-zinc-700 rounded whitespace-nowrap opacity-0 invisible group-hover/lm:opacity-100 group-hover/lm:visible z-50 shadow-lg pointer-events-none">
-                {table1aMode ? "View IUCN Red List Table 1a (PDF)" : "View IUCN SSC Specialist Groups (mammals, reptiles, fishes, invertebrates, plants & fungi)"}
-              </span>
-            </span>
-          )}
-        </div>
       </div>
+    )}
+    {viewSelectorSlotEl && createPortal(
+      <span className="inline-flex items-center gap-1.5">
+        {layoutModeSelect}
+        {(table1aMode || sscMode) && (
+          <span className="relative group/lm">
+            <a
+              href={table1aMode ? IUCN_SOURCE_URL : "https://iucn.org/our-union/commissions/group/1445"}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <FaInfoCircle size={10} />
+            </a>
+            <span className="absolute top-full right-0 mt-1 px-2 py-1 text-xs text-white bg-zinc-800 dark:bg-zinc-700 rounded whitespace-nowrap opacity-0 invisible group-hover/lm:opacity-100 group-hover/lm:visible z-50 shadow-lg pointer-events-none">
+              {table1aMode ? "View IUCN Red List Table 1a (PDF)" : "View IUCN SSC Specialist Groups (mammals, reptiles, fishes, invertebrates, plants & fungi)"}
+            </span>
+          </span>
+        )}
+      </span>,
+      viewSelectorSlotEl
     )}
     </>
   );

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -18,8 +18,6 @@ import { IUCN_SOURCE_URL } from "@/config/taxonomy-tree";
 import { isLiveDrilldownNode, nextDynamicRank, isDynamicNodeId, dynamicNodeDisplayName, dynamicNodeFilter, dynamicNodeRankInfo, parseDynamicNodeId } from "@/lib/dynamic-taxon";
 import type { RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
 import { outdatedCutoffDate } from "@/lib/outdated";
-import { ALPHA2_TO_NAME } from "@/lib/countries";
-import { matchingRegion } from "@/lib/regions";
 
 // See scripts/build-taxa-summary.ts's classifyNoMatch for what each reason means.
 // Modular/additive on top of colBreakdown[].noMatchIds — safe to drop independently
@@ -165,11 +163,6 @@ interface Props {
    * scopes this table's own fetches too. One country, a whole region, or an
    * arbitrary multi-select are all just "the current set of codes" here. */
   countryScope?: string[] | null;
-  /** Clears the country selection without changing layoutMode — used for the
-   * "France ×" chip atop the table when a country's scoped outside Country
-   * View. Country View's own equivalent lives on the map now (see WorldMap's
-   * country chips), not routed through here. */
-  onClearCountryScope?: () => void;
 }
 
 // Any static tree node with children is expandable — plus any node under a live
@@ -1269,7 +1262,7 @@ function DescribedInfoIcon({ nodeId, source, breakdown }: { nodeId: string; sour
   );
 }
 
-export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope, onClearCountryScope }: Props) {
+export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope }: Props) {
   const isNewAssessments = viewMode === "new-assessments";
   const [taxa, setTaxa] = useState<TaxonSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -1322,21 +1315,19 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
   // country and skip applying a now-stale result.
   const countryKeyRef = useRef(countryKey);
   countryKeyRef.current = countryKey;
-  // Display name for the atop-table label: the one country's name, the whole
-  // region's name if the selection exactly matches one (e.g. picked via the
-  // region dropdown, or by happening to cmd-click every one of its countries),
-  // or the countries' own names (comma-separated, alphabetical) for an
-  // arbitrary multi-select that doesn't line up with any single region.
-  const countryScopeLabel = !countryScoped ? "" :
-    countryScope!.length === 1 ? (ALPHA2_TO_NAME[countryScope![0]] ?? countryScope![0]) :
-    matchingRegion(countryScope!) ?? countryScope!
-      .map((c) => ALPHA2_TO_NAME[c] ?? c)
-      .sort()
-      .join(", ");
-  // Country View always uses the plain 3-column style (even before a country is
-  // picked, showing global data) since Described/GBIF/CoL columns have no country
-  // dimension there either — see the `country-scoped` design note near countryMode.
-  const countryStyleColumns = layoutMode === "country" || countryScoped;
+  // Country View's own landing page always uses the plain 3-column style (even
+  // before a country is picked, showing global data) since Described/GBIF/CoL
+  // columns have no country dimension there either. Deliberately NOT also
+  // triggered by countryScoped alone: scoping to a country from an ordinary
+  // taxon view (e.g. clicking the small map widget while browsing Mammals)
+  // used to flip this on too, reformatting the table and duplicating the
+  // selection as a bespoke heading on top of the normal filter pill that
+  // already shows it (RedListView's applied-filters row) — removed per
+  // feedback. Clicking through from Country View into a taxon already resets
+  // layoutMode to null (see handleToggleTaxon's exitCountryModeForTaxon), so
+  // this naturally reverts to the global table at that point without any
+  // extra logic here.
+  const countryStyleColumns = layoutMode === "country";
   // Tighter, non-responsive padding for the sticky Taxonomic Group column in
   // Country View — cellPad's px-4 growth at the md breakpoint is more than the
   // taxon name + icon need just to avoid wrapping, and that column is the
@@ -2878,24 +2869,10 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
           columns get cramped or triggering horizontal scroll). */}
       {countryMode && <div>{countryModeContent}</div>}
       <div className={countryMode ? "min-w-0 flex flex-col h-full" : "contents"}>
-        {/* Country name atop the table — shown whenever a country is scoped
-            OUTSIDE Country View (the normal browsing view's "France ×" chip,
-            via onClearCountryScope). Country View's own version is the
-            chips row above the grid instead. */}
-        {countryScoped && !countryMode && (
-          <div className="flex items-center gap-1.5 mb-1.5 min-w-0 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-            <span className="truncate" title={countryScopeLabel}>{countryScopeLabel}</span>
-            {onClearCountryScope && (
-              <button
-                onClick={onClearCountryScope}
-                className="text-sm font-normal text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors shrink-0"
-                title="Clear selected country"
-              >
-                ✕
-              </button>
-            )}
-          </div>
-        )}
+        {/* No "country name atop the table" heading here anymore — a country
+            scoped outside Country View now shows only as the normal removable
+            pill in RedListView's applied-filters row, like every other filter,
+            instead of duplicating the selection as a bespoke heading too. */}
         {/* mb-4 here (not left to the parent's space-y-4) because this whole
             subtree's outer wrappers (lines above) render as `display: contents`
             outside country mode — a contents element's own margin is dropped

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -170,11 +170,6 @@ interface Props {
    * View. Country View's own equivalent lives on the map now (see WorldMap's
    * country chips), not routed through here. */
   onClearCountryScope?: () => void;
-  /** DOM node (owned by page.tsx's persistent header) that the View-by
-   * selector portals into, so it's reachable regardless of drill-down depth
-   * instead of only appearing on the pre-selection landing page. Null until
-   * the header's ref callback has fired (first client render / SSR). */
-  viewSelectorSlotEl?: HTMLDivElement | null;
 }
 
 // Any static tree node with children is expandable — plus any node under a live
@@ -1274,7 +1269,7 @@ function DescribedInfoIcon({ nodeId, source, breakdown }: { nodeId: string; sour
   );
 }
 
-export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope, onClearCountryScope, viewSelectorSlotEl }: Props) {
+export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope, onClearCountryScope }: Props) {
   const isNewAssessments = viewMode === "new-assessments";
   const [taxa, setTaxa] = useState<TaxonSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -3364,42 +3359,40 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         </div>
       </div>
     </div>
-    {/* Subtle usage hint — landing-only — hidden once a taxon is selected.
-        Gated on perTaxa.length alone (not also !loading) — perTaxa already
-        implies data is present, and also gating on loading made this row
-        flicker away and back on every country switch (loading briefly flips
-        true again for the background refetch even though perTaxa/taxa still
-        hold the previous country's data). The View-by selector itself lives
-        in the page header now (portaled via viewSelectorSlotEl below), not
-        here, so it's reachable at any drill-down depth. */}
+    {/* Subtle controls: usage hint + # Described toggle + expand/table controls,
+        all landing-only — hidden once a taxon is selected. Gated on perTaxa.length
+        alone (not also !loading) — perTaxa already implies data is present, and
+        also gating on loading made this row flicker away and back on every
+        country switch (loading briefly flips true again for the background
+        refetch even though perTaxa/taxa still hold the previous country's data). */}
     {perTaxa.length > 0 && selectedTaxa.size === 0 && (
-      <div className="mt-1.5">
+      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 mt-1.5">
+        {/* Usage hint — desktop only; the toggles below matter more on mobile than this prose.
+            Country View starts hover-driven, then locks to click+multi-select once a
+            country's picked (see handleCountryDrilldown), so it gets its own wording. */}
         <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
           {countryMode ? "Hover over a country, or click to lock it and multi-select." : "Click to filter, Cmd/Ctrl+click to multi-select."}
         </span>
-      </div>
-    )}
-    {viewSelectorSlotEl && createPortal(
-      <span className="inline-flex items-center gap-1.5">
-        {layoutModeSelect}
-        {(table1aMode || sscMode) && (
-          <span className="relative group/lm">
-            <a
-              href={table1aMode ? IUCN_SOURCE_URL : "https://iucn.org/our-union/commissions/group/1445"}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <FaInfoCircle size={10} />
-            </a>
-            <span className="absolute top-full right-0 mt-1 px-2 py-1 text-xs text-white bg-zinc-800 dark:bg-zinc-700 rounded whitespace-nowrap opacity-0 invisible group-hover/lm:opacity-100 group-hover/lm:visible z-50 shadow-lg pointer-events-none">
-              {table1aMode ? "View IUCN Red List Table 1a (PDF)" : "View IUCN SSC Specialist Groups (mammals, reptiles, fishes, invertebrates, plants & fungi)"}
+        <div className="flex flex-wrap items-center gap-3 pl-3 sm:pl-0">
+          {layoutModeSelect}
+          {(table1aMode || sscMode) && (
+            <span className="relative group/lm">
+              <a
+                href={table1aMode ? IUCN_SOURCE_URL : "https://iucn.org/our-union/commissions/group/1445"}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <FaInfoCircle size={10} />
+              </a>
+              <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 text-xs text-white bg-zinc-800 dark:bg-zinc-700 rounded whitespace-nowrap opacity-0 invisible group-hover/lm:opacity-100 group-hover/lm:visible z-50 shadow-lg pointer-events-none">
+                {table1aMode ? "View IUCN Red List Table 1a (PDF)" : "View IUCN SSC Specialist Groups (mammals, reptiles, fishes, invertebrates, plants & fungi)"}
+              </span>
             </span>
-          </span>
-        )}
-      </span>,
-      viewSelectorSlotEl
+          )}
+        </div>
+      </div>
     )}
     </>
   );

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -1297,7 +1297,16 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const [menuPos, setMenuPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
 
-  const countryScoped = !!countryScope?.length;
+  // Only actually scope this table's own data to a country while in Country
+  // View (layoutMode === "country") — countryScope itself is set from ANY
+  // country click/hover anywhere on the page (e.g. the small map widget in
+  // an ordinary taxon view's own charts row), but this table's numbers
+  // (fetchTaxa, ensureSubgroupData, Table 1a/SSC fetches, and the cache-
+  // buster reset below) should stay global outside Country View — clicking
+  // DRC while browsing Mammals shouldn't silently re-scope the breadcrumb
+  // tree to DRC's numbers. countryKey derives from this, so gating here
+  // covers every one of those effects at once.
+  const countryScoped = layoutMode === "country" && !!countryScope?.length;
   // Stable, order-independent key for the current country selection — used in
   // place of the countryScope array itself in effect dependency arrays and
   // fetch query strings. countryScope is a fresh array every render (built via
@@ -1315,18 +1324,10 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
   // country and skip applying a now-stale result.
   const countryKeyRef = useRef(countryKey);
   countryKeyRef.current = countryKey;
-  // Country View's own landing page always uses the plain 3-column style (even
-  // before a country is picked, showing global data) since Described/GBIF/CoL
-  // columns have no country dimension there either. Deliberately NOT also
-  // triggered by countryScoped alone: scoping to a country from an ordinary
-  // taxon view (e.g. clicking the small map widget while browsing Mammals)
-  // used to flip this on too, reformatting the table and duplicating the
-  // selection as a bespoke heading on top of the normal filter pill that
-  // already shows it (RedListView's applied-filters row) — removed per
-  // feedback. Clicking through from Country View into a taxon already resets
-  // layoutMode to null (see handleToggleTaxon's exitCountryModeForTaxon), so
-  // this naturally reverts to the global table at that point without any
-  // extra logic here.
+  // Same layoutMode === "country" gate as countryScoped above — Country
+  // View's own landing page always uses the plain 3-column style (even
+  // before a country is picked, showing global data) since Described/GBIF/
+  // CoL columns have no country dimension there either.
   const countryStyleColumns = layoutMode === "country";
   // Tighter, non-responsive padding for the sticky Taxonomic Group column in
   // Country View — cellPad's px-4 growth at the md breakpoint is more than the

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -142,10 +142,6 @@ interface Props {
   onNavigateToSubgroup?: (taxonId: string, subgroupId: string) => void;
   disableAllSpecies?: boolean;
   viewMode?: "reassessments" | "new-assessments";
-  /** Assessed/Not Evaluated mode switch — paired here with the View selector
-   * (both are page-wide "which lens am I looking through" controls) rather
-   * than living inside RedListView's own stat card. */
-  onViewModeChange?: (mode: "reassessments" | "new-assessments") => void;
   /** Table 1a mode / SSC groups mode / country-view landing page — URL-synced
    * (see useFilterParams) so it survives reload/share and the browser back
    * button can return to it. */
@@ -1266,7 +1262,7 @@ function DescribedInfoIcon({ nodeId, source, breakdown }: { nodeId: string; sour
   );
 }
 
-export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", onViewModeChange, layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope }: Props) {
+export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope }: Props) {
   const isNewAssessments = viewMode === "new-assessments";
   const [taxa, setTaxa] = useState<TaxonSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -3352,33 +3348,14 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
           {countryMode ? "Hover over a country, or click to lock it and multi-select." : "Click to filter, Cmd/Ctrl+click to multi-select."}
         </span>
-        <span className="inline-flex items-center gap-2.5 ml-auto pr-3 sm:pr-0">
-          {onViewModeChange && (
-            <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">
-              <button
-                type="button"
-                onClick={() => onViewModeChange("reassessments")}
-                className={`px-2 py-1 font-medium transition-colors ${
-                  !isNewAssessments
-                    ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                    : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                }`}
-              >
-                Assessed
-              </button>
-              <button
-                type="button"
-                onClick={() => onViewModeChange("new-assessments")}
-                className={`px-2 py-1 font-medium transition-colors ${
-                  isNewAssessments
-                    ? "bg-zinc-800 dark:bg-zinc-100 text-white dark:text-zinc-900"
-                    : "bg-white dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-700"
-                }`}
-              >
-                Not Evaluated
-              </button>
-            </div>
-          )}
+        <span className="inline-flex items-center gap-1.5 ml-auto pr-3 sm:pr-0">
+          {/* Assessed/Not Evaluated toggle used to be paired here too, but it's
+              a scope control that matters just as much (more, really) once
+              you've drilled into a specific taxon as it does on this landing
+              page — pairing its visibility with the View selector's landing-
+              only rule broke that. It now lives as the "Assessed Species"
+              stat card's own header instead (RedListView), which is shown at
+              both states. */}
           {layoutModeSelect}
           {(table1aMode || sscMode) && (
             <span className="relative group/lm">

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -170,11 +170,6 @@ interface Props {
    * View. Country View's own equivalent lives on the map now (see WorldMap's
    * country chips), not routed through here. */
   onClearCountryScope?: () => void;
-  /** DOM node (owned by page.tsx's persistent header) that the View-by
-   * selector portals into, so it's reachable regardless of drill-down depth
-   * instead of only appearing on the pre-selection landing page. Null until
-   * the header's ref callback has fired (first client render / SSR). */
-  viewSelectorSlotEl?: HTMLDivElement | null;
 }
 
 // Any static tree node with children is expandable — plus any node under a live
@@ -1274,7 +1269,7 @@ function DescribedInfoIcon({ nodeId, source, breakdown }: { nodeId: string; sour
   );
 }
 
-export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope, onClearCountryScope, viewSelectorSlotEl }: Props) {
+export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope, onClearCountryScope }: Props) {
   const isNewAssessments = viewMode === "new-assessments";
   const [taxa, setTaxa] = useState<TaxonSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -1491,7 +1486,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         }}
         className="text-sm bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md px-2 py-1 text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
       >
-        <option value="taxonomic">By Taxon</option>
+        <option value="taxonomic">By Taxonomic Group</option>
         <option value="country" disabled={isNewAssessments} title={isNewAssessments ? "Not available for New Assessments — Not Evaluated species have no location data" : undefined}>
           By Country
         </option>
@@ -3364,42 +3359,41 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         </div>
       </div>
     </div>
-    {/* Subtle usage hint — landing-only — hidden once a taxon is selected.
-        Gated on perTaxa.length alone (not also !loading) — perTaxa already
-        implies data is present, and also gating on loading made this row
-        flicker away and back on every country switch (loading briefly flips
-        true again for the background refetch even though perTaxa/taxa still
-        hold the previous country's data). The View-by selector itself lives
-        in the page header now (portaled via viewSelectorSlotEl below), not
-        here, so it's reachable at any drill-down depth. */}
-    {perTaxa.length > 0 && selectedTaxa.size === 0 && (
+    {/* Bottom-right-of-table controls row: usage hint (landing-only, left)
+        + the View selector (always shown, right) — gated on perTaxa.length
+        alone (not also !loading) — perTaxa already implies data is present,
+        and also gating on loading made this row flicker away and back on
+        every country switch (loading briefly flips true again for the
+        background refetch even though perTaxa/taxa still hold the previous
+        country's data). The selector itself stays visible past the landing
+        page (unlike the hint) so it's reachable at any drill-down depth. */}
+    {perTaxa.length > 0 && (
       <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 mt-1.5">
-        <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
-          {countryMode ? "Hover over a country, or click to lock it and multi-select." : "Click to filter, Cmd/Ctrl+click to multi-select."}
-        </span>
-      </div>
-    )}
-    {viewSelectorSlotEl && createPortal(
-      <span className="inline-flex items-center gap-1.5">
-        {layoutModeSelect}
-        {(table1aMode || sscMode) && (
-          <span className="relative group/lm">
-            <a
-              href={table1aMode ? IUCN_SOURCE_URL : "https://iucn.org/our-union/commissions/group/1445"}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <FaInfoCircle size={10} />
-            </a>
-            <span className="absolute top-full right-0 mt-1 px-2 py-1 text-xs text-white bg-zinc-800 dark:bg-zinc-700 rounded whitespace-nowrap opacity-0 invisible group-hover/lm:opacity-100 group-hover/lm:visible z-50 shadow-lg pointer-events-none">
-              {table1aMode ? "View IUCN Red List Table 1a (PDF)" : "View IUCN SSC Specialist Groups (mammals, reptiles, fishes, invertebrates, plants & fungi)"}
-            </span>
+        {selectedTaxa.size === 0 && (
+          <span className="hidden sm:inline pl-3 md:pl-4 text-xs text-zinc-400 dark:text-zinc-500">
+            {countryMode ? "Hover over a country, or click to lock it and multi-select." : "Click to filter, Cmd/Ctrl+click to multi-select."}
           </span>
         )}
-      </span>,
-      viewSelectorSlotEl
+        <span className="inline-flex items-center gap-1.5 ml-auto pr-3 sm:pr-0">
+          {layoutModeSelect}
+          {(table1aMode || sscMode) && (
+            <span className="relative group/lm">
+              <a
+                href={table1aMode ? IUCN_SOURCE_URL : "https://iucn.org/our-union/commissions/group/1445"}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <FaInfoCircle size={10} />
+              </a>
+              <span className="absolute bottom-full right-0 mb-1 px-2 py-1 text-xs text-white bg-zinc-800 dark:bg-zinc-700 rounded whitespace-nowrap opacity-0 invisible group-hover/lm:opacity-100 group-hover/lm:visible z-50 shadow-lg pointer-events-none">
+                {table1aMode ? "View IUCN Red List Table 1a (PDF)" : "View IUCN SSC Specialist Groups (mammals, reptiles, fishes, invertebrates, plants & fungi)"}
+              </span>
+            </span>
+          )}
+        </span>
+      </div>
     )}
     </>
   );


### PR DESCRIPTION
Closes #401, #402, #403, #404

## Summary

Note up front: #401 and #403 both went through a design iteration where the literal ask (View toggle in the top row; pills moved below the table, above the taxon card) was tried, then reverted after live review — see each item below for what shipped instead and why.

- **#401** — Originally asked for the View toggle in the page header's top row. Tried that; reverted because a page-header control read as detached from what it's actually toggling (the taxa breaddown table right below it). Landed instead on: the **View** selector (Standard / Table 1a / SSC Groups / Country) sits at the bottom-right of the taxa breadcrumb table itself, landing-only (hidden once a taxon row is clicked — browsing mode stops mattering once you've committed to a taxon). Option relabeled "By Taxonomic Group" (was "By Taxon") to match the main table's own column header exactly. The page header is back to its original form: title + theme toggle top row, subtitle + search bar second row.
- **#404** — Assessed/Not Evaluated toggle fixed for mobile: `grid-cols-1 sm:grid-cols-2` (was a hardcoded 2-column grid that squeezed it at phone widths), plus `flex-wrap`. The toggle itself sits beside the "Assessed Species"/"Not Evaluated Species" label, vertically centered against the whole stat card (its original pre-PR layout) — not in the landing-only row with the View selector, so it stays usable at any drill-down depth, not just the landing page.
- **#402** — "More Filters" is a full-width card row instead of a bare text link, and its Realm/Trend/Movement/Growth Form sub-row labels match the other card headings' style (bold, `text-sm`) with even padding top and bottom.
- **#403** — Originally asked to move the applied-filter pills below the table and remove the search bar above it. Tried moving the pills to a few different spots (below the table, merged into a stat card, tucked in the Taxon card's corner); reverted all of them — decided the pills belong exactly where they were before this PR touched anything: **directly above the species table**, since that's what they're filtering and where people look right before scanning results. The taxon/subgroup/breakdown-name pills are back in that row too, and **Clear all now resets the taxon/subgroup as well** (previously excluded, but with the taxon showing as a pill again, skipping it on Clear all read as inconsistent — Home remains the separate "go back to nothing selected" action). The local free-text search box also went back in (also originally asked to be removed) — it turned out to do something genuinely different from the page header's `SpeciesSearchBar`: the header bar *navigates* to a taxon/species, this one *filters the currently-visible table by name in place*, composing with whatever pill filters are already active. Distinct placeholder text ("Filter by name..." vs. the header's "Search for a species or taxon...") keeps the two from reading as duplicates.
- The **Taxon** and **Assessed Species** stat cards are pure static facts about the selected taxon — the count never reacts to pill filters, so that row never changes shape as filters are added/removed.
- **Country-scoping bug fix** (found during review, not one of the original 4): clicking a country on the small map widget in an ordinary taxon view (e.g. viewing Mammals, then clicking Mexico) no longer scopes the **taxa breadcrumb table's own numbers** to that country — previously the column *formatting* was already fixed to stay global, but the underlying data fetch was still being re-scoped under the hood, so the table's actual "# Assessed"/"# Outdated" figures would silently change to country-specific ones outside Country View. Now the table's data (not just its columns) stays global unless you're actually in the "By Country" view (`layoutMode === "country"`).

## Screenshots

**Unfiltered — Taxon/Assessed Species cards show fixed facts:**

![Unfiltered](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-405-header-filter-redesign/36-unfiltered-fixed-cards.png)

**Filtered to EN — stat cards stay fixed at 6,054, filters (including the Mammals pill) sit above the table with "565 species":**

![Filters above table](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-405-header-filter-redesign/37-filters-above-table.png)

**Local search box restored — typing "mouse" narrows the table in place, composing with the Mammals pill:**

![Search bar restored](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-405-header-filter-redesign/41-search-bar-restored.png)

**Country selected (Mexico) while browsing Mammals — taxa table at the top stays global (6,854 / 6,054 / 88.3% / 2,631 / 43.5%), only the species list below is scoped:**

![Table stays global with country selected](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-405-header-filter-redesign/39-table-stays-global-with-country.png)

**Mobile (390px):**

![Mobile](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-405-header-filter-redesign/38-mobile-filters-above-table.png)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 679/679 passing
- [x] Verified live in a real browser (desktop 1400px, mobile 390px): unfiltered/filtered states, Clear all resetting the taxon too, toggle usable in single-taxon view, More Filters card-row styling, local search narrowing the table in place, and clicking a country in an ordinary taxon view leaving the taxa table's own numbers untouched