### PR TITLE
Fix intermittent sign-in failures: derive redirect origin from Host, not Origin header

### DIFF
--- a/app/src/lib/auth/actions.ts
+++ b/app/src/lib/auth/actions.ts
@@ -6,7 +6,17 @@ import { createClient } from "@/lib/supabase/server";
 
 export async function signInWithGitHub() {
   const supabase = await createClient();
-  const origin = (await headers()).get("origin");
+
+  // Derive the current domain from the Host header (what Vercel's own routing
+  // is built on, present on every request) rather than the browser-sent
+  // Origin header — Origin proved unreliable across this app's several
+  // custom domains (different DNS/proxy paths), occasionally producing a
+  // redirectTo Supabase didn't recognize and silently falling back to the
+  // Site URL instead of completing sign-in.
+  const headersList = await headers();
+  const host = headersList.get("x-forwarded-host") ?? headersList.get("host");
+  const protocol = headersList.get("x-forwarded-proto") ?? "https";
+  const origin = `${protocol}://${host}`;
 
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: "github",


### PR DESCRIPTION
## Summary

Fixes intermittent, "random"-feeling sign-in failures where a domain that's correctly on Supabase's Redirect URLs allowlist still ends up falling back to the Site URL (landing on `<site-url>/?code=...`, unprocessed) instead of completing login.

Root cause: `signInWithGitHub` (`src/lib/auth/actions.ts`) built Supabase's `redirectTo` from the browser-sent `Origin` header. Across this app's several custom domains — plain CNAMEs (`dashforlife.org`, `dashoflife.org`) alongside one routed through Cambridge's own Caddy server (`red.cst.cam.ac.uk`) — that header apparently isn't reliably reflecting the actual requested domain on every request, occasionally producing a `redirectTo` Supabase's allowlist genuinely didn't recognize, even when the correct entry was present and had been for a while (confirmed by inspecting the live allowlist mid-incident).

Fix: derive the domain from `x-forwarded-host` (falling back to `host`) instead — the header Vercel's own routing is built on, present on every request regardless of path/proxy, and the standard server-side way to determine "what domain is this," rather than trusting what the browser happened to send. `/auth/callback`'s origin (from `new URL(request.url)`, Next's own parsed request URL) was already Host-based and didn't need changing.

## Test plan

- [x] `tsc --noEmit`, `eslint .`, `vitest run` (702/708, 6 pre-existing skips) all clean.
- [x] Verified locally in a real browser: sign-in flow reaches GitHub's actual login page with `redirect_to=http://localhost:3000/auth/callback` correctly encoded in the chain.
- [ ] Live verification across the custom domains that were seeing this — can't fully reproduce the intermittent failure locally since it's specific to production's multi-domain routing; will need a few real attempts on `dashforlife.org`/`dashoflife.org` post-deploy to build confidence it's actually resolved rather than coincidentally not reproducing.

Small, low-risk change (one header source swapped for another, same shape of value) — safe to merge quickly.
