### PR TITLE
Move Country map + Threats chart into More Filters

### DIFF
--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2461,6 +2461,174 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     </div>
   );
 
+  // Country map card — shared between Charts row 2 (new-assessments mode) and
+  // More Filters (reassessments mode, moved there to keep the primary view
+  // focused on Conservation Status / Years Since Assessed / Geospatial GBIF
+  // Records; see the More Filters section below).
+  const countryMapCard = (
+    <div>
+      {speciesLoading && assessedSpecies.length === 0 ? (
+        <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 min-h-[320px] flex flex-col">
+          <div className="flex items-center justify-between mb-1">
+            <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+              Country
+            </h2>
+          </div>
+          <div className="flex-1 flex items-center justify-center">
+            <Spinner />
+          </div>
+        </div>
+      ) : (
+        <WorldMap
+          selectedCountries={selectedCountries}
+          onCountrySelect={handleCountrySelect}
+          precomputedStats={countryStatsForMap}
+          precomputedStatsTotal={countryStatsForMapTotal}
+          selectedTaxa={selectedTaxa}
+          speciesLabel={isNewAssessments ? "# Unassessed" : undefined}
+          showOutdatedMode={!isNewAssessments}
+          showColorModeDropdown={!isNewAssessments}
+          onRegionFilter={handleRegionFilter}
+          endemicsOnly={endemicsOnly}
+          onEndemicsToggle={isNewAssessments ? undefined : () => setEndemicsOnly(!endemicsOnly)}
+          showGbifToggle={showGbifToggle}
+          mapViewMode={mapViewMode}
+          onMapViewModeChange={setMapViewMode}
+          mapSortKey={mapSortKey}
+          mapSortDirection={mapSortDirection}
+          onMapSortChange={setMapSort}
+        />
+      )}
+    </div>
+  );
+
+  // Threats card — reassessments mode only (new-assessments shows Geospatial
+  // GBIF Records instead, in Charts row 2). Lives in More Filters, not the
+  // primary view — see the More Filters section below.
+  const threatsCard = (() => {
+    // Map label→code for reverse lookup from chart clicks
+    const threatLabelToCode = new Map(THREAT_CATEGORIES.map(c => [c.label, c.code]));
+    // Bar label: count + share of all in-view species (see threatTotal).
+    const threatBarLabel = (count: number) =>
+      `${count.toLocaleString()} (${threatTotal > 0 ? Math.round((count / threatTotal) * 100) : 0}%)`;
+    // Use label as `code` field so it displays on y-axis, sorted by count desc
+    const threatBarData = THREAT_CATEGORIES
+      .map(({ code, label }) => ({ code: label, threatCode: code, count: threatCounts[code] ?? 0, label: threatBarLabel(threatCounts[code] ?? 0) }))
+      .filter(d => d.count > 0)
+      .sort((a, b) => b.count - a.count);
+    // selectedItems needs to use labels too for dimming
+    const selectedThreatLabels = new Set(
+      Array.from(selectedThreats).map(code => THREAT_CATEGORIES.find(c => c.code === code)?.label).filter(Boolean) as string[]
+    );
+    // Drill-down: when a top-level category is expanded, its sub-categories
+    // appear in a split pane below the main chart (rather than expanding the
+    // card downward) so the card height stays constant — both charts share a
+    // fixed-height area and scroll internally.
+    const drillCat = expandedThreat ? THREAT_CATEGORIES.find(c => c.code === expandedThreat) ?? null : null;
+    const drillSubData = drillCat
+      ? drillCat.children
+          .map(child => ({ code: child.label, threatCode: child.code, count: threatCounts[child.code] ?? 0, label: threatBarLabel(threatCounts[child.code] ?? 0) }))
+          .filter(d => d.count > 0)
+          .sort((a, b) => b.count - a.count)
+      : [];
+    const isDrilled = drillCat !== null && drillSubData.length > 0;
+    const drillSelectedSubLabels = drillCat ? new Set(
+      Array.from(selectedThreats).map(code => drillCat.children.find(c => c.code === code)?.label).filter(Boolean) as string[]
+    ) : new Set<string>();
+    // The card content area is a constant height (independent of how many
+    // categories are present) so the card never resizes — neither when the
+    // filter changes the category count nor when drilling in — which would
+    // otherwise bump the country map sharing this grid row. The base chart
+    // keeps its natural per-bar height and scrolls within the fixed area.
+    // 266 = the country map card's 320px height minus this card's header +
+    // padding (~54px), so both cards (and their loading skeletons) match.
+    const THREATS_AREA_HEIGHT = 266;
+    const chartHeight = Math.max(200, threatBarData.length * 18 + 30);
+    const loading = speciesLoading && assessedSpecies.length === 0;
+    return (
+      <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
+        <div className="flex items-center justify-between mb-1 min-h-[24px]">
+          <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Threats</span>
+        </div>
+        <div style={{ height: THREATS_AREA_HEIGHT }} className="flex flex-col overflow-hidden">
+          {loading ? (
+            <div className="h-full flex items-center justify-center"><Spinner /></div>
+          ) : threatBarData.length > 0 ? (
+            <>
+              {/* Top-level categories — always visible; scrolls if it overflows the shared height */}
+              <div className="flex-1 min-h-0 overflow-y-auto">
+                <div style={{ height: chartHeight }}>
+                  <FilterBarChart
+                    data={threatBarData}
+                    dataKey="code"
+                    selectedItems={selectedThreatLabels}
+                    onBarClick={(data: { payload?: { code?: string; threatCode?: string } }, event: React.MouseEvent) => {
+                      const label = data.payload?.code;
+                      const code = label ? threatLabelToCode.get(label) : undefined;
+                      if (!code) return;
+                      const isMulti = event.metaKey || event.ctrlKey;
+                      setSelectedThreats(prev => {
+                        if (isMulti) { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; }
+                        if (prev.size === 1 && prev.has(code)) return new Set();
+                        return new Set([code]);
+                      });
+                      setExpandedThreat(prev => prev === code ? null : code);
+                    }}
+                    barColor="#8b5cf6"
+                    yAxisWidth={155}
+                    rightMargin={80}
+                    yAxisTickMaxLength={22}
+                  />
+                </div>
+              </div>
+              {/* Sub-categories of the drilled-into category — shares the fixed height */}
+              {isDrilled && (
+                <div className="shrink-0 mt-2 pt-2 border-t border-zinc-200 dark:border-zinc-800 flex flex-col" style={{ maxHeight: "50%" }}>
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 truncate">{drillCat!.label}</span>
+                    <button
+                      onClick={() => setExpandedThreat(null)}
+                      className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
+                      aria-label="Close sub-categories"
+                    >
+                      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
+                    </button>
+                  </div>
+                  <div className="min-h-0 overflow-y-auto">
+                    <div style={{ height: Math.max(80, drillSubData.length * 18 + 30) }}>
+                      <FilterBarChart
+                        data={drillSubData}
+                        dataKey="code"
+                        selectedItems={drillSelectedSubLabels}
+                        onBarClick={(data: { payload?: { code?: string } }, event: React.MouseEvent) => {
+                          const label = data.payload?.code;
+                          const child = drillCat!.children.find(c => c.label === label);
+                          if (!child) return;
+                          const isMulti = event.metaKey || event.ctrlKey;
+                          setSelectedThreats(prev => {
+                            if (isMulti) { const next = new Set(prev); if (next.has(child.code)) next.delete(child.code); else next.add(child.code); return next; }
+                            if (prev.size === 1 && prev.has(child.code)) return new Set();
+                            return new Set([child.code]);
+                          });
+                        }}
+                        barColor="#a78bfa"
+                        yAxisWidth={170}
+                        rightMargin={80}
+                        yAxisTickMaxLength={24}
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="h-full flex items-center justify-center"><span className="text-sm text-zinc-400 dark:text-zinc-500">No threat data</span></div>
+          )}
+        </div>
+      </div>
+    );
+  })();
+
   return (
     <div className="space-y-4 min-w-0">
       {/* Always show Taxa Summary table */}
@@ -2889,228 +3057,71 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           </div>
           )}
 
-          {/* Charts row 2: Country map + (Threats, 2-col) for reassessments; Country
-              map + Year Described + Geospatial GBIF Records (3-col, 1/3 each) for
-              new-assessments — Year Described used to sit alone in its own row
-              below (a half-width chart with empty space beside it, since that row
-              was also grid-cols-2), now folded into this one instead. */}
-          <div className={`grid grid-cols-1 gap-4 ${isNewAssessments ? "sm:grid-cols-3" : "md:grid-cols-2"}`}>
-            {/* Country Map */}
-            <div>
-              {speciesLoading && assessedSpecies.length === 0 ? (
-                <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 min-h-[320px] flex flex-col">
-                  <div className="flex items-center justify-between mb-1">
-                    <h2 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-                      Country
-                    </h2>
-                  </div>
-                  <div className="flex-1 flex items-center justify-center">
-                    <Spinner />
-                  </div>
-                </div>
-              ) : (
-                <WorldMap
-                  selectedCountries={selectedCountries}
-                  onCountrySelect={handleCountrySelect}
-                  precomputedStats={countryStatsForMap}
-                  precomputedStatsTotal={countryStatsForMapTotal}
-                  selectedTaxa={selectedTaxa}
-                  speciesLabel={isNewAssessments ? "# Unassessed" : undefined}
-                  showOutdatedMode={!isNewAssessments}
-                  showColorModeDropdown={!isNewAssessments}
-                  onRegionFilter={handleRegionFilter}
-                  endemicsOnly={endemicsOnly}
-                  onEndemicsToggle={isNewAssessments ? undefined : () => setEndemicsOnly(!endemicsOnly)}
-                  showGbifToggle={showGbifToggle}
-                  mapViewMode={mapViewMode}
-                  onMapViewModeChange={setMapViewMode}
-                  mapSortKey={mapSortKey}
-                  mapSortDirection={mapSortDirection}
-                  onMapSortChange={setMapSort}
-                />
-              )}
+          {/* Charts row 2 (new-assessments mode only): Country map + Year
+              Described + Geospatial GBIF Records, 3-col, 1/3 each. For
+              reassessments, Country map + Threats live in More Filters
+              instead (below) — decluttered out of the always-visible primary
+              view now that they're not the only geographic/threat filter
+              (see countryMapCard/threatsCard, defined above). */}
+          {isNewAssessments && (
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {countryMapCard}
+
+            {/* Year Described */}
+            <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 flex items-center gap-1">
+                  Year Described
+                  <HoverTooltip text="Year the species was scientifically described, from the Catalogue of Life. Available for ~99% of animals; many plants, fungi and algae have no datable record in CoL and fall under 'Unknown'.">
+                    <svg className="w-3 h-3 text-zinc-400 dark:text-zinc-500 cursor-help" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <circle cx="12" cy="12" r="10" />
+                      <path d="M12 16v-4M12 8h.01" />
+                    </svg>
+                  </HoverTooltip>
+                </span>
+              </div>
+              <div style={{ height: 180 }} className="flex items-center justify-center">
+                {speciesLoading && assessedSpecies.length === 0 ? (
+                  <Spinner />
+                ) : describedYearData.length > 0 ? (
+                  <FilterBarChart
+                    data={describedYearData}
+                    dataKey="shortRange"
+                    selectedItems={selectedDescribedYears}
+                    onBarClick={handleDescribedYearClick}
+                    barColor="#3b82f6"
+                    yAxisWidth={64}
+                    rightMargin={85}
+                  />
+                ) : (
+                  <span className="text-sm text-zinc-400 dark:text-zinc-500">No description-year data</span>
+                )}
+              </div>
             </div>
 
-            {/* Year Described (new-assessments only) — second column of this row. */}
-            {isNewAssessments && (
-              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 flex items-center gap-1">
-                    Year Described
-                    <HoverTooltip text="Year the species was scientifically described, from the Catalogue of Life. Available for ~99% of animals; many plants, fungi and algae have no datable record in CoL and fall under 'Unknown'.">
-                      <svg className="w-3 h-3 text-zinc-400 dark:text-zinc-500 cursor-help" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                        <circle cx="12" cy="12" r="10" />
-                        <path d="M12 16v-4M12 8h.01" />
-                      </svg>
-                    </HoverTooltip>
-                  </span>
-                </div>
-                <div style={{ height: 180 }} className="flex items-center justify-center">
-                  {speciesLoading && assessedSpecies.length === 0 ? (
-                    <Spinner />
-                  ) : describedYearData.length > 0 ? (
-                    <FilterBarChart
-                      data={describedYearData}
-                      dataKey="shortRange"
-                      selectedItems={selectedDescribedYears}
-                      onBarClick={handleDescribedYearClick}
-                      barColor="#3b82f6"
-                      yAxisWidth={64}
-                      rightMargin={85}
-                    />
-                  ) : (
-                    <span className="text-sm text-zinc-400 dark:text-zinc-500">No description-year data</span>
-                  )}
-                </div>
+            {/* Geospatial GBIF Records */}
+            <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 flex items-center gap-1">Geospatial GBIF Records <GbifInfoTooltip /></span>
               </div>
-            )}
-
-            {/* Threats (reassessments) or GBIF Observations chart (new-assessments) */}
-            {isNewAssessments ? (
-              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 flex items-center gap-1">Geospatial GBIF Records <GbifInfoTooltip /></span>
-                </div>
-                <div style={{ height: 180 }} className="flex items-center justify-center">
-                  {speciesLoading && assessedSpecies.length === 0 ? (
-                    <Spinner />
-                  ) : (
-                    <FilterBarChart
-                      data={gbifObsData}
-                      dataKey="shortRange"
-                      selectedItems={selectedObsRanges}
-                      onBarClick={handleObsClick}
-                      barColor="#10b981"
-                      yAxisWidth={42}
-                      rightMargin={85}
-                    />
-                  )}
-                </div>
+              <div style={{ height: 180 }} className="flex items-center justify-center">
+                {speciesLoading && assessedSpecies.length === 0 ? (
+                  <Spinner />
+                ) : (
+                  <FilterBarChart
+                    data={gbifObsData}
+                    dataKey="shortRange"
+                    selectedItems={selectedObsRanges}
+                    onBarClick={handleObsClick}
+                    barColor="#10b981"
+                    yAxisWidth={42}
+                    rightMargin={85}
+                  />
+                )}
               </div>
-            ) : (() => {
-              // Map label→code for reverse lookup from chart clicks
-              const threatLabelToCode = new Map(THREAT_CATEGORIES.map(c => [c.label, c.code]));
-              // Bar label: count + share of all in-view species (see threatTotal).
-              const threatBarLabel = (count: number) =>
-                `${count.toLocaleString()} (${threatTotal > 0 ? Math.round((count / threatTotal) * 100) : 0}%)`;
-              // Use label as `code` field so it displays on y-axis, sorted by count desc
-              const threatBarData = THREAT_CATEGORIES
-                .map(({ code, label }) => ({ code: label, threatCode: code, count: threatCounts[code] ?? 0, label: threatBarLabel(threatCounts[code] ?? 0) }))
-                .filter(d => d.count > 0)
-                .sort((a, b) => b.count - a.count);
-              // selectedItems needs to use labels too for dimming
-              const selectedThreatLabels = new Set(
-                Array.from(selectedThreats).map(code => THREAT_CATEGORIES.find(c => c.code === code)?.label).filter(Boolean) as string[]
-              );
-              // Drill-down: when a top-level category is expanded, its sub-categories
-              // appear in a split pane below the main chart (rather than expanding the
-              // card downward) so the card height stays constant — both charts share a
-              // fixed-height area and scroll internally.
-              const drillCat = expandedThreat ? THREAT_CATEGORIES.find(c => c.code === expandedThreat) ?? null : null;
-              const drillSubData = drillCat
-                ? drillCat.children
-                    .map(child => ({ code: child.label, threatCode: child.code, count: threatCounts[child.code] ?? 0, label: threatBarLabel(threatCounts[child.code] ?? 0) }))
-                    .filter(d => d.count > 0)
-                    .sort((a, b) => b.count - a.count)
-                : [];
-              const isDrilled = drillCat !== null && drillSubData.length > 0;
-              const drillSelectedSubLabels = drillCat ? new Set(
-                Array.from(selectedThreats).map(code => drillCat.children.find(c => c.code === code)?.label).filter(Boolean) as string[]
-              ) : new Set<string>();
-              // The card content area is a constant height (independent of how many
-              // categories are present) so the card never resizes — neither when the
-              // filter changes the category count nor when drilling in — which would
-              // otherwise bump the country map sharing this grid row. The base chart
-              // keeps its natural per-bar height and scrolls within the fixed area.
-              // 266 = the country map card's 320px height minus this card's header +
-              // padding (~54px), so both cards (and their loading skeletons) match.
-              const THREATS_AREA_HEIGHT = 266;
-              const chartHeight = Math.max(200, threatBarData.length * 18 + 30);
-              const loading = speciesLoading && assessedSpecies.length === 0;
-              return (
-                <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
-                  <div className="flex items-center justify-between mb-1 min-h-[24px]">
-                    <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Threats</span>
-                  </div>
-                  <div style={{ height: THREATS_AREA_HEIGHT }} className="flex flex-col overflow-hidden">
-                    {loading ? (
-                      <div className="h-full flex items-center justify-center"><Spinner /></div>
-                    ) : threatBarData.length > 0 ? (
-                      <>
-                        {/* Top-level categories — always visible; scrolls if it overflows the shared height */}
-                        <div className="flex-1 min-h-0 overflow-y-auto">
-                          <div style={{ height: chartHeight }}>
-                            <FilterBarChart
-                              data={threatBarData}
-                              dataKey="code"
-                              selectedItems={selectedThreatLabels}
-                              onBarClick={(data: { payload?: { code?: string; threatCode?: string } }, event: React.MouseEvent) => {
-                                const label = data.payload?.code;
-                                const code = label ? threatLabelToCode.get(label) : undefined;
-                                if (!code) return;
-                                const isMulti = event.metaKey || event.ctrlKey;
-                                setSelectedThreats(prev => {
-                                  if (isMulti) { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; }
-                                  if (prev.size === 1 && prev.has(code)) return new Set();
-                                  return new Set([code]);
-                                });
-                                setExpandedThreat(prev => prev === code ? null : code);
-                              }}
-                              barColor="#8b5cf6"
-                              yAxisWidth={155}
-                              rightMargin={80}
-                              yAxisTickMaxLength={22}
-                            />
-                          </div>
-                        </div>
-                        {/* Sub-categories of the drilled-into category — shares the fixed height */}
-                        {isDrilled && (
-                          <div className="shrink-0 mt-2 pt-2 border-t border-zinc-200 dark:border-zinc-800 flex flex-col" style={{ maxHeight: "50%" }}>
-                            <div className="flex items-center justify-between mb-1">
-                              <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 truncate">{drillCat!.label}</span>
-                              <button
-                                onClick={() => setExpandedThreat(null)}
-                                className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                                aria-label="Close sub-categories"
-                              >
-                                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
-                              </button>
-                            </div>
-                            <div className="min-h-0 overflow-y-auto">
-                              <div style={{ height: Math.max(80, drillSubData.length * 18 + 30) }}>
-                                <FilterBarChart
-                                  data={drillSubData}
-                                  dataKey="code"
-                                  selectedItems={drillSelectedSubLabels}
-                                  onBarClick={(data: { payload?: { code?: string } }, event: React.MouseEvent) => {
-                                    const label = data.payload?.code;
-                                    const child = drillCat!.children.find(c => c.label === label);
-                                    if (!child) return;
-                                    const isMulti = event.metaKey || event.ctrlKey;
-                                    setSelectedThreats(prev => {
-                                      if (isMulti) { const next = new Set(prev); if (next.has(child.code)) next.delete(child.code); else next.add(child.code); return next; }
-                                      if (prev.size === 1 && prev.has(child.code)) return new Set();
-                                      return new Set([child.code]);
-                                    });
-                                  }}
-                                  barColor="#a78bfa"
-                                  yAxisWidth={170}
-                                  rightMargin={80}
-                                  yAxisTickMaxLength={24}
-                                />
-                              </div>
-                            </div>
-                          </div>
-                        )}
-                      </>
-                    ) : (
-                      <div className="h-full flex items-center justify-center"><span className="text-sm text-zinc-400 dark:text-zinc-500">No threat data</span></div>
-                    )}
-                  </div>
-                </div>
-              );
-            })()}
+            </div>
           </div>
+          )}
 
           {/* More Filters — a full-width collapsible card row, consistent with
               the other cards on the page (hidden for New Assessments) */}
@@ -3123,9 +3134,9 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
               More Filters
-              {(selectedSystems.size + selectedGrowthForms.size + selectedPopulationTrends.size + selectedMovementPatterns.size + selectedThreats.size > 0) && (
+              {(selectedSystems.size + selectedGrowthForms.size + selectedPopulationTrends.size + selectedMovementPatterns.size + selectedThreats.size + selectedCountries.size + (endemicsOnly ? 1 : 0) > 0) && (
                 <span className="ml-1 px-1.5 py-0.5 text-[10px] rounded-full bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300">
-                  {selectedSystems.size + selectedGrowthForms.size + selectedPopulationTrends.size + selectedMovementPatterns.size + selectedThreats.size} active
+                  {selectedSystems.size + selectedGrowthForms.size + selectedPopulationTrends.size + selectedMovementPatterns.size + selectedThreats.size + selectedCountries.size + (endemicsOnly ? 1 : 0)} active
                 </span>
               )}
             </button>
@@ -3286,6 +3297,15 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                       </div>
                   </div>
                 )}
+
+                {/* Country map + Threats — moved here from the primary view (Charts row
+                    2) so that row stays focused on Conservation Status / Years Since
+                    Assessed / Geospatial GBIF Records; these still filter live like
+                    every other control on this page, just tucked a click away. */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  {countryMapCard}
+                  {threatsCard}
+                </div>
 
                 {/* Assessors and Reviewers, shown side by side */}
                 {isSingleSpecies && singleSpecies ? (

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3025,10 +3025,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               </div>
             </div>
 
-            {/* Geospatial GBIF Records */}
+            {/* GBIF Records */}
             <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
               <div className="flex items-center justify-between mb-1">
-                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 flex items-center gap-1">Geospatial GBIF Records <GbifInfoTooltip /></span>
+                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 flex items-center gap-1">GBIF Records <GbifInfoTooltip /></span>
                               </div>
               <div className="flex-1 min-h-[150px] flex items-center justify-center">
                 {speciesLoading && assessedSpecies.length === 0 ? (
@@ -3058,7 +3058,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           )}
 
           {/* Charts row 2 (new-assessments mode only): Country map + Year
-              Described + Geospatial GBIF Records, 3-col, 1/3 each. For
+              Described + GBIF Records, 3-col, 1/3 each. For
               reassessments, Country map + Threats live in More Filters
               instead (below) — decluttered out of the always-visible primary
               view now that they're not the only geographic/threat filter
@@ -3099,10 +3099,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               </div>
             </div>
 
-            {/* Geospatial GBIF Records */}
+            {/* GBIF Records */}
             <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
               <div className="flex items-center justify-between mb-1">
-                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 flex items-center gap-1">Geospatial GBIF Records <GbifInfoTooltip /></span>
+                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 flex items-center gap-1">GBIF Records <GbifInfoTooltip /></span>
               </div>
               <div style={{ height: 180 }} className="flex items-center justify-center">
                 {speciesLoading && assessedSpecies.length === 0 ? (
@@ -3133,7 +3133,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               <svg className={`w-3.5 h-3.5 transition-transform ${moreFiltersOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
-              More Filters
+              <span className="sm:hidden">More Filters</span>
+              <span className="hidden sm:inline">More Filters: Country, Threats, and more</span>
               {(selectedSystems.size + selectedGrowthForms.size + selectedPopulationTrends.size + selectedMovementPatterns.size + selectedThreats.size + selectedCountries.size + (endemicsOnly ? 1 : 0) > 0) && (
                 <span className="ml-1 px-1.5 py-0.5 text-[10px] rounded-full bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300">
                   {selectedSystems.size + selectedGrowthForms.size + selectedPopulationTrends.size + selectedMovementPatterns.size + selectedThreats.size + selectedCountries.size + (endemicsOnly ? 1 : 0)} active
@@ -3144,7 +3145,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               <div className="px-3 md:px-4 pb-3 md:pb-4 pt-3 md:pt-4 border-t border-zinc-200 dark:border-zinc-800 flex flex-col gap-3">
                 {/* Country map + Threats — moved here from the primary view (Charts row
                     2) so that row stays focused on Conservation Status / Years Since
-                    Assessed / Geospatial GBIF Records; these still filter live like
+                    Assessed / GBIF Records; these still filter live like
                     every other control on this page, just tucked a click away. */}
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                   {countryMapCard}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3133,8 +3133,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               <svg className={`w-3.5 h-3.5 transition-transform ${moreFiltersOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
-              <span className="sm:hidden">More Filters</span>
-              <span className="hidden sm:inline">More Filters: Country, Threats, and more</span>
+              More Filters
               {(selectedSystems.size + selectedGrowthForms.size + selectedPopulationTrends.size + selectedMovementPatterns.size + selectedThreats.size + selectedCountries.size + (endemicsOnly ? 1 : 0) > 0) && (
                 <span className="ml-1 px-1.5 py-0.5 text-[10px] rounded-full bg-zinc-200 dark:bg-zinc-700 text-zinc-600 dark:text-zinc-300">
                   {selectedSystems.size + selectedGrowthForms.size + selectedPopulationTrends.size + selectedMovementPatterns.size + selectedThreats.size + selectedCountries.size + (endemicsOnly ? 1 : 0)} active

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2743,7 +2743,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                       : totalFiltered < taxaFilteredSpeciesBase.length ? (
                         <>
                           {totalFiltered.toLocaleString()}
-                          <span className="text-base font-normal text-zinc-400 dark:text-zinc-500"> matching filters of {taxaFilteredSpeciesBase.length.toLocaleString()} total</span>
+                          <span className="text-base font-normal text-zinc-400 dark:text-zinc-500"> matching filters, of {taxaFilteredSpeciesBase.length.toLocaleString()} total</span>
                         </>
                       ) : totalFiltered.toLocaleString()}
                   </div>

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3151,40 +3151,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   {threatsCard}
                 </div>
 
-                {/* Realm */}
-                <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
-                  <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Realm</span>
-                  <div className="flex flex-wrap gap-1.5">
-                    {(["Terrestrial", "Freshwater", "Marine"] as const).map(system => {
-                      const isSelected = selectedSystems.has(system);
-                      const count = realmCounts[system] ?? 0;
-                      return (
-                        <button
-                          key={system}
-                          onClick={(e) => {
-                            const isMulti = e.metaKey || e.ctrlKey;
-                            setSelectedSystems(prev => {
-                              if (isMulti) { const next = new Set(prev); if (next.has(system)) next.delete(system); else next.add(system); return next; }
-                              if (prev.size === 1 && prev.has(system)) return new Set();
-                              return new Set([system]);
-                            });
-                          }}
-                          className={`px-2 py-1 text-xs rounded-full transition-colors cursor-pointer ${
-                            isSelected
-                              ? system === "Terrestrial" ? "bg-amber-500 text-white"
-                              : system === "Freshwater" ? "bg-cyan-500 text-white"
-                              : "bg-blue-600 text-white"
-                              : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
-                          }`}
-                        >
-                          {system} ({count.toLocaleString()})
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-
-
                 {/* Growth Form (plants/fungi only) */}
                 {(() => {
                   // Compute growth form counts cross-filtered (exclude own filter)
@@ -3242,8 +3208,44 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   );
                 })()}
 
-                {/* Trend */}
-                <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
+                {/* Realm, Trend, Movement — side by side as three columns rather
+                    than stacked rows, since each is a short, independent filter. */}
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                  {/* Realm */}
+                  <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
+                    <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Realm</span>
+                    <div className="flex flex-wrap gap-1.5">
+                      {(["Terrestrial", "Freshwater", "Marine"] as const).map(system => {
+                        const isSelected = selectedSystems.has(system);
+                        const count = realmCounts[system] ?? 0;
+                        return (
+                          <button
+                            key={system}
+                            onClick={(e) => {
+                              const isMulti = e.metaKey || e.ctrlKey;
+                              setSelectedSystems(prev => {
+                                if (isMulti) { const next = new Set(prev); if (next.has(system)) next.delete(system); else next.add(system); return next; }
+                                if (prev.size === 1 && prev.has(system)) return new Set();
+                                return new Set([system]);
+                              });
+                            }}
+                            className={`px-2 py-1 text-xs rounded-full transition-colors cursor-pointer ${
+                              isSelected
+                                ? system === "Terrestrial" ? "bg-amber-500 text-white"
+                                : system === "Freshwater" ? "bg-cyan-500 text-white"
+                                : "bg-blue-600 text-white"
+                                : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                            }`}
+                          >
+                            {system} ({count.toLocaleString()})
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {/* Trend */}
+                  <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
                     <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Trend</span>
                     <div className="flex flex-wrap gap-1.5">
                       {(["Increasing", "Stable", "Decreasing", "Unknown"] as const).map(trend => {
@@ -3273,39 +3275,40 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                     </div>
                   </div>
 
-                {/* Movement Patterns */}
-                {!isNewAssessments && (
-                  <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
-                    <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Movement</span>
-                      <div className="flex flex-wrap gap-1.5">
-                        {(["Full Migrant", "Altitudinal Migrant", "Nomadic", "Not a Migrant", "Unknown"] as const).map(pattern => {
-                          const isSelected = selectedMovementPatterns.has(pattern);
-                          const count = movementPatternCounts[pattern] ?? 0;
-                          if (count === 0) return null;
-                          return (
-                            <button
-                              key={pattern}
-                              onClick={(e) => {
-                                const isMulti = e.metaKey || e.ctrlKey;
-                                setSelectedMovementPatterns(prev => {
-                                  if (isMulti) { const next = new Set(prev); if (next.has(pattern)) next.delete(pattern); else next.add(pattern); return next; }
-                                  if (prev.size === 1 && prev.has(pattern)) return new Set();
-                                  return new Set([pattern]);
-                                });
-                              }}
-                              className={`px-2 py-1 text-xs rounded-full transition-colors cursor-pointer ${
-                                isSelected
-                                  ? "bg-teal-500 text-white"
-                                  : "bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-700"
-                              }`}
-                            >
-                              {pattern} ({count.toLocaleString()})
-                            </button>
-                          );
-                        })}
-                      </div>
-                  </div>
-                )}
+                  {/* Movement Patterns */}
+                  {!isNewAssessments && (
+                    <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
+                      <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Movement</span>
+                        <div className="flex flex-wrap gap-1.5">
+                          {(["Full Migrant", "Altitudinal Migrant", "Nomadic", "Not a Migrant", "Unknown"] as const).map(pattern => {
+                            const isSelected = selectedMovementPatterns.has(pattern);
+                            const count = movementPatternCounts[pattern] ?? 0;
+                            if (count === 0) return null;
+                            return (
+                              <button
+                                key={pattern}
+                                onClick={(e) => {
+                                  const isMulti = e.metaKey || e.ctrlKey;
+                                  setSelectedMovementPatterns(prev => {
+                                    if (isMulti) { const next = new Set(prev); if (next.has(pattern)) next.delete(pattern); else next.add(pattern); return next; }
+                                    if (prev.size === 1 && prev.has(pattern)) return new Set();
+                                    return new Set([pattern]);
+                                  });
+                                }}
+                                className={`px-2 py-1 text-xs rounded-full transition-colors cursor-pointer ${
+                                  isSelected
+                                    ? "bg-teal-500 text-white"
+                                    : "bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-200 dark:hover:bg-zinc-700"
+                                }`}
+                              >
+                                {pattern} ({count.toLocaleString()})
+                              </button>
+                            );
+                          })}
+                        </div>
+                    </div>
+                  )}
+                </div>
 
                 {/* Assessors and Reviewers, shown side by side */}
                 {isSingleSpecies && singleSpecies ? (
@@ -3390,22 +3393,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
               </svg>
             </div>
-            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
-              <button
-                onClick={() => {
-                  clearAllFiltersAndTaxa();
-                  setShowOnlyStarred(false);
-                  setExpandedThreat(null);
-                }}
-                title="Reset all filters and the selected taxon"
-                className="px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
-              >
-                <svg className="w-3.5 h-3.5 md:w-4 md:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-                <span className="hidden sm:inline">Clear all</span>
-              </button>
-            )}
             {pinnedSpecies.length > 0 && (
               <button
                 onClick={() => setShowOnlyStarred(!showOnlyStarred)}
@@ -3651,13 +3638,22 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 </button>
               ));
             })()}
-            <span className="ml-auto text-sm md:text-base font-semibold text-zinc-700 dark:text-zinc-300 tabular-nums flex items-center gap-2">
-              {speciesLoading && totalFiltered === 0 && !singleSpeciesPreview ? (
-                <Spinner className="h-4 w-4" />
-              ) : (
-                <>{totalFiltered.toLocaleString()} species</>
-              )}
-            </span>
+            {(selectedTaxa.size > 0 || selectedSubgroups.size > 0 || selectedCategories.size > 0 || selectedYearRanges.size > 0 || selectedAssessmentYears.size > 0 || selectedDescribedYears.size > 0 || selectedObsRanges.size > 0 || selectedCountries.size > 0 || selectedSystems.size > 0 || endemicsOnly || selectedGrowthForms.size > 0 || selectedPopulationTrends.size > 0 || selectedMovementPatterns.size > 0 || selectedThreats.size > 0 || selectedAssessors.size > 0 || selectedReviewers.size > 0 || showOnlyStarred || exactFilters.outdated || exactFilters.minObs != null || exactFilters.maxObs != null || exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null || exactFilters.minDescribedYear != null || exactFilters.maxDescribedYear != null) && (
+              <button
+                onClick={() => {
+                  clearAllFiltersAndTaxa();
+                  setShowOnlyStarred(false);
+                  setExpandedThreat(null);
+                }}
+                title="Reset all filters and the selected taxon"
+                className="ml-auto px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"
+              >
+                <svg className="w-3.5 h-3.5 md:w-4 md:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                <span className="hidden sm:inline">Clear all</span>
+              </button>
+            )}
             {!isNewAssessments && (neCount > 0 || neBlockedForAll) && (
               <button
                 disabled={neBlockedForAll}
@@ -3673,7 +3669,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                     return next;
                   });
                 }}
-                className={`px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
+                className={`ml-auto px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 ${
                   neBlockedForAll
                     ? "bg-white text-zinc-400 border border-zinc-200 opacity-60 cursor-not-allowed dark:bg-zinc-800 dark:text-zinc-500 dark:border-zinc-700"
                     : selectedCategories.has("NE")

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3142,6 +3142,15 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             </button>
             {moreFiltersOpen && (
               <div className="px-3 md:px-4 pb-3 md:pb-4 pt-3 md:pt-4 border-t border-zinc-200 dark:border-zinc-800 flex flex-col gap-3">
+                {/* Country map + Threats — moved here from the primary view (Charts row
+                    2) so that row stays focused on Conservation Status / Years Since
+                    Assessed / Geospatial GBIF Records; these still filter live like
+                    every other control on this page, just tucked a click away. */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  {countryMapCard}
+                  {threatsCard}
+                </div>
+
                 {/* Realm */}
                 <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
                   <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Realm</span>
@@ -3297,15 +3306,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                       </div>
                   </div>
                 )}
-
-                {/* Country map + Threats — moved here from the primary view (Charts row
-                    2) so that row stays focused on Conservation Status / Years Since
-                    Assessed / Geospatial GBIF Records; these still filter live like
-                    every other control on this page, just tucked a click away. */}
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                  {countryMapCard}
-                  {threatsCard}
-                </div>
 
                 {/* Assessors and Reviewers, shown side by side */}
                 {isSingleSpecies && singleSpecies ? (


### PR DESCRIPTION
## Summary

- Country map and Threats chart previously rendered directly in the primary view for every taxon (Mammals, Carnivora, All Species, etc, via "Charts row 2"), pushing the species table further down the page.
- Moved them into the existing "More Filters" collapsible instead, at the top (ahead of the pill-style filters Realm/Trend/Movement, and Assessors/Reviewers) — still fully interactive/filtering, just a click away rather than always visible.
- Realm, Trend, and Movement now sit side by side as a 3-column grid instead of three stacked full-width rows (Growth Form, conditional/plants-fungi-only, stays its own row above them).
- Only affects reassessments mode (Country + Threats + this reorder). New-assessments mode's row (Country + Year Described + Geospatial GBIF Records) is unchanged, since More Filters is already hidden there.
- The true landing page (nothing selected, just the Taxonomic Group summary table) already showed no charts and is untouched.
- Folded `selectedCountries`/`endemicsOnly` into the "N active" badge on the More Filters button, since an active country filter would otherwise be invisible while the panel is collapsed.
- Renamed "Geospatial GBIF Records" → "GBIF Records" everywhere (shorter, same meaning).
- Added a comma to the filtered-count stat card copy — "X matching filters, of Y total" — since without it, "matching filters of Y total" can misread as one phrase where "of Y total" attaches to "filters" rather than back to the count.
- Dropped the "N species" count from the row above the species table — it duplicated the taxon stat card's count just above it — and put "Clear all" in that now-empty right-pinned slot instead of its old position next to the search box.
- (Tried and reverted: a more descriptive "More Filters: Country, Threats, and more" button label for discoverability. Decided plain "More Filters" reads better.)

## Screenshots

Mammals, no filters — More Filters collapsed, no redundant count, no Clear all (nothing to clear):

![collapsed](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-426-country-threats-more-filters/01-collapsed-v4.png)

Mammals, More Filters expanded — Country map + Threats first, then Realm/Trend/Movement as 3 columns, then Assessors/Reviewers:

![expanded](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-426-country-threats-more-filters/02-expanded-v4.png)

Mammals + Threatened filter — Clear all pinned to the right edge, no duplicate species count:

![filtered](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-426-country-threats-more-filters/04-filtered-clearall.png)

Mobile, More Filters expanded — Realm/Trend/Movement stack to one column, Clear all still pinned right (icon-only):

![mobile](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-426-country-threats-more-filters/03-mobile-v3.png)

## Test plan

- [x] Typecheck passes
- [x] Verified in browser: true landing page unchanged
- [x] Verified in browser: Mammals + All Species — Country/Threats gone from primary view, appear correctly inside More Filters when expanded, in the reordered position (Country/Threats → Realm/Trend/Movement 3-col → Assessors/Reviewers)
- [x] Verified in browser: clicking a Threats bar inside More Filters still filters the table, and the collapsed "More Filters" button shows "1 active"
- [x] Verified in browser: new-assessments (Unassessed) mode unaffected, "GBIF Records" rename applied there too
- [x] Verified at mobile width (390px): Country + Threats stack to one column inside More Filters; Realm/Trend/Movement stack to one column; Clear all still right-pinned
- [x] Verified in browser: filtered-count stat card now reads "X matching filters, of Y total"
- [x] Verified in browser: no-filter state shows neither species count nor Clear all; filtered state shows Clear all pinned right, no redundant count
- [x] No console errors