### PR TITLE
Fix mobile avatar dropdown rendering off-screen (blocks sign-out)

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -102,7 +102,7 @@ export default function RedListPage() {
             {brand.subtitle && (
               <p className="[grid-area:subtitle] text-[15px] md:text-[1.375rem] text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
             )}
-            <div className="[grid-area:controls] flex items-center gap-2 sm:justify-self-end">
+            <div className="[grid-area:controls] flex items-center gap-2 justify-end sm:justify-self-end">
               <Link
                 href="/compare"
                 className="flex items-center gap-1.5 px-2.5 py-1.5 text-sm font-medium rounded-lg border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"


### PR DESCRIPTION
## Summary

Fixes the sign-out dropdown rendering off-screen on mobile, making it impossible to actually click "Sign out."

Root cause: the header's controls row (`Compare` link, theme toggle, avatar) only right-aligned at the `sm:` breakpoint and above (`sm:justify-self-end`) — below that, it start-aligned instead, so the avatar landed roughly mid-screen rather than at the true right edge. `AuthStatus`'s dropdown is positioned `absolute right-0` (anchored to grow *leftward* from the trigger), which assumes the trigger sits at its container's right edge — true on desktop, not on mobile with this layout.

Confirmed via Playwright at a 375px viewport (iPhone SE-width): the dropdown rendered from `x=-23` to `x=199`, running off the left edge of the screen and overlapping the search bar, with "Sign out" text visibly truncated to "...gn out".

Fix: add a plain `justify-end` alongside the existing `sm:justify-self-end` on the controls row, so it right-aligns at every breakpoint, not just `sm:` and up. The avatar now sits at the true right edge on mobile too, and `AuthStatus`'s existing `right-0` dropdown anchor just works correctly — no dropdown-specific positioning code needed.

## Test plan

- [x] `tsc --noEmit`, `eslint .`, `vitest run` (702/708, 6 pre-existing skips) all clean.
- [x] Reproduced the bug in a real browser (Playwright, 375px viewport): dropdown bounding box `x: -23.4, width: 222` before the fix.
- [x] Re-verified after the fix: dropdown bounding box `x: 136, width: 222` — right edge at 358px, fully within the 375px viewport.
- [x] Confirmed "Sign out" is actually clickable (not just visually present) — Playwright's `.click()` passes its actionability check (visible, enabled, not obscured by another element) before clicking.
- [x] Screenshot below, mobile viewport, dropdown open, "Sign out" fully visible:

![Mobile dropdown after fix](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-413-mobile-avatar-dropdown-fix/01-after-fix.png)
