### PR TITLE
Zoom the By Country map in one level by default

### DIFF
--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -266,7 +266,7 @@ interface WorldMapProps {
 }
 
 const DEFAULT_CENTER: [number, number] = [10, 10];
-const DEFAULT_ZOOM = 1.0;
+const DEFAULT_ZOOM = 1.5;
 const MIN_ZOOM = 1.0;
 const MAX_ZOOM = 8.0;
 


### PR DESCRIPTION
## Summary

The world map in the **By Country** view opened too zoomed out, leaving a lot of empty canvas around the continents. This bumps the map's default zoom in by one level so the map fills the frame on load.

- `DEFAULT_ZOOM` in `WorldMap.tsx` goes from `1.0` → `1.5`. That's exactly one step of the on-map `+`/`−` zoom controls (they use a 1.5× factor), i.e. "one level zoomed in."
- `MIN_ZOOM` stays at `1.0`, so users can still zoom back out to the fuller view, and the reset button returns to the new `1.5` default.

## Test plan

- Browser drive-through with Playwright against the local dev server: switched the View dropdown to **By Country** and confirmed the map now renders zoomed in, filling the frame edge-to-edge (240 country paths rendered, no console errors from app code).
- Verified the reset-zoom control still returns to the default and `+`/`−` behave as before.

> Note: verification screenshots couldn't be uploaded to the R2 `pr-assets` bucket from this environment (no R2 credentials available), so none are embedded here per the repo's "no screenshots in the repo" convention. The change was still verified visually in a real browser.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8zpgLvWiebhm4fAHShe8g)_