### PR TITLE
Mobile: header controls on title row, iNat photos below map

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -66,9 +66,12 @@ export default function RedListPage() {
       <main className="max-w-5xl w-full min-w-0 mx-auto flex-1">
         {/* Header: two aligned rows (title | controls, subtitle | search).
             Globe sits inline with the title so the subtitle, controls and
-            search bar share the same flush-left edge as the table below. */}
+            search bar share the same flush-left edge as the table below.
+            Title and controls (theme toggle, sign-in) share a row even on
+            mobile — only subtitle and search drop to their own full-width
+            rows below that on narrow screens. */}
         <div className="mb-[0.9rem] md:mb-[1.35rem]">
-          <div className="min-w-0 grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center gap-x-3 gap-y-1.5 sm:gap-y-3 [grid-template-areas:'title'_'subtitle'_'controls'_'search'] sm:[grid-template-areas:'title_controls'_'subtitle_search']">
+          <div className="min-w-0 grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1.5 sm:gap-y-3 [grid-template-areas:'title_controls'_'subtitle_subtitle'_'search_search'] sm:[grid-template-areas:'title_controls'_'subtitle_search']">
             <button
               type="button"
               onClick={() => {

--- a/app/src/components/OccurrenceMapRow.tsx
+++ b/app/src/components/OccurrenceMapRow.tsx
@@ -2399,9 +2399,11 @@ export default function OccurrenceMapRow({
           {/* ── Left sidebar (iNat photos + contributors) + Map (right) ── */}
           <div className="flex flex-col sm:flex-row sm:items-stretch gap-2">
             {/* Left column — iNat photo gallery only (hidden if no iNat data); narrow
-                since it's just a 2-col thumbnail grid now, leaving more room for the map */}
+                since it's just a 2-col thumbnail grid now, leaving more room for the map.
+                Ordered after the map on mobile (order-2) since the map is the primary
+                content there; back to its normal DOM order (first, on the left) at sm+. */}
             {(!breakdown || breakdown.iNaturalist > 0) && (
-            <div className="sm:w-44 shrink-0 flex flex-col gap-2">
+            <div className="order-2 sm:order-none sm:w-44 shrink-0 flex flex-col gap-2">
               {/* iNat photo grid — only shown when photos exist or loading */}
               {(inatPhotos.length > 0 || loadingInatPhotos) && (
                 <div className="flex flex-col bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden relative z-10">
@@ -2411,8 +2413,9 @@ export default function OccurrenceMapRow({
                   </div>
                   {inatPhotos.length > 0 ? (
                     <>
-                      {/* Photos — 2-col x 5-row grid */}
-                      <div className={`grid grid-cols-2 gap-1 p-1.5 ${loadingInatPhotos ? "opacity-50" : ""}`}>
+                      {/* Photos — 5-col x 2-row grid on mobile (full-width column there),
+                          2-col x 5-row once the sidebar narrows to w-44 at sm+ */}
+                      <div className={`grid grid-cols-5 sm:grid-cols-2 gap-1 p-1.5 ${loadingInatPhotos ? "opacity-50" : ""}`}>
                         {inatPhotos.slice(0, pageSize).map((obs, idx) => (
                           <div key={`${inatPage}-${idx}`} className="aspect-square">
                             <InatPhotoWithPreview
@@ -2475,7 +2478,7 @@ export default function OccurrenceMapRow({
             )}
 
             {/* Map(s) — takes remaining width, stretches to match left column */}
-            <div className="flex-1 min-w-0 flex flex-col gap-2">
+            <div className="order-1 sm:order-none flex-1 min-w-0 flex flex-col gap-2">
                 {splitView && splitDate ? (
                   <div className="flex flex-col gap-2">
                     {/* Split view control bar */}


### PR DESCRIPTION
## Summary

Two small mobile-layout fixes to the species dashboard, bundled together since both are narrow-viewport-only tweaks:

- **Header**: the theme toggle and sign-in icon used to drop to their own row beneath the title on mobile. They now share the title's row at every breakpoint — only the subtitle and search bar still stack below on narrow screens.

  ![Header controls on the title row](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-421-mobile-header-inat-layout/01-header-controls-same-row.png)

- **iNaturalist photos**: on the species occurrence view, the iNat photo gallery used to render *above* the GBIF map on mobile, squeezed into the same narrow 2-column grid used for the desktop sidebar. It now renders *below* the map, and widens to a 5-column grid there since it's no longer constrained to a narrow sidebar width.

  ![iNat photo gallery below the GBIF map, 5-column grid](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-421-mobile-header-inat-layout/02-inat-below-map.png)

## Test plan

- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx eslint .` — clean
- [x] `npx vitest run` — 702 passed / 6 skipped (708 total)
- [x] Verified live in a real browser (Playwright, 390×844 mobile viewport): header shows theme toggle + sign-in on the same row as the title; iNat photo gallery renders below the GBIF occurrence map in a 5-column grid.
- [x] Verified desktop (1400px) layout unaffected: header row unchanged, iNat sidebar still narrow 2-column to the left of the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
