### PR TITLE
Taxon stat card: show filtered count instead of a static total

### DIFF
--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2544,19 +2544,16 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               sub-group row drilled into via TaxaSummary's own tree
               (selectedSubgroupTaxon: dynamic order/family/genus, or a static SSC
               group), or a non-curated arbitrary rank reached via search
-              (arbitraryTaxon). Two fixed stat cards — the taxon (name + rank)
-              and its total species count (taxaFilteredSpeciesBase) — neither
-              reacts to pill filters, so this row never grows/changes as
-              filters are added; the applied-filters row below (right above
-              the species table) is what shows the live, filtered picture.
-              The Species card's Assessed/Not Evaluated toggle sits to the
-              right of its label, vertically centered against the whole card;
-              it lives here (not the landing-only row with the View selector)
-              so it's usable at any drill-down depth. TaxaSummary's own
-              breadcrumb table above already shows the tree branch that led
-              here (Mammals → Rodentia → Heteromyidae → ...) when applicable —
-              this is purely an additional, more prominent summary, not a
-              replacement for it. */}
+              (arbitraryTaxon). Two stat cards: the taxon (name + rank) and the
+              Species card. The Species card's number is totalFiltered (live,
+              reacts to pill filters), with a "of Y" qualifier + "matching
+              filters" caption once a filter narrows it below the taxon's own
+              total (taxaFilteredSpeciesBase) — naming it explicitly avoids
+              reading as some other ratio (e.g. assessed-of-described).
+              TaxaSummary's own breadcrumb table above already shows the tree
+              branch that led here (Mammals → Rodentia → Heteromyidae → ...)
+              when applicable — this is purely an additional, more prominent
+              summary, not a replacement for it. */}
           {focusedTaxonCard && !isSingleSpecies && (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3">
@@ -2575,8 +2572,16 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   <div className="mt-0.5 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
                     {speciesLoading && assessedSpecies.length === 0
                       ? <Spinner className="h-6 w-6" />
-                      : taxaFilteredSpeciesBase.length.toLocaleString()}
+                      : totalFiltered < taxaFilteredSpeciesBase.length ? (
+                        <>
+                          {totalFiltered.toLocaleString()}
+                          <span className="text-base font-normal text-zinc-400 dark:text-zinc-500"> of {taxaFilteredSpeciesBase.length.toLocaleString()}</span>
+                        </>
+                      ) : totalFiltered.toLocaleString()}
                   </div>
+                  {!(speciesLoading && assessedSpecies.length === 0) && totalFiltered < taxaFilteredSpeciesBase.length && (
+                    <div className="text-[11px] text-zinc-400 dark:text-zinc-500 mt-0.5">matching filters</div>
+                  )}
                 </div>
                 {onViewModeChange && (
                   <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2564,8 +2564,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   {focusedTaxonCard.name}
                 </div>
               </div>
-              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex items-center justify-between gap-3">
-                <div>
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-3">
+                <div className="min-w-0">
                   <div className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
                     {isNewAssessments ? "Not Evaluated Species" : "Assessed Species"}
                   </div>
@@ -2575,8 +2575,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                       : totalFiltered < taxaFilteredSpeciesBase.length ? (
                         <>
                           {totalFiltered.toLocaleString()}
-                          <span className="text-base font-normal text-zinc-400 dark:text-zinc-500"> of {taxaFilteredSpeciesBase.length.toLocaleString()}</span>
-                          <span className="text-[11px] font-normal text-zinc-400 dark:text-zinc-500"> matching filters</span>
+                          <span className="text-base font-normal text-zinc-400 dark:text-zinc-500"> matching filters of {taxaFilteredSpeciesBase.length.toLocaleString()} total</span>
                         </>
                       ) : totalFiltered.toLocaleString()}
                   </div>

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2576,12 +2576,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                         <>
                           {totalFiltered.toLocaleString()}
                           <span className="text-base font-normal text-zinc-400 dark:text-zinc-500"> of {taxaFilteredSpeciesBase.length.toLocaleString()}</span>
+                          <span className="text-[11px] font-normal text-zinc-400 dark:text-zinc-500"> matching filters</span>
                         </>
                       ) : totalFiltered.toLocaleString()}
                   </div>
-                  {!(speciesLoading && assessedSpecies.length === 0) && totalFiltered < taxaFilteredSpeciesBase.length && (
-                    <div className="text-[11px] text-zinc-400 dark:text-zinc-500 mt-0.5">matching filters</div>
-                  )}
                 </div>
                 {onViewModeChange && (
                   <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700 overflow-hidden text-xs shrink-0">


### PR DESCRIPTION
## Summary

- The "Assessed Species"/"Not Evaluated Species" stat card next to the taxon card was made a static, non-reactive total two days ago (f783972) specifically so pill filters wouldn't move it, with filter chips relegated to a separate row above the table.
- In practice, applying a filter and having the taxon's headline count not budge reads as broken/stale, not intentional.
- Restores the live `totalFiltered` count. When a filter narrows it below the taxon's own total, the value reads **`X matching filters of Y total`** — the qualifier sits right next to the number it describes (avoids "X of Y matching filters" misreading as Y being the matching-filters figure), and "total" unambiguously labels Y so it can't be misread as a different ratio (e.g. assessed-of-described).
- Applies to both the curated-taxon path (e.g. Mammals) and the arbitrary-taxon search path (e.g. Carnivora).
- On narrow/mobile widths, the Assessed/Not Evaluated toggle stacks below the count instead of beside it, so the phrase never wraps mid-word.

## Screenshots

Mammals, no filters — plain total:

![unfiltered](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-424-filtered-count-stat-card/01-unfiltered.png)

Mammals, "Threatened" filter applied — filtered count + qualifier:

![filtered](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-424-filtered-count-stat-card/02-filtered.png)

Mobile, filtered — toggle stacks below, no mid-word wrap:

![mobile filtered](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-424-filtered-count-stat-card/03-mobile-filtered.png)

## Test plan

- [x] Typecheck passes
- [x] Verified in browser: Mammals (curated taxon) unfiltered shows plain count, filtered shows "X matching filters of Y total"
- [x] Verified in browser: Carnivora (arbitrary taxon via search) same behavior
- [x] Verified at mobile width (390px): no mid-word wrap, toggle stacks below the count
- [x] No console errors