### PR TITLE
Add generic user_roles RBAC + CI migration deploy (Supabase's documented pattern)

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -1,0 +1,50 @@
+name: Deploy Supabase migrations
+
+# Applies pending migrations under app/supabase/migrations/ to the Supabase
+# project on merge to main, per Supabase's own recommended CI/CD workflow:
+# https://supabase.com/docs/guides/deployment/managing-environments
+#
+# Safety notes (this repo is public, mirrors the data-sync workflow's
+# reasoning — see weekly-sync.yml):
+#   - Only triggers on push to main (a merge) or a manual workflow_dispatch —
+#     never pull_request/pull_request_target, so a fork PR can't run this
+#     with access to the secrets below or tamper with this file.
+#   - The Supabase access token / DB password live on the `supabase-migrations`
+#     GitHub Environment (required reviewer: the repo owner only), NOT as
+#     plain repo secrets — repo secrets are usable by anyone with push
+#     access. Environment protection pauses ANY job that declares
+#     `environment: supabase-migrations` for manual approval first,
+#     regardless of branch or trigger.
+#   - These credentials can alter production schema (create/drop
+#     tables/columns, change RLS policies), so treat them with at least as
+#     much care as the R2 data-sync credentials.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "app/supabase/migrations/**"
+  workflow_dispatch: {} # allows a manual re-run from the Actions tab
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: supabase-migrations
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
+        working-directory: app
+
+      - name: Push migrations
+        run: supabase db push
+        working-directory: app

--- a/app/src/lib/auth/__tests__/roles.test.ts
+++ b/app/src/lib/auth/__tests__/roles.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { hasRole, isAdmin } from "../roles";
+
+function mockSupabase(row: { role: string } | null) {
+  const maybeSingle = vi.fn().mockResolvedValue({ data: row });
+  const eq2 = vi.fn().mockReturnValue({ maybeSingle });
+  const eq1 = vi.fn().mockReturnValue({ eq: eq2 });
+  const select = vi.fn().mockReturnValue({ eq: eq1 });
+  const from = vi.fn().mockReturnValue({ select });
+  return { from, _spies: { from, select, eq1, eq2, maybeSingle } } as unknown as Parameters<typeof hasRole>[0];
+}
+
+describe("hasRole", () => {
+  it("returns true when a matching row exists", async () => {
+    const supabase = mockSupabase({ role: "admin" });
+    await expect(hasRole(supabase, "user-1", "admin")).resolves.toBe(true);
+  });
+
+  it("returns false when no matching row exists", async () => {
+    const supabase = mockSupabase(null);
+    await expect(hasRole(supabase, "user-1", "admin")).resolves.toBe(false);
+  });
+
+  it("queries the user_roles table filtered by user_id and role", async () => {
+    const supabase = mockSupabase({ role: "admin" });
+    await hasRole(supabase, "user-1", "admin");
+    const spies = (supabase as unknown as { _spies: Record<string, ReturnType<typeof vi.fn>> })._spies;
+    expect(spies.from).toHaveBeenCalledWith("user_roles");
+    expect(spies.eq1).toHaveBeenCalledWith("user_id", "user-1");
+    expect(spies.eq2).toHaveBeenCalledWith("role", "admin");
+  });
+});
+
+describe("isAdmin", () => {
+  it("returns false for null/undefined userId without querying", async () => {
+    const supabase = mockSupabase({ role: "admin" });
+    expect(await isAdmin(supabase, null)).toBe(false);
+    expect(await isAdmin(supabase, undefined)).toBe(false);
+  });
+
+  it("returns true when the user has the admin role", async () => {
+    const supabase = mockSupabase({ role: "admin" });
+    expect(await isAdmin(supabase, "user-1")).toBe(true);
+  });
+
+  it("returns false when the user has no admin row", async () => {
+    const supabase = mockSupabase(null);
+    expect(await isAdmin(supabase, "user-1")).toBe(false);
+  });
+});

--- a/app/src/lib/auth/roles.ts
+++ b/app/src/lib/auth/roles.ts
@@ -1,0 +1,27 @@
+import type { createClient } from "@/lib/supabase/server";
+
+export type AppRole = "admin";
+
+type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>;
+
+export async function hasRole(
+  supabase: SupabaseServerClient,
+  userId: string,
+  role: AppRole
+): Promise<boolean> {
+  const { data } = await supabase
+    .from("user_roles")
+    .select("role")
+    .eq("user_id", userId)
+    .eq("role", role)
+    .maybeSingle();
+  return !!data;
+}
+
+export async function isAdmin(
+  supabase: SupabaseServerClient,
+  userId: string | null | undefined
+): Promise<boolean> {
+  if (!userId) return false;
+  return hasRole(supabase, userId, "admin");
+}

--- a/app/supabase/migrations/20260724120000_user_roles.sql
+++ b/app/supabase/migrations/20260724120000_user_roles.sql
@@ -1,0 +1,35 @@
+-- Role-based access control, following Supabase's documented pattern:
+-- https://supabase.com/docs/guides/api/custom-claims-and-role-based-access-control-rbac
+--
+-- Deliberately skips that guide's Custom Access Token Auth Hook step (which
+-- injects the role into the JWT for use in RLS policies elsewhere) — this
+-- app checks roles from trusted server-side Next.js API routes/actions, not
+-- from client-side Supabase queries gated by RLS, so a direct table query
+-- is simpler and sufficient. Add the hook later only if a client-side RLS
+-- policy ever needs to reference someone's role.
+
+create type app_role as enum ('admin');
+
+create table public.user_roles (
+  id bigint generated always as identity primary key,
+  user_id uuid references auth.users (id) on delete cascade not null,
+  role app_role not null,
+  granted_at timestamptz not null default now(),
+  unique (user_id, role)
+);
+
+alter table public.user_roles enable row level security;
+
+-- Signed-in users can see their own roles (handy for client-side UI checks
+-- later, e.g. "show an admin badge"); nobody can grant/revoke their own role
+-- via the client — that's deliberately not covered by any insert/update/
+-- delete policy, so it only happens via the Supabase Studio Table Editor,
+-- the SQL Editor, or the service-role key.
+create policy "Users can view their own roles"
+  on public.user_roles for select
+  using (auth.uid() = user_id);
+
+-- Run once after applying this migration, to grant yourself the admin role:
+--
+--   insert into public.user_roles (user_id, role)
+--   select id, 'admin' from auth.users where email = 'shaneweisz@gmail.com';

--- a/app/supabase/migrations/20260724120000_user_roles.sql
+++ b/app/supabase/migrations/20260724120000_user_roles.sql
@@ -29,7 +29,8 @@ create policy "Users can view their own roles"
   on public.user_roles for select
   using (auth.uid() = user_id);
 
--- Run once after applying this migration, to grant yourself the admin role:
+-- Run once after applying this migration, to grant an account the admin
+-- role (swap in the actual signed-up account's email):
 --
 --   insert into public.user_roles (user_id, role)
---   select id, 'admin' from auth.users where email = 'shaneweisz@gmail.com';
+--   select id, 'admin' from auth.users where email = '<your account email>';


### PR DESCRIPTION
## Summary

Adds generic role-based access control (`user_roles` table + `hasRole`/`isAdmin` helpers) on top of the GitHub SSO login from PR #406 — kept as its own PR, isolated from the range-map work in PR #207, since it's reusable infrastructure rather than anything range-map-specific.

This directly replaces the plan from PR #207's auth-gating commit, which used an env var (`RANGE_MAP_ALLOWED_EMAILS`) as a stopgap. That didn't sit right — env vars mean a Vercel dashboard trip + redeploy to change who's authorized, no audit trail, and no path to more granular access later. This is Supabase's own documented pattern instead: [Custom Claims & Role-based Access Control (RBAC)](https://supabase.com/docs/guides/api/custom-claims-and-role-based-access-control-rbac).

- **`supabase/migrations/20260724120000_user_roles.sql`**: `app_role` enum (currently just `'admin'`) + `user_roles(id, user_id, role, granted_at)`, FK'd to `auth.users.id`, `unique(user_id, role)`. RLS enabled with a `select`-only policy (users can see their own roles; nobody can grant themselves one via the client — that only happens through Studio's Table Editor, the SQL Editor, or the service-role key).
- **`src/lib/auth/roles.ts`**: `hasRole(supabase, userId, role)` and a convenience `isAdmin(supabase, userId)`, both plain table queries — no Custom Access Token Auth Hook. That hook (the other half of Supabase's guide) exists to make the role available to *client-side* Supabase queries gated by RLS; this app's role checks all happen server-side in Next.js API routes/actions that already hold a request-scoped Supabase client, so a direct query is simpler and sufficient. Worth adding later only if a client-side RLS-gated query ever needs to know someone's role.
- Not wired into anything yet — a follow-up PR will swap PR #207's `RANGE_MAP_ALLOWED_EMAILS` check for `isAdmin()`.
- **`.github/workflows/supabase-migrations.yml`**: applies pending migrations on merge to `main`, following Supabase's own [documented CI/CD pattern](https://supabase.com/docs/guides/deployment/managing-environments) (`supabase link` + `supabase db push`) instead of hand-pasting SQL into the Dashboard each time. Gated behind a `supabase-migrations` GitHub Environment with a required reviewer — same reasoning as the R2 data-sync workflow (`weekly-sync.yml`): this repo is public with outside collaborators, so credentials that can alter production schema shouldn't be plain repo secrets.

## Manual setup needed before merging

I can't do either of these myself — they need your Supabase account and repo admin access, not just the anon/service-role keys already in `.env.local`:

1. **GitHub → repo Settings → Environments → New environment**, name it `supabase-migrations`, enable "Required reviewers" and add yourself (mirrors the existing `data-sync` environment).
2. Add three secrets **scoped to that environment** (not plain repo secrets):
   - `SUPABASE_ACCESS_TOKEN` — generate one at Supabase Dashboard → Account → Access Tokens
   - `SUPABASE_DB_PASSWORD` — Project Settings → Database (reset it there if you don't have it saved)
   - `SUPABASE_PROJECT_ID` — `styqwjdaexkojhunvkqa`

Once that's set up, merging this PR (or re-running it via `workflow_dispatch`) will apply the migration automatically — no manual SQL needed. Then grant yourself the role:

```sql
insert into public.user_roles (user_id, role)
select id, 'admin' from auth.users where email = '<your account email>';
```

(also left as a comment at the bottom of the migration file) — that part's still manual since it's a one-off grant, not a schema change.

## Test plan

- [x] `tsc --noEmit`, `eslint .`, `vitest run` (679/679 pre-existing + 6 new for `hasRole`/`isAdmin`) all clean.
- [x] Unit tests cover: role match → true, no match → false, null/undefined userId short-circuits without querying, and the query is filtered by both `user_id` and `role`.
- [x] Workflow YAML validated (parses cleanly via js-yaml); mirrors the exact CLI steps from Supabase's own docs.
- [ ] Live migration deploy + query against the real table — can't verify end-to-end until the `supabase-migrations` environment/secrets are set up and this merges; the mocked unit tests are what's exercised so far.

Once the environment/secrets are set up and you've granted yourself `admin`, this is ready to merge. The actual range-map gating swap is a separate follow-up PR against #207.
