### PR TITLE
Add compare mode: side-by-side dashboard panels

### DIFF
--- a/app/src/app/compare/page.tsx
+++ b/app/src/app/compare/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { FaGlobeAmericas, FaArrowLeft } from "react-icons/fa";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { useBrand } from "@/components/BrandProvider";
+import { parseParams, type ViewMode } from "@/hooks/useFilterParams";
+import { SpeciesCacheProvider } from "@/contexts/SpeciesCacheContext";
+
+const RedListView = dynamic(
+  () => import("@/components/redlist/RedListView"),
+  {
+    loading: () => (
+      <div className="flex flex-col items-center justify-center py-20">
+        <div className="animate-spin h-10 w-10 border-4 border-zinc-400 border-t-transparent rounded-full" />
+        <p className="mt-4 text-zinc-500 dark:text-zinc-400">
+          Loading view...
+        </p>
+      </div>
+    ),
+  }
+);
+
+// Mirrors page.tsx's own view-mode <-> URL sync (RedListPage's `viewMode`
+// state + handleViewModeChange), namespaced to one compare panel's suffixed
+// `view`/`view_b` param instead of the single dashboard's bare `view`.
+function usePanelViewMode(paramSuffix: string) {
+  const [viewMode, setViewMode] = useState<ViewMode>("reassessments");
+
+  useEffect(() => {
+    const syncFromUrl = () => {
+      setViewMode(parseParams(window.location.search, paramSuffix).viewMode);
+    };
+    syncFromUrl();
+    window.addEventListener("popstate", syncFromUrl);
+    return () => window.removeEventListener("popstate", syncFromUrl);
+  }, [paramSuffix]);
+
+  const handleViewModeChange = (mode: ViewMode) => {
+    if (viewMode === mode) return;
+    setViewMode(mode);
+    // Preserve every other param (including the other panel's suffixed ones)
+    // across the switch — only this panel's `view`/`view_b` key changes.
+    const params = new URLSearchParams(window.location.search);
+    const key = `view${paramSuffix}`;
+    if (mode === "reassessments") params.delete(key);
+    else params.set(key, "new-assessments");
+    const qs = params.toString();
+    window.history.pushState(null, "", qs ? `/compare?${qs}` : "/compare");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  };
+
+  return { viewMode, handleViewModeChange };
+}
+
+// One dashboard panel — same RedListView the single-dashboard page renders,
+// just namespaced to its own slice of the URL via paramSuffix (see
+// useFilterParams.ts) so panel B's filters live at `taxa_b=`/`categories_b=`
+// etc. without touching panel A's bare `taxa=`/`categories=`.
+function ComparePanel({ paramSuffix }: { paramSuffix: string }) {
+  const { viewMode, handleViewModeChange } = usePanelViewMode(paramSuffix);
+  // Same "remember taxa across the Assessed/Not Evaluated toggle" pattern
+  // page.tsx uses for the single dashboard, kept independent per panel.
+  const [sharedTaxa, setSharedTaxa] = useState<Set<string>>(new Set());
+  const [sharedSubgroups, setSharedSubgroups] = useState<Set<string>>(new Set());
+
+  return (
+    <RedListView
+      paramSuffix={paramSuffix}
+      viewMode={viewMode}
+      onViewModeChange={handleViewModeChange}
+      sharedTaxa={sharedTaxa}
+      sharedSubgroups={sharedSubgroups}
+      onTaxaChange={setSharedTaxa}
+      onSubgroupsChange={setSharedSubgroups}
+    />
+  );
+}
+
+export default function ComparePage() {
+  const brand = useBrand();
+
+  return (
+    <div className="min-h-screen flex flex-col bg-zinc-50 dark:bg-zinc-950 px-4 sm:px-6 py-4 md:px-10 md:py-8">
+      <main className="max-w-[110rem] w-full min-w-0 mx-auto flex-1">
+        <div className="mb-4 md:mb-6 flex items-center justify-between gap-3">
+          <Link
+            href="/"
+            className="flex items-center gap-2 min-w-0 hover:opacity-80 transition-opacity"
+            title="Back to dashboard"
+          >
+            {brand.showGlobe && (
+              <FaGlobeAmericas className="shrink-0 text-2xl text-emerald-600 dark:text-emerald-400" aria-hidden="true" />
+            )}
+            <h1 className="text-xl sm:text-2xl font-bold text-zinc-900 dark:text-zinc-100 truncate">
+              {brand.title} <span className="text-zinc-400 dark:text-zinc-500 font-normal">— Compare</span>
+            </h1>
+          </Link>
+          <div className="flex items-center gap-2 shrink-0">
+            <Link
+              href="/"
+              className="flex items-center gap-1.5 px-2.5 py-1.5 text-sm font-medium rounded-lg border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
+            >
+              <FaArrowLeft aria-hidden="true" />
+              Dashboard
+            </Link>
+            <ThemeToggle />
+          </div>
+        </div>
+
+        {/* One shared cache above both panels — picking the same taxon on both
+            sides only fetches it once (see SpeciesCacheContext). */}
+        <SpeciesCacheProvider>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-0 items-start">
+            <div className="min-w-0 lg:pr-6">
+              <ComparePanel paramSuffix="" />
+            </div>
+            <div className="min-w-0 lg:pl-6 lg:border-l lg:border-zinc-200 lg:dark:border-zinc-800">
+              <ComparePanel paramSuffix="_b" />
+            </div>
+          </div>
+        </SpeciesCacheProvider>
+      </main>
+    </div>
+  );
+}

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -3,11 +3,12 @@
 import { useState, useEffect } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { FaGlobeAmericas } from "react-icons/fa";
+import { FaGlobeAmericas, FaColumns } from "react-icons/fa";
 import { SpeciesSearchBar } from "../components/SpeciesSearchBar";
 import { ThemeToggle } from "../components/ThemeToggle";
 import { useBrand } from "../components/BrandProvider";
 import { parseParams, type ViewMode } from "../hooks/useFilterParams";
+import { SpeciesCacheProvider } from "../contexts/SpeciesCacheContext";
 
 // Dynamically import view component
 const RedListView = dynamic(
@@ -101,6 +102,14 @@ export default function RedListPage() {
               <p className="[grid-area:subtitle] text-[15px] md:text-[1.375rem] text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
             )}
             <div className="[grid-area:controls] flex items-center gap-2 sm:justify-self-end">
+              <Link
+                href="/compare"
+                className="flex items-center gap-1.5 px-2.5 py-1.5 text-sm font-medium rounded-lg border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
+                title="Compare two taxa side by side"
+              >
+                <FaColumns aria-hidden="true" />
+                Compare
+              </Link>
               <ThemeToggle />
             </div>
             <div className="[grid-area:search] sm:justify-self-end">
@@ -110,14 +119,16 @@ export default function RedListPage() {
         </div>
 
         {/* Content — single component instance stays mounted on viewMode switch */}
-        <RedListView
-          viewMode={viewMode}
-          onViewModeChange={handleViewModeChange}
-          sharedTaxa={sharedTaxa}
-          sharedSubgroups={sharedSubgroups}
-          onTaxaChange={setSharedTaxa}
-          onSubgroupsChange={setSharedSubgroups}
-        />
+        <SpeciesCacheProvider>
+          <RedListView
+            viewMode={viewMode}
+            onViewModeChange={handleViewModeChange}
+            sharedTaxa={sharedTaxa}
+            sharedSubgroups={sharedSubgroups}
+            onTaxaChange={setSharedTaxa}
+            onSubgroupsChange={setSharedSubgroups}
+          />
+        </SpeciesCacheProvider>
       </main>
 
       <footer className="max-w-xl mx-auto mt-2 pb-6 pt-4 border-t border-zinc-200 dark:border-zinc-800">

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -19,6 +19,7 @@ import { parseAssessors } from "@/lib/parseAssessors";
 import { iucnRegionCountries, countryToIucnRegion } from "@/lib/regions";
 import { useFilterParams } from "@/hooks/useFilterParams";
 import { type RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
+import { useSpeciesCache } from "@/contexts/SpeciesCacheContext";
 import { isOutdated, outdatedCutoffDate } from "@/lib/outdated";
 
 import AssessorCandidatesTable from "../AssessorCandidatesTable";
@@ -315,21 +316,14 @@ interface RedListViewProps {
   sharedSubgroups?: Set<string>;
   onTaxaChange?: (taxa: Set<string>) => void;
   onSubgroupsChange?: (subgroups: Set<string>) => void;
+  // Namespaces this instance's URL params (e.g. "_b" turns `taxa` into `taxa_b`) so
+  // two instances can share one URL without clobbering each other — compare mode's
+  // second panel. Defaults to "" (today's single-dashboard behavior).
+  paramSuffix?: string;
 }
 
-export default function RedListView({ viewMode = "reassessments", onViewModeChange, sharedTaxa, sharedSubgroups, onTaxaChange, onSubgroupsChange }: RedListViewProps = {}) {
+export default function RedListView({ viewMode = "reassessments", onViewModeChange, sharedTaxa, sharedSubgroups, onTaxaChange, onSubgroupsChange, paramSuffix = "" }: RedListViewProps = {}) {
   const isNewAssessments = viewMode === "new-assessments";
-  // Every species/truncation cache below is keyed by (mode, taxonId), not taxonId
-  // alone — a taxon's Assessed and Not Evaluated species lists are entirely
-  // different data. Previously taxonId alone was the key, with the whole cache
-  // wiped on every mode switch (see the effect below that used to do this) to
-  // avoid serving one mode's data under the other's key — meaning toggling back
-  // to a mode you'd already loaded for this taxon still paid the full fetch cost
-  // again (reported: several seconds each time for a large taxon like Plants,
-  // whose Not Evaluated list is huge). Prefixing the key means each mode's data
-  // is cached independently: revisiting a mode you've already loaded for this
-  // taxon is instant, and only a genuinely new (mode, taxon) pair fetches.
-  const modeKeyPrefix = isNewAssessments ? "ne:" : "assessed:";
 
   // The species table scrolls horizontally on narrow screens, so an expanded
   // detail row's `<td colSpan>` is as wide as the (often off-screen) table, not
@@ -380,7 +374,13 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     species: urlSpecies, tab: urlTab,
     setSpeciesParam, setTabParam,
     fromPopstateRef,
-  } = useFilterParams();
+  } = useFilterParams(paramSuffix);
+
+  const cache = useSpeciesCache();
+  const speciesApiUrl = useCallback(
+    (taxonId: string, categoryParam: string) => `${SPECIES_API}?taxon=${encodeURIComponent(taxonId)}${categoryParam}`,
+    []
+  );
 
   // Country view needs real per-country location data, which Not Evaluated
   // species don't have (no assessment means no assessment_locations row) — see
@@ -441,16 +441,15 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   }, [selectedTaxa, selectedSubgroups, isNewAssessments, onViewModeChange]);
 
   // Reset mode-specific filter state when switching between reassessments and
-  // new-assessments. speciesByTaxon/truncationByTaxon are NOT cleared here — they're
-  // keyed by (mode, taxonId) (see modeKeyPrefix above), so each mode's data survives
-  // the switch independently and toggling back to a mode already loaded for the
-  // current taxon is instant instead of re-fetching from scratch every time.
+  // new-assessments. The shared species cache (SpeciesCacheContext) is NOT cleared
+  // here — it's keyed by the exact request URL, which already differs between modes
+  // (`?taxon=X` vs `?taxon=X&category=NE`), so each mode's data survives the switch
+  // independently and toggling back to a mode already loaded for the current taxon
+  // is instant instead of re-fetching from scratch every time.
   const prevViewModeRef = useRef(viewMode);
   useEffect(() => {
     if (prevViewModeRef.current === viewMode) return;
     prevViewModeRef.current = viewMode;
-    setNeSpecies([]);
-    setNeSpeciesFetched(false);
     // Clear assessment-specific filters (preserve search + species so search-bar navigation survives mode
     // switch; also preserve selectedSubgroups — new-assessments mode fetches a selected sub-group directly
     // (see the fetch effect below), so e.g. toggling Unassessed while viewing an SSC group should stay
@@ -616,144 +615,83 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   const PAGE_SIZE = pageSize;
 
   // ── Data fetching ────────────────────────────────────────────────────
-  // Cache of fetched species per taxon ID. When "all" is fetched, it supersedes
-  // individual taxa caches. Each taxon is fetched at most once.
-  const [speciesByTaxon, setSpeciesByTaxon] = useState<Record<string, RedListSpecies[]>>({});
-  // Per-taxon NE-list truncation (giant aggregates are capped at 400k server-side).
-  const [truncationByTaxon, setTruncationByTaxon] = useState<Record<string, { truncated: boolean; tooLarge: boolean; neTotal: number | null; shown: number }>>({});
-  const [loadingTaxa, setLoadingTaxa] = useState<Set<string>>(new Set());
-  const [error, setError] = useState<string | null>(null);
-  const abortRefs = useRef<Record<string, AbortController>>({});
-  const prefetchPromiseRef = useRef<Promise<void> | null>(null);
+  // Species are fetched and cached in the shared SpeciesCacheContext (keyed by
+  // the exact request URL, e.g. `/api/redlist/species?taxon=birds`), not local
+  // component state — this is what lets compare mode's two panels share a
+  // fetch when they pick the same taxon, and it naturally keeps Assessed vs Not
+  // Evaluated data for the same taxon separate too, since their URLs differ
+  // (`?taxon=birds` vs `?taxon=birds&category=NE`) without needing an explicit
+  // mode-prefixed cache key.
+  const error = useMemo(() => {
+    if (selectedTaxa.size === 0) return null;
+    const fetchSet = isNewAssessments && selectedSubgroups.size > 0 ? [...selectedSubgroups] : [...selectedTaxa];
+    const categoryParam = isNewAssessments ? "&category=NE" : "";
+    for (const t of fetchSet) {
+      if (isNewAssessments && t === "all") continue;
+      const err = cache.errors[speciesApiUrl(t, categoryParam)];
+      if (err) return err;
+    }
+    return null;
+  }, [selectedTaxa, selectedSubgroups, isNewAssessments, cache.errors, speciesApiUrl]);
 
-  // Prefetch all species on mount so taxa clicks feel instant (skip for new-assessments — NE dataset too large).
-  // Declared before the taxa-fetch effect below so that on initial mount (e.g. landing directly on
-  // "All Species"), prefetchPromiseRef is already set by the time that effect runs — avoiding a
-  // duplicate concurrent fetch of the same "all" data and letting it attach to this one instead.
-  // Also re-runs whenever isNewAssessments flips back to false (switching back to Assessed mode),
-  // since that's this effect's own dependency — the guard below skips the fetch entirely once
-  // "assessed:all" is already cached (not just skipping the cache WRITE after an unnecessary
-  // request completes, which the old code did), which is what makes switching back to Assessed
-  // mode instant instead of re-fetching the whole dataset every time. speciesByTaxon deliberately
-  // ISN'T a dependency here — this only needs its value at the moment isNewAssessments changes
-  // (which the effect's own closure already captures fresh each time it re-runs), not a re-run on
-  // every unrelated speciesByTaxon update (e.g. an NE per-taxon fetch elsewhere completing), which
-  // would abort and restart this fetch pointlessly.
+  // Prefetch all species on mount so taxa clicks feel instant (skip for new-assessments — NE
+  // dataset too large). Idempotent via the shared cache's request() — a no-op once
+  // `?taxon=all` is cached or already in flight (e.g. requested by another compare-mode panel,
+  // or by the per-taxon effect below reaching "all" first).
   useEffect(() => {
-    if (isNewAssessments || speciesByTaxon["assessed:all"]) return;
-    const controller = new AbortController();
-    const promise = fetch(`${SPECIES_API}?taxon=all`, { signal: controller.signal })
-      .then(res => res.ok ? res.json() : null)
-      .then(data => {
-        if (data && !controller.signal.aborted) {
-          setSpeciesByTaxon(prev => prev["assessed:all"] ? prev : { ...prev, "assessed:all": data.species });
-        }
-      })
-      .catch(() => {})
-      .finally(() => { prefetchPromiseRef.current = null; });
-    prefetchPromiseRef.current = promise;
-    return () => { controller.abort(); prefetchPromiseRef.current = null; };
-  }, [isNewAssessments]); // eslint-disable-line react-hooks/exhaustive-deps -- speciesByTaxon read intentionally excluded, see comment above
+    if (isNewAssessments) return;
+    cache.request(`${SPECIES_API}?taxon=all`);
+  }, [isNewAssessments, cache]);
 
-  // Determine which taxa need fetching
+  // Determine which taxa need fetching, and request them from the shared cache
   useEffect(() => {
     if (selectedTaxa.size === 0) return;
 
     // In new-assessments mode, a drill-down fetches the SUB-GROUP directly so a sub-group of
     // a too-large aggregate (e.g. crustaceans under invertebrates, beetles under insects)
     // loads on its own instead of being filtered out of the parent's empty (tooLarge) result.
-    // Skip "all" — NE dataset too large for serverless.
     const fetchSet = isNewAssessments && selectedSubgroups.size > 0
       ? [...selectedSubgroups]
       : [...selectedTaxa];
-    const taxaToFetch = fetchSet.filter(t => {
-      if (isNewAssessments && t === "all") return false;
-      const key = modeKeyPrefix + t;
-      return !speciesByTaxon[key] && !loadingTaxa.has(key);
-    });
-    // If "all" is already cached for this mode, no individual fetches needed
-    if (speciesByTaxon[modeKeyPrefix + "all"] && !selectedTaxa.has("all")) {
-      // "all" data covers everything — no new fetches needed
-      return;
+    const categoryParam = isNewAssessments ? "&category=NE" : "";
+
+    // If "all" is already cached, no individual fetches needed — "all" data covers everything.
+    if (cache.entries[speciesApiUrl("all", categoryParam)] && !selectedTaxa.has("all")) return;
+
+    for (const taxonId of fetchSet) {
+      if (isNewAssessments && taxonId === "all") continue; // NE dataset too large for "all"
+      cache.request(speciesApiUrl(taxonId, categoryParam));
     }
-    if (taxaToFetch.length === 0) return;
+  }, [selectedTaxa, selectedSubgroups, isNewAssessments, cache, speciesApiUrl]);
 
-    for (const taxonId of taxaToFetch) {
-      const key = modeKeyPrefix + taxonId;
-      // Reuse the in-flight background prefetch instead of duplicating the request
-      // (the prefetch is assessed-only — see its own effect above — so only applies
-      // when this fetch is also for assessed mode).
-      if (taxonId === "all" && !isNewAssessments && prefetchPromiseRef.current) {
-        setLoadingTaxa(prev => new Set(prev).add(key));
-        prefetchPromiseRef.current.then(() => {
-          setLoadingTaxa(prev => { const next = new Set(prev); next.delete(key); return next; });
-        });
-        continue;
-      }
-
-      // If fetching "all", abort any in-flight individual taxon fetches FOR THIS MODE
-      // (a different mode's in-flight fetch is unrelated and shouldn't be aborted).
-      if (taxonId === "all") {
-        Object.entries(abortRefs.current).forEach(([id, ctrl]) => {
-          if (id !== key && id.startsWith(modeKeyPrefix)) ctrl.abort();
-        });
-      }
-
-      const controller = new AbortController();
-      abortRefs.current[key] = controller;
-
-      setLoadingTaxa(prev => new Set(prev).add(key));
-
-      const categoryParam = isNewAssessments ? "&category=NE" : "";
-      fetch(`${SPECIES_API}?taxon=${encodeURIComponent(taxonId)}${categoryParam}`, { signal: controller.signal })
-        .then(async res => {
-          if (!res.ok) {
-            const body = await res.json().catch(() => ({}));
-            throw new Error(body.error || `Species API returned ${res.status}`);
-          }
-          return res.json();
-        })
-        .then(data => {
-          if (!controller.signal.aborted) {
-            setSpeciesByTaxon(prev => ({ ...prev, [key]: data.species }));
-            setTruncationByTaxon(prev => ({ ...prev, [key]: { truncated: !!data.truncated, tooLarge: !!data.tooLarge, neTotal: data.neTotal ?? null, shown: data.species.length } }));
-          }
-        })
-        .catch(err => {
-          if (!controller.signal.aborted) {
-            setError(err instanceof Error ? err.message : "Unknown error");
-          }
-        })
-        .finally(() => {
-          if (!controller.signal.aborted) {
-            setLoadingTaxa(prev => { const next = new Set(prev); next.delete(key); return next; });
-          }
-          delete abortRefs.current[key];
-        });
-    }
-  }, [selectedTaxa, selectedSubgroups, speciesByTaxon, loadingTaxa, isNewAssessments, modeKeyPrefix]);
-
-  const speciesLoading = loadingTaxa.size > 0;
+  // "Loading" means one of THIS panel's currently-relevant URLs is still in flight —
+  // deliberately not "is anything in the shared cache loading", since in compare mode
+  // that set can include requests belonging to the other panel entirely.
+  const speciesLoading = useMemo(() => {
+    if (selectedTaxa.size === 0) return false;
+    const fetchSet = isNewAssessments && selectedSubgroups.size > 0 ? [...selectedSubgroups] : [...selectedTaxa];
+    const categoryParam = isNewAssessments ? "&category=NE" : "";
+    return fetchSet.some(t => !(isNewAssessments && t === "all") && cache.loadingUrls.has(speciesApiUrl(t, categoryParam)));
+  }, [selectedTaxa, selectedSubgroups, isNewAssessments, cache.loadingUrls, speciesApiUrl]);
 
   // Merge species from all fetched taxa relevant to current selection
   const assessedSpecies = useMemo(() => {
     if (selectedTaxa.size === 0) return [];
+    const categoryParam = isNewAssessments ? "&category=NE" : "";
     // If "all" is cached for this mode, use it directly
-    if (speciesByTaxon[modeKeyPrefix + "all"]) return speciesByTaxon[modeKeyPrefix + "all"];
+    const allEntry = cache.entries[speciesApiUrl("all", categoryParam)];
+    if (allEntry) return allEntry.species;
     // In new-assessments mode a drill-down is fetched per sub-group, so merge those caches
     // when sub-groups are selected; otherwise merge the per-taxon caches.
     const sourceIds = isNewAssessments && selectedSubgroups.size > 0 ? [...selectedSubgroups] : [...selectedTaxa];
     let merged: RedListSpecies[] = [];
     for (const taxonId of sourceIds) {
-      const key = modeKeyPrefix + taxonId;
-      if (speciesByTaxon[key]) merged = merged.concat(speciesByTaxon[key]);
+      const entry = cache.entries[speciesApiUrl(taxonId, categoryParam)];
+      if (entry) merged = merged.concat(entry.species);
     }
     return merged;
-  }, [selectedTaxa, selectedSubgroups, speciesByTaxon, isNewAssessments, modeKeyPrefix]);
+  }, [selectedTaxa, selectedSubgroups, cache.entries, isNewAssessments, speciesApiUrl]);
 
-  // NE species lazy loading (only fetched when NE category is selected)
-  const [neSpecies, setNeSpecies] = useState<RedListSpecies[]>([]);
-  const [neSpeciesFetched, setNeSpeciesFetched] = useState(false);
   // Determine taxon for NE fetch: "all" if selected or multi-taxa, otherwise the single taxon
   const neFetchTaxon = useMemo(() => {
     if (selectedTaxa.size === 0) return null;
@@ -762,18 +700,20 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     return "all";
   }, [selectedTaxa]);
 
+  // NE species lazy loading (only fetched when NE category is selected in Assessed mode —
+  // in new-assessments mode the main path above already fetches NE species). Shares the same
+  // shared-cache URL as the new-assessments-mode fetch for the same taxon, so switching
+  // between "Assessed + NE filter" and New Assessments for one taxon only ever fetches once.
   useEffect(() => {
-    // Skip NE lazy-load in new-assessments mode — main path already fetches NE species
     if (isNewAssessments) return;
-    if (!selectedCategories.has("NE") || neSpeciesFetched || neFetchTaxon === null) return;
-    fetch(`${SPECIES_API}?taxon=${encodeURIComponent(neFetchTaxon)}&category=NE`)
-      .then(res => res.ok ? res.json() : null)
-      .then(data => { if (data?.species) setNeSpecies(data.species); setNeSpeciesFetched(true); })
-      .catch(() => {});
-  }, [selectedCategories, neSpeciesFetched, neFetchTaxon, isNewAssessments]);
+    if (!selectedCategories.has("NE") || neFetchTaxon === null) return;
+    cache.request(speciesApiUrl(neFetchTaxon, "&category=NE"));
+  }, [selectedCategories, neFetchTaxon, isNewAssessments, cache, speciesApiUrl]);
 
-  // Reset NE fetch when taxon selection changes
-  useEffect(() => { setNeSpecies([]); setNeSpeciesFetched(false); }, [neFetchTaxon]);
+  const neSpecies = useMemo(() => {
+    if (isNewAssessments || !selectedCategories.has("NE") || neFetchTaxon === null) return [];
+    return cache.entries[speciesApiUrl(neFetchTaxon, "&category=NE")]?.species ?? [];
+  }, [isNewAssessments, selectedCategories, neFetchTaxon, cache.entries, speciesApiUrl]);
 
   // "All Species" (or any multi-taxon selection, which also resolves neFetchTaxon to
   // "all") has ~1.8M not-evaluated species — far past querySpecies's NE_CAP, so the
@@ -1079,7 +1019,9 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       return;
     }
     // Skip if species is already in bulk-loaded data
-    const allSpecies = [...(speciesByTaxon[modeKeyPrefix + (selectedTaxa.size === 1 ? [...selectedTaxa][0] : "all")] ?? []), ...neSpecies];
+    const bulkTaxon = selectedTaxa.size === 1 ? [...selectedTaxa][0] : "all";
+    const bulkUrl = speciesApiUrl(bulkTaxon, isNewAssessments ? "&category=NE" : "");
+    const allSpecies = [...(cache.entries[bulkUrl]?.species ?? []), ...neSpecies];
     if (allSpecies.some(s => s.id === urlSpecies)) {
       setSingleSpeciesPreview(null);
       return;
@@ -1763,11 +1705,11 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     if (!isNewAssessments) return null;
     let truncated = false; let neTotal = 0; let shown = 0;
     for (const t of selectedTaxa) {
-      const info = truncationByTaxon[modeKeyPrefix + t];
-      if (info?.truncated) { truncated = true; neTotal += info.neTotal ?? 0; shown += info.shown; }
+      const info = cache.entries[speciesApiUrl(t, "&category=NE")];
+      if (info?.truncated) { truncated = true; neTotal += info.neTotal ?? 0; shown += info.species.length; }
     }
     return truncated ? { neTotal, shown } : null;
-  }, [isNewAssessments, selectedTaxa, truncationByTaxon, modeKeyPrefix]);
+  }, [isNewAssessments, selectedTaxa, cache.entries, speciesApiUrl]);
 
   // A giant aggregate (insects, invertebrates) exceeds the cap — the API returns no rows
   // and flags tooLarge. Don't render the charts/list; prompt a drill-down into a sub-group.
@@ -1781,11 +1723,11 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     const names: string[] = [];
     let neTotal = 0;
     for (const t of targets) {
-      const info = truncationByTaxon[modeKeyPrefix + t];
+      const info = cache.entries[speciesApiUrl(t, "&category=NE")];
       if (info?.tooLarge) { names.push(findNode(t)?.name ?? t); neTotal += info.neTotal ?? 0; }
     }
     return names.length > 0 ? { names, neTotal } : null;
-  }, [isNewAssessments, selectedTaxa, selectedSubgroups, truncationByTaxon, modeKeyPrefix]);
+  }, [isNewAssessments, selectedTaxa, selectedSubgroups, cache.entries, speciesApiUrl]);
 
   // ── Client-side pagination ─────────────────────────────────────────
   const totalFiltered = filteredSpecies.length;

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -641,7 +641,14 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   useEffect(() => {
     if (isNewAssessments) return;
     cache.request(`${SPECIES_API}?taxon=all`);
-  }, [isNewAssessments, cache]);
+  // Depends on cache.request specifically, not the whole cache object: the
+  // linter conservatively wants the whole object for any method call off a
+  // hook-returned value, but cache.request's identity only ever changes
+  // together with cache.entries (see SpeciesCacheContext) — depending on the
+  // whole object here would additionally re-run this effect on every
+  // loadingUrls/errors-only update, e.g. another compare-mode panel's fetch
+  // completing or failing, which has nothing to do with this taxon.
+  }, [isNewAssessments, cache.request]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Determine which taxa need fetching, and request them from the shared cache
   useEffect(() => {
@@ -662,7 +669,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       if (isNewAssessments && taxonId === "all") continue; // NE dataset too large for "all"
       cache.request(speciesApiUrl(taxonId, categoryParam));
     }
-  }, [selectedTaxa, selectedSubgroups, isNewAssessments, cache, speciesApiUrl]);
+  // cache.entries (for the "all" fast-path check above) + cache.request
+  // specifically, not the whole cache object — see the prefetch effect
+  // above for why depending on the whole object over-triggers this.
+  }, [selectedTaxa, selectedSubgroups, isNewAssessments, cache.entries, cache.request, speciesApiUrl]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // "Loading" means one of THIS panel's currently-relevant URLs is still in flight —
   // deliberately not "is anything in the shared cache loading", since in compare mode
@@ -708,7 +718,9 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     if (isNewAssessments) return;
     if (!selectedCategories.has("NE") || neFetchTaxon === null) return;
     cache.request(speciesApiUrl(neFetchTaxon, "&category=NE"));
-  }, [selectedCategories, neFetchTaxon, isNewAssessments, cache, speciesApiUrl]);
+    // cache.request specifically, not the whole cache object — same reasoning
+    // as the prefetch effect above.
+  }, [selectedCategories, neFetchTaxon, isNewAssessments, cache.request, speciesApiUrl]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const neSpecies = useMemo(() => {
     if (isNewAssessments || !selectedCategories.has("NE") || neFetchTaxon === null) return [];

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -435,6 +435,16 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     const prev = prevSelectionRef.current;
     prevSelectionRef.current = { taxa: selectedTaxa, subgroups: selectedSubgroups };
     if (prev === null) return;
+    // Skip going from no taxa to some taxa too — this is URL hydration
+    // (useFilterParams starts empty then populates from URL on mount), not a
+    // user browsing to a new taxon. Without this, a shared link combining
+    // ?view=new-assessments&taxa=X hydrates its taxa a render after this
+    // effect's first (skipped, prev === null) run, so that second run sees
+    // an empty→populated transition, misreads it as a real taxon change, and
+    // immediately resets straight back to Assessed — the exact case the
+    // "very first render" skip above was meant to protect (see the same
+    // hydration guard on the "reset all other filters" effect below).
+    if (prev.taxa.size === 0 && prev.subgroups.size === 0) return;
     const setsEqual = (a: Set<string>, b: Set<string>) => a.size === b.size && [...a].every((v) => b.has(v));
     const changed = !setsEqual(prev.taxa, selectedTaxa) || !setsEqual(prev.subgroups, selectedSubgroups);
     if (changed && isNewAssessments) onViewModeChange?.("reassessments");

--- a/app/src/contexts/SpeciesCacheContext.tsx
+++ b/app/src/contexts/SpeciesCacheContext.tsx
@@ -1,14 +1,9 @@
 "use client";
 
 import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from "react";
-import { type RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
+import { shouldSkipRequest, toCacheEntry, type SpeciesCacheEntry } from "./species-cache-logic";
 
-export interface SpeciesCacheEntry {
-  species: RedListSpecies[];
-  truncated: boolean;
-  tooLarge: boolean;
-  neTotal: number | null;
-}
+export type { SpeciesCacheEntry };
 
 interface SpeciesCacheValue {
   entries: Record<string, SpeciesCacheEntry>;
@@ -39,7 +34,7 @@ export function SpeciesCacheProvider({ children }: { children: ReactNode }) {
   const inFlightRef = useRef<Set<string>>(new Set());
 
   const request = useCallback((url: string) => {
-    if (entries[url] !== undefined || inFlightRef.current.has(url)) return;
+    if (shouldSkipRequest(url, entries, inFlightRef.current)) return;
     inFlightRef.current.add(url);
     setLoadingUrls(prev => new Set(prev).add(url));
     fetch(url)
@@ -51,15 +46,7 @@ export function SpeciesCacheProvider({ children }: { children: ReactNode }) {
         return res.json();
       })
       .then(data => {
-        setEntries(prev => ({
-          ...prev,
-          [url]: {
-            species: data.species ?? [],
-            truncated: !!data.truncated,
-            tooLarge: !!data.tooLarge,
-            neTotal: data.neTotal ?? null,
-          },
-        }));
+        setEntries(prev => ({ ...prev, [url]: toCacheEntry(data) }));
       })
       .catch(err => {
         setErrors(prev => ({ ...prev, [url]: err instanceof Error ? err.message : "Unknown error" }));

--- a/app/src/contexts/SpeciesCacheContext.tsx
+++ b/app/src/contexts/SpeciesCacheContext.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from "react";
+import { type RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
+
+export interface SpeciesCacheEntry {
+  species: RedListSpecies[];
+  truncated: boolean;
+  tooLarge: boolean;
+  neTotal: number | null;
+}
+
+interface SpeciesCacheValue {
+  entries: Record<string, SpeciesCacheEntry>;
+  loadingUrls: Set<string>;
+  errors: Record<string, string>;
+  // Idempotent: fetches `url` at most once, no matter how many callers request it
+  // concurrently (e.g. two compare-mode panels both selecting "Birds") — later
+  // callers for an already-cached or in-flight url are a no-op.
+  request: (url: string) => void;
+}
+
+const SpeciesCacheContext = createContext<SpeciesCacheValue | null>(null);
+
+/**
+ * Shared species-fetch cache, keyed by the exact request URL (so e.g.
+ * `?taxon=birds` and `?taxon=birds&category=NE` are naturally distinct entries).
+ * Wrap one or more RedListView instances in a single provider to have them share
+ * fetches — the single-dashboard page wraps exactly one instance (no behavior
+ * change from today), compare mode wraps two so picking the same taxon on both
+ * sides only fetches it once.
+ */
+export function SpeciesCacheProvider({ children }: { children: ReactNode }) {
+  const [entries, setEntries] = useState<Record<string, SpeciesCacheEntry>>({});
+  const [loadingUrls, setLoadingUrls] = useState<Set<string>>(new Set());
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  // Tracks in-flight requests so concurrent callers (e.g. both panels mounting at
+  // once) dedupe even before the first `entries` update lands.
+  const inFlightRef = useRef<Set<string>>(new Set());
+
+  const request = useCallback((url: string) => {
+    if (entries[url] !== undefined || inFlightRef.current.has(url)) return;
+    inFlightRef.current.add(url);
+    setLoadingUrls(prev => new Set(prev).add(url));
+    fetch(url)
+      .then(async res => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || `Species API returned ${res.status}`);
+        }
+        return res.json();
+      })
+      .then(data => {
+        setEntries(prev => ({
+          ...prev,
+          [url]: {
+            species: data.species ?? [],
+            truncated: !!data.truncated,
+            tooLarge: !!data.tooLarge,
+            neTotal: data.neTotal ?? null,
+          },
+        }));
+      })
+      .catch(err => {
+        setErrors(prev => ({ ...prev, [url]: err instanceof Error ? err.message : "Unknown error" }));
+      })
+      .finally(() => {
+        inFlightRef.current.delete(url);
+        setLoadingUrls(prev => {
+          const next = new Set(prev);
+          next.delete(url);
+          return next;
+        });
+      });
+  }, [entries]);
+
+  const value = useMemo<SpeciesCacheValue>(
+    () => ({ entries, loadingUrls, errors, request }),
+    [entries, loadingUrls, errors, request]
+  );
+
+  return <SpeciesCacheContext.Provider value={value}>{children}</SpeciesCacheContext.Provider>;
+}
+
+export function useSpeciesCache(): SpeciesCacheValue {
+  const ctx = useContext(SpeciesCacheContext);
+  if (!ctx) throw new Error("useSpeciesCache must be used within a SpeciesCacheProvider");
+  return ctx;
+}

--- a/app/src/contexts/SpeciesCacheContext.tsx
+++ b/app/src/contexts/SpeciesCacheContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { shouldSkipRequest, toCacheEntry, type SpeciesCacheEntry } from "./species-cache-logic";
 
 export type { SpeciesCacheEntry };
@@ -29,15 +29,29 @@ export function SpeciesCacheProvider({ children }: { children: ReactNode }) {
   const [entries, setEntries] = useState<Record<string, SpeciesCacheEntry>>({});
   const [loadingUrls, setLoadingUrls] = useState<Set<string>>(new Set());
   const [errors, setErrors] = useState<Record<string, string>>({});
+
   // Tracks in-flight requests so concurrent callers (e.g. both panels mounting at
   // once) dedupe even before the first `entries` update lands.
   const inFlightRef = useRef<Set<string>>(new Set());
+  // One AbortController per in-flight url, aborted on provider unmount — so
+  // navigating away (e.g. leaving /compare) actually cancels in-flight
+  // requests instead of letting them complete for a component tree that's
+  // gone, and their completion doesn't call setState on an unmounted provider.
+  const abortControllersRef = useRef<Record<string, AbortController>>({});
+  useEffect(() => {
+    return () => {
+      Object.values(abortControllersRef.current).forEach(c => c.abort());
+      abortControllersRef.current = {};
+    };
+  }, []);
 
   const request = useCallback((url: string) => {
     if (shouldSkipRequest(url, entries, inFlightRef.current)) return;
     inFlightRef.current.add(url);
+    const controller = new AbortController();
+    abortControllersRef.current[url] = controller;
     setLoadingUrls(prev => new Set(prev).add(url));
-    fetch(url)
+    fetch(url, { signal: controller.signal })
       .then(async res => {
         if (!res.ok) {
           const body = await res.json().catch(() => ({}));
@@ -49,16 +63,30 @@ export function SpeciesCacheProvider({ children }: { children: ReactNode }) {
         setEntries(prev => ({ ...prev, [url]: toCacheEntry(data) }));
       })
       .catch(err => {
+        if (controller.signal.aborted) return; // provider unmounted; nothing left to update
         setErrors(prev => ({ ...prev, [url]: err instanceof Error ? err.message : "Unknown error" }));
       })
       .finally(() => {
         inFlightRef.current.delete(url);
+        delete abortControllersRef.current[url];
+        if (controller.signal.aborted) return;
         setLoadingUrls(prev => {
           const next = new Set(prev);
           next.delete(url);
           return next;
         });
       });
+  // `request`'s identity legitimately changes whenever `entries` does — reading
+  // `entries` fresh here (rather than via a ref kept "in sync" by a separate
+  // effect) matters: a ref updated in its own useEffect lags one commit behind
+  // whichever consumer effect's `cache.entries` change triggered it, so a
+  // component whose own fetch just resolved could re-run its request effect
+  // before the ref catches up and re-fire a request for the url it just
+  // received (confirmed by hand — this actually happened). Consumers avoid
+  // over-triggering not by making `request` stable, but by depending on
+  // `cache.entries`/`cache.request` specifically rather than the whole cache
+  // object (see RedListView.tsx) — those two only change together with
+  // `entries`, never independently on a loadingUrls/errors-only update.
   }, [entries]);
 
   const value = useMemo<SpeciesCacheValue>(

--- a/app/src/contexts/__tests__/species-cache-logic.test.ts
+++ b/app/src/contexts/__tests__/species-cache-logic.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { shouldSkipRequest, toCacheEntry, type SpeciesCacheEntry } from "../species-cache-logic";
+import { type RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
+
+const emptyEntry: SpeciesCacheEntry = { species: [], truncated: false, tooLarge: false, neTotal: null };
+
+describe("shouldSkipRequest", () => {
+  it("does not skip a url that's neither cached nor in flight", () => {
+    expect(shouldSkipRequest("/api/species?taxon=birds", {}, new Set())).toBe(false);
+  });
+
+  it("skips a url that's already cached", () => {
+    const entries = { "/api/species?taxon=birds": emptyEntry };
+    expect(shouldSkipRequest("/api/species?taxon=birds", entries, new Set())).toBe(true);
+  });
+
+  it("skips a url that's already in flight (concurrent callers dedupe before the first response lands)", () => {
+    const inFlight = new Set(["/api/species?taxon=birds"]);
+    expect(shouldSkipRequest("/api/species?taxon=birds", {}, inFlight)).toBe(true);
+  });
+
+  it("does not skip a different url just because another url is cached or in flight", () => {
+    const entries = { "/api/species?taxon=birds": emptyEntry };
+    const inFlight = new Set(["/api/species?taxon=mammals"]);
+    expect(shouldSkipRequest("/api/species?taxon=reptiles", entries, inFlight)).toBe(false);
+  });
+
+  it("treats a taxon's Assessed and Not-Evaluated urls as distinct cache keys", () => {
+    // The cache key is the exact request URL, so `?taxon=mammals` and
+    // `?taxon=mammals&category=NE` are naturally separate entries — this is
+    // what lets compare mode's two panels sit in different view modes for the
+    // same taxon without one mode's cached data masking the other's.
+    const entries = { "/api/species?taxon=mammals": emptyEntry };
+    expect(shouldSkipRequest("/api/species?taxon=mammals&category=NE", entries, new Set())).toBe(false);
+  });
+});
+
+describe("toCacheEntry", () => {
+  it("defaults species to an empty array when absent", () => {
+    expect(toCacheEntry({}).species).toEqual([]);
+  });
+
+  it("passes the species array through unchanged", () => {
+    const species = [{ id: 1 }] as unknown as RedListSpecies[];
+    expect(toCacheEntry({ species }).species).toBe(species);
+  });
+
+  it("coerces truncated/tooLarge to booleans, defaulting to false", () => {
+    expect(toCacheEntry({}).truncated).toBe(false);
+    expect(toCacheEntry({}).tooLarge).toBe(false);
+    expect(toCacheEntry({ truncated: true, tooLarge: true }).truncated).toBe(true);
+    expect(toCacheEntry({ truncated: true, tooLarge: true }).tooLarge).toBe(true);
+  });
+
+  it("defaults neTotal to null when absent", () => {
+    expect(toCacheEntry({}).neTotal).toBe(null);
+  });
+
+  it("keeps a provided neTotal, including 0", () => {
+    expect(toCacheEntry({ neTotal: 0 }).neTotal).toBe(0);
+    expect(toCacheEntry({ neTotal: 42 }).neTotal).toBe(42);
+  });
+});

--- a/app/src/contexts/species-cache-logic.ts
+++ b/app/src/contexts/species-cache-logic.ts
@@ -1,0 +1,36 @@
+import { type RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
+
+export interface SpeciesCacheEntry {
+  species: RedListSpecies[];
+  truncated: boolean;
+  tooLarge: boolean;
+  neTotal: number | null;
+}
+
+// True when a request for `url` should be skipped — already cached, or a
+// fetch for it is already in flight. Pulled out of SpeciesCacheProvider as a
+// plain function (rather than left inline in the component) so the actual
+// dedup decision is directly unit-testable — this repo's test suite only
+// covers .ts logic, not .tsx rendering (see vitest.config.ts).
+export function shouldSkipRequest(
+  url: string,
+  entries: Record<string, SpeciesCacheEntry>,
+  inFlight: ReadonlySet<string>
+): boolean {
+  return entries[url] !== undefined || inFlight.has(url);
+}
+
+// Normalizes a raw /api/redlist/species JSON response into a cache entry.
+export function toCacheEntry(data: {
+  species?: RedListSpecies[];
+  truncated?: boolean;
+  tooLarge?: boolean;
+  neTotal?: number | null;
+}): SpeciesCacheEntry {
+  return {
+    species: data.species ?? [],
+    truncated: !!data.truncated,
+    tooLarge: !!data.tooLarge,
+    neTotal: data.neTotal ?? null,
+  };
+}

--- a/app/src/hooks/__tests__/filterParams.test.ts
+++ b/app/src/hooks/__tests__/filterParams.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseParams, buildQs } from "../useFilterParams";
+import { parseParams, buildQs, mergeParamsIntoSearch } from "../useFilterParams";
 
 describe("parseParams", () => {
   it("defaults viewMode to reassessments", () => {
@@ -629,5 +629,114 @@ describe("parseParams ↔ buildQs round-trip", () => {
     const qs = buildQs(original);
     const parsed = parseParams(qs);
     expect(parsed.sortField).toBe("newGbif");
+  });
+});
+
+describe("param suffixing (compare mode)", () => {
+  const emptyState = {
+    viewMode: "reassessments" as const,
+    taxa: new Set<string>(),
+    categories: new Set<string>(),
+    yearRanges: new Set<string>(),
+    assessmentYears: new Set<string>(),
+    describedYears: new Set<string>(),
+    countries: new Set<string>(),
+    obsRanges: new Set<string>(),
+    systems: new Set<string>(),
+    populationTrends: new Set<string>(),
+    movementPatterns: new Set<string>(),
+    threats: new Set<string>(),
+    endemicsOnly: false,
+    growthForms: new Set<string>(),
+    assessors: new Set<string>(),
+    reviewers: new Set<string>(),
+    search: "",
+    subgroups: new Set<string>(),
+    sortField: null as "year" | "category" | "totalGbif" | "newGbif" | "pctNewGbif" | "describedYear" | null,
+    sortDirection: "desc" as const,
+    species: null as number | null,
+    tab: null as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol" | null,
+  };
+
+  describe("parseParams with a suffix", () => {
+    it("reads the suffixed key, not the bare one", () => {
+      const result = parseParams("?taxa_b=reptiles", "_b");
+      expect(result.taxa).toEqual(new Set(["reptiles"]));
+    });
+
+    it("ignores the bare key when a suffix is given", () => {
+      const result = parseParams("?taxa=birds", "_b");
+      expect(result.taxa.size).toBe(0);
+    });
+
+    it("each suffix only sees its own slice of a combined query string", () => {
+      const search = "?taxa=birds&taxa_b=reptiles";
+      expect(parseParams(search, "").taxa).toEqual(new Set(["birds"]));
+      expect(parseParams(search, "_b").taxa).toEqual(new Set(["reptiles"]));
+    });
+
+    it("suffixes categories, search, and sort too, not just taxa", () => {
+      const result = parseParams("?categories_b=CR,EN&search_b=shrew&sort_b=category&dir_b=asc", "_b");
+      expect(result.categories).toEqual(new Set(["CR", "EN"]));
+      expect(result.search).toBe("shrew");
+      expect(result.sortField).toBe("category");
+      expect(result.sortDirection).toBe("asc");
+    });
+  });
+
+  describe("buildQs with a suffix", () => {
+    it("writes the suffixed key", () => {
+      const qs = buildQs({ ...emptyState, taxa: new Set(["reptiles"]) }, "_b");
+      expect(qs).toBe("?taxa_b=reptiles");
+    });
+
+    it("round-trips through parseParams with the same suffix", () => {
+      const qs = buildQs({ ...emptyState, taxa: new Set(["reptiles"]), categories: new Set(["CR"]) }, "_b");
+      const parsed = parseParams(qs, "_b");
+      expect(parsed.taxa).toEqual(new Set(["reptiles"]));
+      expect(parsed.categories).toEqual(new Set(["CR"]));
+    });
+
+    it("defaults to no suffix, matching pre-compare-mode behavior", () => {
+      const qs = buildQs({ ...emptyState, taxa: new Set(["birds"]) });
+      expect(qs).toBe("?taxa=birds");
+    });
+  });
+
+  describe("mergeParamsIntoSearch", () => {
+    it("adds this panel's params without touching an existing different-suffix panel's params", () => {
+      const currentSearch = "?taxa_b=reptiles&categories_b=CR";
+      const qs = mergeParamsIntoSearch(currentSearch, { ...emptyState, taxa: new Set(["birds"]) }, "");
+      const params = new URLSearchParams(qs);
+      expect(params.get("taxa")).toBe("birds");
+      expect(params.get("taxa_b")).toBe("reptiles");
+      expect(params.get("categories_b")).toBe("CR");
+    });
+
+    it("replaces this panel's own previous value rather than accumulating it", () => {
+      const qs = mergeParamsIntoSearch("?taxa=birds", { ...emptyState, taxa: new Set(["mammals"]) }, "");
+      const params = new URLSearchParams(qs);
+      expect(params.getAll("taxa")).toEqual(["mammals"]);
+    });
+
+    it("preserves query params outside this hook's own vocabulary (e.g. utm tracking)", () => {
+      const currentSearch = "?taxa_b=reptiles&utm_source=newsletter";
+      const qs = mergeParamsIntoSearch(currentSearch, { ...emptyState, taxa: new Set(["birds"]) }, "");
+      const params = new URLSearchParams(qs);
+      expect(params.get("utm_source")).toBe("newsletter");
+    });
+
+    it("clears this panel's own params (e.g. returning to the landing page) without touching the other panel's", () => {
+      const currentSearch = "?taxa=birds&taxa_b=reptiles";
+      const qs = mergeParamsIntoSearch(currentSearch, { ...emptyState, taxa: new Set() }, "");
+      const params = new URLSearchParams(qs);
+      expect(params.has("taxa")).toBe(false);
+      expect(params.get("taxa_b")).toBe("reptiles");
+    });
+
+    it("with no existing foreign params, matches buildQs's own output exactly (backward compatible)", () => {
+      const state = { ...emptyState, taxa: new Set(["birds"]), categories: new Set(["CR", "EN"]) };
+      expect(mergeParamsIntoSearch("", state, "")).toBe(buildQs(state));
+    });
   });
 });

--- a/app/src/hooks/__tests__/filterParams.test.ts
+++ b/app/src/hooks/__tests__/filterParams.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseParams, buildQs, mergeParamsIntoSearch } from "../useFilterParams";
+import { parseParams, buildQs, mergeParamsIntoSearch, OWN_PARAM_NAMES } from "../useFilterParams";
 
 describe("parseParams", () => {
   it("defaults viewMode to reassessments", () => {
@@ -738,5 +738,64 @@ describe("param suffixing (compare mode)", () => {
       const state = { ...emptyState, taxa: new Set(["birds"]), categories: new Set(["CR", "EN"]) };
       expect(mergeParamsIntoSearch("", state, "")).toBe(buildQs(state));
     });
+  });
+});
+
+describe("OWN_PARAM_NAMES stays in sync with buildQs", () => {
+  it("every key buildQs can write is in OWN_PARAM_NAMES", () => {
+    // mergeParamsIntoSearch/syncUrl only ever delete this instance's OWN_PARAM_NAMES
+    // keys before re-setting from buildQs's output — if a param were ever added to
+    // buildQs without adding it here too, its stale value would survive every
+    // future write instead of being replaced, and (worse) it'd never get a suffix,
+    // so it would leak across compare-mode panels. This "kitchen sink" state
+    // populates every field with a non-default value so buildQs emits every key it
+    // knows how to write, then asserts each one is accounted for.
+    const kitchenSink = {
+      viewMode: "new-assessments" as const,
+      layoutMode: "table1a" as const,
+      originLayout: "ssc" as const,
+      taxa: new Set(["mammals"]),
+      subgroups: new Set<string>(),
+      categories: new Set(["CR"]),
+      yearRanges: new Set(["<1 year"]),
+      assessmentYears: new Set(["2023"]),
+      describedYears: new Set(["2000-2009"]),
+      countries: new Set(["ZA"]),
+      obsRanges: new Set(["1-10"]),
+      systems: new Set(["Terrestrial"]),
+      populationTrends: new Set(["Decreasing"]),
+      movementPatterns: new Set(["Migratory"]),
+      threats: new Set(["Agriculture"]),
+      breakdown: { nodeId: "n1", rank: "order" as const, name: "Test" },
+      endemicsOnly: true,
+      growthForms: new Set(["Tree"]),
+      assessors: new Set(["Someone"]),
+      reviewers: new Set(["Someone Else"]),
+      search: "shrew",
+      outdated: "yes" as const,
+      minObs: 1,
+      maxObs: 9,
+      minAssessmentYear: 2000,
+      maxAssessmentYear: 2020,
+      minDescribedYear: 1990,
+      maxDescribedYear: 2010,
+      sortField: "category" as const,
+      sortDirection: "asc" as const,
+      mapViewMode: "list" as const,
+      mapSortKey: "outdated" as const,
+      mapSortDirection: "asc" as const,
+      species: 12345,
+      tab: "literature" as const,
+    };
+
+    const qs = buildQs(kitchenSink, "_test");
+    const writtenKeys = [...new URLSearchParams(qs).keys()].map((k) => k.replace(/_test$/, ""));
+    // Sanity check the fixture itself is actually exercising things, so this test
+    // can't silently pass by writing nothing.
+    expect(writtenKeys.length).toBeGreaterThan(20);
+
+    const ownNames = new Set(OWN_PARAM_NAMES);
+    const missing = writtenKeys.filter((k) => !ownNames.has(k));
+    expect(missing).toEqual([]);
   });
 });

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -49,6 +49,26 @@ const numParam = (p: URLSearchParams, key: string): number | null => {
 
 const FILTER_RANKS: FilterRank[] = ["class", "order", "family", "genus", "species"];
 
+// Compare mode support: every param name this hook owns can be namespaced with a
+// suffix (e.g. "_b") so two independent panels can each keep their own filter
+// state in one shared URL without colliding (?taxa=birds&taxa_b=reptiles). A
+// bare "" suffix (the default / single-dashboard case) is identical to no
+// namespacing at all.
+const paramKey = (name: string, suffix: string): string => (suffix ? `${name}${suffix}` : name);
+
+// The full set of base (unsuffixed) param names this hook reads/writes — used by
+// syncUrl to know which keys in the URL "belong to" a given hook instance (so it
+// can merge its own writes into the URL without clobbering another instance's
+// differently-suffixed params). Keep in sync with parseParams/buildQs below.
+const OWN_PARAM_NAMES = [
+  "view", "layout", "origin", "countries", "region", "taxa", "subgroups",
+  "categories", "years", "assessmentYears", "describedYears", "obsRanges",
+  "systems", "trends", "movement", "threats", "bd", "endemics", "growthForms",
+  "assessors", "reviewers", "search", "outdated", "minObs", "maxObs",
+  "minAssessmentYear", "maxAssessmentYear", "minDescribedYear", "maxDescribedYear",
+  "species", "tab", "sort", "dir", "mapview", "mapsort", "mapdir",
+];
+
 // `bd=ssc-small-mammal:order:rodentia` — narrows a node's species list to one
 // breakdown row (see TaxaSummary.tsx's BreakdownList). nodeId:rank:name, colon-joined
 // like the rest of the URL scheme. Carries its own nodeId (rather than always
@@ -65,8 +85,8 @@ export interface BreakdownParam {
   onlyIds?: number[];
   excludeIds?: number[];
 }
-const parseBreakdownParam = (p: URLSearchParams): BreakdownParam | null => {
-  const raw = p.get("bd");
+const parseBreakdownParam = (p: URLSearchParams, key: string): BreakdownParam | null => {
+  const raw = p.get(key);
   if (!raw) return null;
   const [nodeId, rank, name, mode, idsCsv] = raw.split(":");
   if (!nodeId || !name || !FILTER_RANKS.includes(rank as FilterRank)) return null;
@@ -81,30 +101,31 @@ const parseBreakdownParam = (p: URLSearchParams): BreakdownParam | null => {
   return result;
 };
 
-export function parseParams(search: string) {
+export function parseParams(search: string, suffix: string = "") {
   const p = new URLSearchParams(search);
-  const sortParam = p.get("sort");
-  const viewParam = p.get("view");
-  const layoutParam = p.get("layout");
+  const k = (name: string) => paramKey(name, suffix);
+  const sortParam = p.get(k("sort"));
+  const viewParam = p.get(k("view"));
+  const layoutParam = p.get(k("layout"));
   // A `region` param expands to its country codes (the dashboard has no separate
   // region state — it stores a region AS its countries and re-derives the chip).
   const countryCodes = new Set<string>(
-    p.get("countries") ? p.get("countries")!.split(",").filter(Boolean) : []
+    p.get(k("countries")) ? p.get(k("countries"))!.split(",").filter(Boolean) : []
   );
-  if (p.get("region")) {
-    resolveRegions(p.get("region")!.split(",").filter(Boolean)).codes.forEach((c) => countryCodes.add(c));
+  if (p.get(k("region"))) {
+    resolveRegions(p.get(k("region"))!.split(",").filter(Boolean)).codes.forEach((c) => countryCodes.add(c));
   }
   // Taxa: the URL carries a single flat `taxa` token list; expand each into the
   // internal display-root + (optional) sub-group. Legacy `subgroups=` links still
   // parse (their values are added directly, with the parent root ensured present).
   const taxaSet = new Set<string>();
   const subgroupSet = new Set<string>();
-  for (const tok of p.get("taxa")?.split(",").filter(Boolean) ?? []) {
+  for (const tok of p.get(k("taxa"))?.split(",").filter(Boolean) ?? []) {
     const { taxa, subgroup } = expandTaxaToken(tok);
     taxaSet.add(taxa);
     if (subgroup) subgroupSet.add(subgroup);
   }
-  for (const sg of p.get("subgroups")?.split(",").filter(Boolean) ?? []) {
+  for (const sg of p.get(k("subgroups"))?.split(",").filter(Boolean) ?? []) {
     const id = canonicalizeTaxonId(sg);
     subgroupSet.add(id);
     const root = getViewRootForNode(id);
@@ -122,60 +143,60 @@ export function parseParams(search: string) {
     // hook entirely). Cleared wherever a new layoutMode is deliberately set
     // (setLayoutMode/navigateToTaxonSubgroup/returnToLayoutMode) — a fresh,
     // explicit mode choice overrides whatever "return to X" memory it held.
-    originLayout: (p.get("origin") === "table1a" || p.get("origin") === "ssc" || p.get("origin") === "country" ? p.get("origin") : null) as LayoutMode,
+    originLayout: (p.get(k("origin")) === "table1a" || p.get(k("origin")) === "ssc" || p.get(k("origin")) === "country" ? p.get(k("origin")) : null) as LayoutMode,
     // Expanded from the flat `taxa` token list (+ legacy `subgroups=`) above.
     taxa: taxaSet,
     subgroups: subgroupSet,
-    categories: p.get("categories")
-      ? new Set(p.get("categories")!.split(",").filter(Boolean))
+    categories: p.get(k("categories"))
+      ? new Set(p.get(k("categories"))!.split(",").filter(Boolean))
       : new Set<string>(),
-    yearRanges: p.get("years")
-      ? new Set(p.get("years")!.split(",").filter(Boolean))
+    yearRanges: p.get(k("years"))
+      ? new Set(p.get(k("years"))!.split(",").filter(Boolean))
       : new Set<string>(),
-    assessmentYears: p.get("assessmentYears")
-      ? new Set(p.get("assessmentYears")!.split(",").filter(Boolean))
+    assessmentYears: p.get(k("assessmentYears"))
+      ? new Set(p.get(k("assessmentYears"))!.split(",").filter(Boolean))
       : new Set<string>(),
     // CoL description-year range buckets (NE/new-assessments view only).
-    describedYears: p.get("describedYears")
-      ? new Set(p.get("describedYears")!.split(",").filter(Boolean))
+    describedYears: p.get(k("describedYears"))
+      ? new Set(p.get(k("describedYears"))!.split(",").filter(Boolean))
       : new Set<string>(),
     countries: countryCodes,
-    obsRanges: p.get("obsRanges")
-      ? new Set(p.get("obsRanges")!.split(",").filter(Boolean))
+    obsRanges: p.get(k("obsRanges"))
+      ? new Set(p.get(k("obsRanges"))!.split(",").filter(Boolean))
       : new Set<string>(),
-    systems: p.get("systems")
-      ? new Set(p.get("systems")!.split(",").filter(Boolean))
+    systems: p.get(k("systems"))
+      ? new Set(p.get(k("systems"))!.split(",").filter(Boolean))
       : new Set<string>(),
-    populationTrends: p.get("trends")
-      ? new Set(p.get("trends")!.split(",").filter(Boolean))
+    populationTrends: p.get(k("trends"))
+      ? new Set(p.get(k("trends"))!.split(",").filter(Boolean))
       : new Set<string>(),
-    movementPatterns: p.get("movement")
-      ? new Set(p.get("movement")!.split(",").filter(Boolean))
+    movementPatterns: p.get(k("movement"))
+      ? new Set(p.get(k("movement"))!.split(",").filter(Boolean))
       : new Set<string>(),
-    threats: p.get("threats")
-      ? new Set(p.get("threats")!.split(",").filter(Boolean))
+    threats: p.get(k("threats"))
+      ? new Set(p.get(k("threats"))!.split(",").filter(Boolean))
       : new Set<string>(),
-    breakdown: parseBreakdownParam(p),
+    breakdown: parseBreakdownParam(p, k("bd")),
     // Endemics-only: restrict to species occurring in exactly one country.
-    endemicsOnly: p.get("endemics") === "1",
-    growthForms: p.get("growthForms")
-      ? new Set(p.get("growthForms")!.split(",").filter(Boolean))
+    endemicsOnly: p.get(k("endemics")) === "1",
+    growthForms: p.get(k("growthForms"))
+      ? new Set(p.get(k("growthForms"))!.split(",").filter(Boolean))
       : new Set<string>(),
-    assessors: p.get("assessors")
-      ? new Set(p.get("assessors")!.split("|").filter(Boolean))
+    assessors: p.get(k("assessors"))
+      ? new Set(p.get(k("assessors"))!.split("|").filter(Boolean))
       : new Set<string>(),
-    reviewers: p.get("reviewers")
-      ? new Set(p.get("reviewers")!.split("|").filter(Boolean))
+    reviewers: p.get(k("reviewers"))
+      ? new Set(p.get(k("reviewers"))!.split("|").filter(Boolean))
       : new Set<string>(),
-    search: p.get("search") || "",
+    search: p.get(k("search")) || "",
     // Exact URL-only base filters (see ExactFilters).
-    outdated: (p.get("outdated") === "yes" ? "yes" : p.get("outdated") === "no" ? "no" : null) as "yes" | "no" | null,
-    minObs: numParam(p, "minObs"),
-    maxObs: numParam(p, "maxObs"),
-    minAssessmentYear: numParam(p, "minAssessmentYear"),
-    maxAssessmentYear: numParam(p, "maxAssessmentYear"),
-    minDescribedYear: numParam(p, "minDescribedYear"),
-    maxDescribedYear: numParam(p, "maxDescribedYear"),
+    outdated: (p.get(k("outdated")) === "yes" ? "yes" : p.get(k("outdated")) === "no" ? "no" : null) as "yes" | "no" | null,
+    minObs: numParam(p, k("minObs")),
+    maxObs: numParam(p, k("maxObs")),
+    minAssessmentYear: numParam(p, k("minAssessmentYear")),
+    maxAssessmentYear: numParam(p, k("maxAssessmentYear")),
+    minDescribedYear: numParam(p, k("minDescribedYear")),
+    maxDescribedYear: numParam(p, k("maxDescribedYear")),
     sortField: (
       sortParam === "category" ? "category" :
       sortParam === "year" ? "year" :
@@ -185,17 +206,17 @@ export function parseParams(search: string) {
       sortParam === "describedYear" ? "describedYear" :
       null
     ) as "year" | "category" | "totalGbif" | "newGbif" | "pctNewGbif" | "describedYear" | null,
-    sortDirection: (p.get("dir") === "asc" ? "asc" : "desc") as "asc" | "desc",
-    mapViewMode: (p.get("mapview") === "list" ? "list" : "map") as MapViewMode,
+    sortDirection: (p.get(k("dir")) === "asc" ? "asc" : "desc") as "asc" | "desc",
+    mapViewMode: (p.get(k("mapview")) === "list" ? "list" : "map") as MapViewMode,
     mapSortKey: (
-      p.get("mapsort") === "name" ? "name" :
-      p.get("mapsort") === "outdated" ? "outdated" :
-      p.get("mapsort") === "percentOutdated" ? "percentOutdated" :
+      p.get(k("mapsort")) === "name" ? "name" :
+      p.get(k("mapsort")) === "outdated" ? "outdated" :
+      p.get(k("mapsort")) === "percentOutdated" ? "percentOutdated" :
       "species"
     ) as MapSortKey,
-    mapSortDirection: (p.get("mapdir") === "asc" ? "asc" : "desc") as "asc" | "desc",
-    species: p.get("species") ? Number(p.get("species")) : null,
-    tab: (p.get("tab") || null) as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol" | null,
+    mapSortDirection: (p.get(k("mapdir")) === "asc" ? "asc" : "desc") as "asc" | "desc",
+    species: p.get(k("species")) ? Number(p.get(k("species"))) : null,
+    tab: (p.get(k("tab")) || null) as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol" | null,
   };
 }
 
@@ -235,56 +256,57 @@ export function buildQs(state: {
   mapSortDirection?: "asc" | "desc";
   species: number | null;
   tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol" | null;
-}): string {
+}, suffix: string = ""): string {
   const p = new URLSearchParams();
-  if (state.viewMode === "new-assessments") p.set("view", "new-assessments");
-  if (state.layoutMode) p.set("layout", state.layoutMode);
-  if (state.originLayout) p.set("origin", state.originLayout);
+  const k = (name: string) => paramKey(name, suffix);
+  if (state.viewMode === "new-assessments") p.set(k("view"), "new-assessments");
+  if (state.layoutMode) p.set(k("layout"), state.layoutMode);
+  if (state.originLayout) p.set(k("origin"), state.originLayout);
   // taxa + subgroups collapse to a single flat `taxa` token list (e.g.
   // invertebrates + inv-corals → taxa=corals); no separate subgroups param.
   const taxaTokens = collapseTaxaToTokens(state.taxa, state.subgroups);
-  if (taxaTokens.length > 0) p.set("taxa", taxaTokens.join(","));
-  if (state.categories.size > 0) p.set("categories", [...state.categories].join(","));
-  if (state.yearRanges.size > 0) p.set("years", [...state.yearRanges].join(","));
-  if (state.assessmentYears.size > 0) p.set("assessmentYears", [...state.assessmentYears].join(","));
-  if (state.describedYears.size > 0) p.set("describedYears", [...state.describedYears].join(","));
-  if (state.countries.size > 0) p.set("countries", [...state.countries].join(","));
-  if (state.obsRanges.size > 0) p.set("obsRanges", [...state.obsRanges].join(","));
-  if (state.systems.size > 0) p.set("systems", [...state.systems].join(","));
-  if (state.populationTrends.size > 0) p.set("trends", [...state.populationTrends].join(","));
-  if (state.movementPatterns.size > 0) p.set("movement", [...state.movementPatterns].join(","));
-  if (state.threats.size > 0) p.set("threats", [...state.threats].join(","));
+  if (taxaTokens.length > 0) p.set(k("taxa"), taxaTokens.join(","));
+  if (state.categories.size > 0) p.set(k("categories"), [...state.categories].join(","));
+  if (state.yearRanges.size > 0) p.set(k("years"), [...state.yearRanges].join(","));
+  if (state.assessmentYears.size > 0) p.set(k("assessmentYears"), [...state.assessmentYears].join(","));
+  if (state.describedYears.size > 0) p.set(k("describedYears"), [...state.describedYears].join(","));
+  if (state.countries.size > 0) p.set(k("countries"), [...state.countries].join(","));
+  if (state.obsRanges.size > 0) p.set(k("obsRanges"), [...state.obsRanges].join(","));
+  if (state.systems.size > 0) p.set(k("systems"), [...state.systems].join(","));
+  if (state.populationTrends.size > 0) p.set(k("trends"), [...state.populationTrends].join(","));
+  if (state.movementPatterns.size > 0) p.set(k("movement"), [...state.movementPatterns].join(","));
+  if (state.threats.size > 0) p.set(k("threats"), [...state.threats].join(","));
   if (state.breakdown) {
     let bd = `${state.breakdown.nodeId}:${state.breakdown.rank}:${state.breakdown.name}`;
     if (state.breakdown.onlyIds?.length) bd += `:only:${state.breakdown.onlyIds.join(",")}`;
     else if (state.breakdown.excludeIds?.length) bd += `:excl:${state.breakdown.excludeIds.join(",")}`;
-    p.set("bd", bd);
+    p.set(k("bd"), bd);
   }
-  if (state.endemicsOnly) p.set("endemics", "1");
-  if (state.growthForms.size > 0) p.set("growthForms", [...state.growthForms].join(","));
-  if (state.assessors.size > 0) p.set("assessors", [...state.assessors].join("|"));
-  if (state.reviewers.size > 0) p.set("reviewers", [...state.reviewers].join("|"));
-  if (state.search) p.set("search", state.search);
-  if (state.outdated) p.set("outdated", state.outdated);
-  if (state.minObs != null) p.set("minObs", String(state.minObs));
-  if (state.maxObs != null) p.set("maxObs", String(state.maxObs));
-  if (state.minAssessmentYear != null) p.set("minAssessmentYear", String(state.minAssessmentYear));
-  if (state.maxAssessmentYear != null) p.set("maxAssessmentYear", String(state.maxAssessmentYear));
-  if (state.minDescribedYear != null) p.set("minDescribedYear", String(state.minDescribedYear));
-  if (state.maxDescribedYear != null) p.set("maxDescribedYear", String(state.maxDescribedYear));
-  if (state.species != null) p.set("species", String(state.species));
-  if (state.species != null && state.tab && state.tab !== "gbif") p.set("tab", state.tab);
+  if (state.endemicsOnly) p.set(k("endemics"), "1");
+  if (state.growthForms.size > 0) p.set(k("growthForms"), [...state.growthForms].join(","));
+  if (state.assessors.size > 0) p.set(k("assessors"), [...state.assessors].join("|"));
+  if (state.reviewers.size > 0) p.set(k("reviewers"), [...state.reviewers].join("|"));
+  if (state.search) p.set(k("search"), state.search);
+  if (state.outdated) p.set(k("outdated"), state.outdated);
+  if (state.minObs != null) p.set(k("minObs"), String(state.minObs));
+  if (state.maxObs != null) p.set(k("maxObs"), String(state.maxObs));
+  if (state.minAssessmentYear != null) p.set(k("minAssessmentYear"), String(state.minAssessmentYear));
+  if (state.maxAssessmentYear != null) p.set(k("maxAssessmentYear"), String(state.maxAssessmentYear));
+  if (state.minDescribedYear != null) p.set(k("minDescribedYear"), String(state.minDescribedYear));
+  if (state.maxDescribedYear != null) p.set(k("maxDescribedYear"), String(state.maxDescribedYear));
+  if (state.species != null) p.set(k("species"), String(state.species));
+  if (state.species != null && state.tab && state.tab !== "gbif") p.set(k("tab"), state.tab);
   // null / "year" desc is the default — only write non-default sort to URL
   const isDefaultSort = state.sortField === null || state.sortField === "year";
   if (!isDefaultSort) {
-    p.set("sort", state.sortField!);
-    if (state.sortDirection !== "desc") p.set("dir", state.sortDirection);
+    p.set(k("sort"), state.sortField!);
+    if (state.sortDirection !== "desc") p.set(k("dir"), state.sortDirection);
   } else if (state.sortDirection !== "desc") {
-    p.set("dir", state.sortDirection);
+    p.set(k("dir"), state.sortDirection);
   }
-  if (state.mapViewMode === "list") p.set("mapview", "list");
-  if (state.mapSortKey && state.mapSortKey !== "species") p.set("mapsort", state.mapSortKey);
-  if (state.mapSortDirection === "asc") p.set("mapdir", "asc");
+  if (state.mapViewMode === "list") p.set(k("mapview"), "list");
+  if (state.mapSortKey && state.mapSortKey !== "species") p.set(k("mapsort"), state.mapSortKey);
+  if (state.mapSortDirection === "asc") p.set(k("mapdir"), "asc");
   const qs = p.toString();
   return qs ? `?${qs}` : "";
 }
@@ -298,10 +320,15 @@ export function buildQs(state: {
  * router overhead.
  *
  * Example URL: /?taxa=mammals&categories=CR,EN&years=11-20+years&search=shrew
+ *
+ * `paramSuffix` namespaces every URL param this hook reads/writes (e.g. "_b" turns
+ * `taxa` into `taxa_b`), so a second, independently-filtered instance of this hook
+ * can share one URL with the first (compare mode) without either clobbering the
+ * other's params. Defaults to "" — identical to the single-dashboard behavior.
  */
-export function useFilterParams() {
+export function useFilterParams(paramSuffix: string = "") {
   // Initialize with empty state (SSR-safe), hydrate from URL in effect
-  const [state, setState] = useState(() => parseParams(""));
+  const [state, setState] = useState(() => parseParams("", paramSuffix));
 
   // Tracks whether the most recent state update came from a popstate (URL navigation).
   // Consumers can check this to avoid clearing URL-driven state.
@@ -310,24 +337,34 @@ export function useFilterParams() {
   // Hydrate from URL on mount + sync on popstate (back/forward button)
   useEffect(() => {
     fromPopstateRef.current = true;
-    setState(parseParams(window.location.search)); // eslint-disable-line react-hooks/set-state-in-effect -- hydrate from URL on mount
+    setState(parseParams(window.location.search, paramSuffix)); // eslint-disable-line react-hooks/set-state-in-effect -- hydrate from URL on mount
     const onPopState = () => {
       fromPopstateRef.current = true;
-      setState(parseParams(window.location.search));
+      setState(parseParams(window.location.search, paramSuffix));
     };
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
-  }, []);
+  }, [paramSuffix]);
 
-  // Write URL silently (no Next.js navigation, no re-render loop)
+  // Write URL silently (no Next.js navigation, no re-render loop). Merges this
+  // instance's (suffixed) params into whatever's currently in the URL rather than
+  // replacing the whole query string, so a second useFilterParams instance with a
+  // different paramSuffix (compare mode) can co-exist in the same URL — each
+  // instance only ever touches its own suffixed keys.
   const syncUrl = useCallback((newState: typeof state, push: boolean) => {
-    const url = window.location.pathname + buildQs(newState);
+    const current = new URLSearchParams(window.location.search);
+    for (const name of OWN_PARAM_NAMES) current.delete(paramKey(name, paramSuffix));
+    for (const [ownKey, value] of new URLSearchParams(buildQs(newState, paramSuffix))) {
+      current.set(ownKey, value);
+    }
+    const qs = current.toString();
+    const url = window.location.pathname + (qs ? `?${qs}` : "");
     if (push) {
       window.history.pushState(null, "", url);
     } else {
       window.history.replaceState(null, "", url);
     }
-  }, []);
+  }, [paramSuffix]);
 
   // --- Setters: update local state instantly, sync URL in background ---
 

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -60,7 +60,12 @@ const paramKey = (name: string, suffix: string): string => (suffix ? `${name}${s
 // syncUrl to know which keys in the URL "belong to" a given hook instance (so it
 // can merge its own writes into the URL without clobbering another instance's
 // differently-suffixed params). Keep in sync with parseParams/buildQs below.
-const OWN_PARAM_NAMES = [
+// Exported so tests can assert this list actually tracks every key
+// parseParams/buildQs read or write — otherwise a future param added to one
+// but not the other would silently leak across compare-mode panels with
+// nothing catching it (see filterParams.test.ts's "OWN_PARAM_NAMES stays in
+// sync" test).
+export const OWN_PARAM_NAMES = [
   "view", "layout", "origin", "countries", "region", "taxa", "subgroups",
   "categories", "years", "assessmentYears", "describedYears", "obsRanges",
   "systems", "trends", "movement", "threats", "bd", "endemics", "growthForms",

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -311,6 +311,27 @@ export function buildQs(state: {
   return qs ? `?${qs}` : "";
 }
 
+// Pure merge: combines this instance's (suffixed) params into whatever's
+// already present in `currentSearch`, rather than replacing the whole query
+// string — so a second useFilterParams instance with a different paramSuffix
+// (compare mode) can co-exist in the same URL, each only ever touching its
+// own suffixed keys. Exported (and used by syncUrl below, its only caller)
+// so this merge behavior — the actual novel logic here — is directly
+// unit-testable rather than only reachable through the hook itself.
+export function mergeParamsIntoSearch(
+  currentSearch: string,
+  newState: Parameters<typeof buildQs>[0],
+  suffix: string
+): string {
+  const current = new URLSearchParams(currentSearch);
+  for (const name of OWN_PARAM_NAMES) current.delete(paramKey(name, suffix));
+  for (const [ownKey, value] of new URLSearchParams(buildQs(newState, suffix))) {
+    current.set(ownKey, value);
+  }
+  const qs = current.toString();
+  return qs ? `?${qs}` : "";
+}
+
 /**
  * Hook that syncs filter state with URL search parameters,
  * enabling shareable/bookmarkable filtered views.
@@ -352,13 +373,8 @@ export function useFilterParams(paramSuffix: string = "") {
   // different paramSuffix (compare mode) can co-exist in the same URL — each
   // instance only ever touches its own suffixed keys.
   const syncUrl = useCallback((newState: typeof state, push: boolean) => {
-    const current = new URLSearchParams(window.location.search);
-    for (const name of OWN_PARAM_NAMES) current.delete(paramKey(name, paramSuffix));
-    for (const [ownKey, value] of new URLSearchParams(buildQs(newState, paramSuffix))) {
-      current.set(ownKey, value);
-    }
-    const qs = current.toString();
-    const url = window.location.pathname + (qs ? `?${qs}` : "");
+    const qs = mergeParamsIntoSearch(window.location.search, newState, paramSuffix);
+    const url = window.location.pathname + qs;
     if (push) {
       window.history.pushState(null, "", url);
     } else {


### PR DESCRIPTION
## Summary

Closes #386. Adds a `/compare` route that splits the screen into two full copies of the dashboard (e.g. Birds vs Reptiles), so you can compare taxa side by side.

- Each panel is the real `RedListView` — same filters, charts, map, and species table as the main dashboard — not a lightweight reimplementation.
- Both panels' filter state lives in one shareable URL: panel A uses the normal params (`taxa=`, `categories=`, ...), panel B uses `_b`-suffixed params (`taxa_b=`, `categories_b=`, ...). `useFilterParams` now takes an optional suffix and merges its writes into the URL instead of replacing it, so the two panels don't clobber each other. The mechanism isn't hardcoded to exactly two panels — a third would just be `_c`.
- Species fetches are deduped across panels via a new `SpeciesCacheContext` — a shared cache keyed by the exact request URL. Picking the same taxon on both sides (or toggling both to Not Evaluated) only fetches it once. This replaced `RedListView`'s previous local-state cache, so the component is smaller, not bigger.
- No search bar in compare mode — sidesteps a pre-existing module-level singleton in `SpeciesSearchBar` that assumes a single `RedListView` consumer, rather than needing to make it suffix-aware.
- The two riskiest bits of new logic — the URL-merge behavior in `useFilterParams` and the cache dedup decision in `SpeciesCacheContext` — are pulled out into plain, directly-testable functions (`mergeParamsIntoSearch`, `src/contexts/species-cache-logic.ts`) with dedicated unit tests, rather than left inline where they'd only be reachable through manual browser testing.
- Follow-up from an independent review pass: `SpeciesCacheContext.request` now aborts its fetch on provider unmount instead of letting it complete against a gone component tree, and the three fetch-triggering effects in `RedListView` depend on `cache.entries`/`cache.request` specifically instead of the whole cache object, so one panel's unrelated loading/error activity can't re-trigger the other's fetch effects. (An initial attempt at this — making `request` itself identity-stable via a ref — turned out to introduce a real dedup regression, caught by re-running the browser verification; reverted in favor of the narrower fix.) Also added a test asserting the param-suffix allowlist stays in sync with what `buildQs` actually writes.
- Fixed the pre-existing deep-link bug noted below: `?view=new-assessments&taxa=X` now correctly stays in Not Evaluated mode instead of silently resetting to Assessed. Root cause was a hydration-vs-real-change ambiguity in an existing effect — same one-line guard pattern already used by a neighboring effect in the same file for the identical hazard.

## Screenshots

**Birds vs Reptiles, each panel fully independent:**

![Compare mode](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-407-compare-mode/01-birds-vs-reptiles.png)

**Responsive stacking on narrow viewports:**

![Narrow viewport](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-407-compare-mode/02-narrow-stacked.png)

## Test plan

- [x] `tsc --noEmit`, `eslint`, and the full `vitest` suite (702 tests, up from 673 — new tests cover the URL-suffix merge, cache dedup logic, and param-name sync) all pass
- [x] Regression-checked `/` in a real browser: taxa/filter selection, species drilldown, no console errors — unchanged from before
- [x] `/compare` happy path: pick Birds (left) / Reptiles (right), URL becomes `?taxa=birds&taxa_b=reptiles`, survives reload
- [x] Dedup verified in the Network tab: (1) via the shared "all" prefetch, (2) via a genuine per-taxon fetch — toggling both panels to Not Evaluated for Mammals fires exactly one `taxon=mammals&category=NE` request, not two
- [x] Mid-fetch unmount (navigating from `/compare` back to `/` while a fetch is in flight) produces no console errors
- [x] Responsive stacking checked on a narrow viewport
- [x] Independent code review pass (dispatched separately) verified URL-suffix merge correctness, cache race/staleness safety, and that the `RedListView` refactor preserves existing behavior — flagged three minor follow-ups, all addressed
- [x] `?view=new-assessments&taxa=mammals` deep link now correctly stays in Not Evaluated mode (was silently resetting to Assessed before); confirmed `?view=new-assessments` alone is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)