### PR TITLE
Fold Compare mode into the View dropdown

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { FaGlobeAmericas, FaColumns } from "react-icons/fa";
+import { FaGlobeAmericas } from "react-icons/fa";
 import { SpeciesSearchBar } from "../components/SpeciesSearchBar";
 import { ThemeToggle } from "../components/ThemeToggle";
 import { AuthStatus } from "../components/AuthStatus";
@@ -103,14 +103,6 @@ export default function RedListPage() {
               <p className="[grid-area:subtitle] text-[15px] md:text-[1.375rem] text-zinc-500 dark:text-zinc-400">{brand.subtitle}</p>
             )}
             <div className="[grid-area:controls] flex items-center gap-2 justify-end sm:justify-self-end">
-              <Link
-                href="/compare"
-                className="flex items-center gap-1.5 px-2.5 py-1.5 text-sm font-medium rounded-lg border border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-colors"
-                title="Compare two taxa side by side"
-              >
-                <FaColumns aria-hidden="true" />
-                Compare
-              </Link>
               <ThemeToggle />
               <AuthStatus />
             </div>

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
+import { useRouter } from "next/navigation";
 import { FaInfoCircle, FaChevronRight } from "react-icons/fa";
 
 import { HiOutlineAdjustmentsHorizontal } from "react-icons/hi2";
@@ -1264,6 +1265,7 @@ function DescribedInfoIcon({ nodeId, source, breakdown }: { nodeId: string; sour
 
 export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgroups, onToggleSubgroup, onNavigateToSubgroup, disableAllSpecies, viewMode = "reassessments", layoutMode, onLayoutModeChange, countryModeContent, countryPillsContent, countryScope }: Props) {
   const isNewAssessments = viewMode === "new-assessments";
+  const router = useRouter();
   const [taxa, setTaxa] = useState<TaxonSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -1474,6 +1476,10 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         value={layoutMode ?? "taxonomic"}
         onChange={(e) => {
           const v = e.target.value;
+          if (v === "compare") {
+            router.push("/compare");
+            return;
+          }
           onLayoutModeChange(v === "taxonomic" ? null : (v as "table1a" | "ssc" | "country"));
         }}
         className="text-sm bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md px-2 py-1 text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
@@ -1484,6 +1490,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         </option>
         <option value="ssc">By SSC Specialist Group (WIP)</option>
         <option value="table1a">Table 1a</option>
+        <option value="compare">Compare Taxa Side by Side</option>
       </select>
     </span>
   );


### PR DESCRIPTION
## Summary
- Removes the standalone "Compare" link/button from the page header (page.tsx)
- Adds "Compare Taxa Side by Side" as an option in the existing View selector (By Taxonomic Group / By Country / SSC / Table 1a), navigating to `/compare` on selection instead of toggling `layoutMode`

## Screenshots

**Header — no more standalone Compare button; option now lives in the View dropdown:**

![header](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-414-compare-dropdown/01-header.png)

**Selecting "Compare Taxa Side by Side" from the dropdown navigates to /compare, unaffected:**

![compare page](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-414-compare-dropdown/02-compare-page.png)

## Test plan
- [x] `tsc --noEmit` and `eslint` clean on both edited files
- [x] Browser-verified: header no longer shows a separate Compare button/link (`a[href="/compare"]` count is 0)
- [x] Browser-verified: View dropdown lists "Compare Taxa Side by Side" as the last option
- [x] Browser-verified: selecting it navigates to `/compare`, which renders unaffected (both side-by-side panels still work, each with their own independent View dropdown)
- [x] No console errors during the flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)