### PR TITLE
Fix: allow Server Actions from all custom domains (login 500 on red.cst.cam.ac.uk)

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -47,6 +47,28 @@ const nextConfig: NextConfig = {
   // and breaks event capture through the proxy.
   skipTrailingSlashRedirect: true,
 
+  // Server Actions (e.g. the GitHub sign-in form in /login) reject any request
+  // whose Origin header doesn't match the request's own host, as CSRF
+  // protection — by default only the exact same origin is trusted. This app is
+  // served on multiple custom domains (see src/config/brand.ts), and at least
+  // one (red.cst.cam.ac.uk, likely proxied through Cambridge's own campus DNS/
+  // reverse-proxy layer in front of Vercel) was seen 500ing on sign-in because
+  // the origin Next.js saw didn't match what it expected — list every domain
+  // this app answers on explicitly, plus a wildcard for Vercel's own preview
+  // deployments (both URL shapes: the stable git-branch alias and the
+  // per-deployment hash that changes on every push).
+  experimental: {
+    serverActions: {
+      allowedOrigins: [
+        "dashforlife.org",
+        "dashoflife.org",
+        "red-list-dashboard.vercel.app",
+        "red.cst.cam.ac.uk",
+        "*-shaneweiszs-projects.vercel.app",
+      ],
+    },
+  },
+
   // #261: DuckDB-backed read routes query Parquet in R2. Keep the native addon
   // out of the bundler, and force-include the 68MB libduckdb.so it dlopens at
   // runtime (file-tracing misses dlopen deps). Scoped to the v2 routes so the


### PR DESCRIPTION
## Summary

Fixes a live bug on production: GitHub sign-in works on `dashforlife.org` but 500s on `red.cst.cam.ac.uk` with a generic "Error occurred in the Server Components render" — console showed `POST https://red.cst.cam.ac.uk/login 500`.

Root cause: Next.js Server Actions reject any request whose `Origin` header doesn't match the request's expected host, as CSRF protection — by default only the exact same origin is trusted (docs: [`serverActions.allowedOrigins`](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverActions)). `red.cst.cam.ac.uk`, being a `.cam.ac.uk` subdomain, is plausibly routed through Cambridge's own DNS/reverse-proxy layer in front of Vercel, which can cause an origin/host mismatch that plain-CNAME domains like `dashforlife.org` don't hit.

Fix: explicitly list every domain this app is served on (from `src/config/brand.ts`) in `next.config.ts`'s `experimental.serverActions.allowedOrigins`, plus a wildcard for Vercel's own preview deployment URLs.

Small side finding while debugging with Shane: a *separate* issue on `dashoflife.org` (silent redirect to `red.cst.cam.ac.uk` instead of erroring) turned out to be the Supabase "redirect_to not in the allowlist, falls back to Site URL" behavior documented in PR #406 — a Supabase Dashboard config check, not a code fix, so it's not part of this PR.

## Test plan

- [x] `tsc --noEmit`, `eslint .`, `vitest run` (679/679) all clean.
- [ ] Live verification on `red.cst.cam.ac.uk` after this deploys — sign-in should no longer 500. Can't fully verify pre-merge since this is specifically about production domain routing that local dev/previews don't reproduce.

This is a small, low-risk config-only change (adds to an allowlist, doesn't remove/change anything) — safe to merge and deploy quickly given it's fixing a live-broken flow.
