### PR TITLE
Fix weekly data sync: skip DB/STAR-dependent phases 14-15 under --skip-redlist

### DIFF
--- a/.github/workflows/weekly-sync.yml
+++ b/.github/workflows/weekly-sync.yml
@@ -4,9 +4,11 @@ name: Weekly data sync
 # derived taxa-summary stats (incl. isOutdated, which drifts stale over time
 # even when no new data has arrived — see src/lib/outdated.ts) on a schedule,
 # without needing the IUCN Postgres DB (see scripts/sync.ts's --skip-redlist:
-# only phase 1, fetch-redlist-species, needs DB access). The Red List data
-# itself stays on its own manual ~6-month refresh cadence (README § Data Sync
-# Pipeline) — this job only refreshes everything downstream of it.
+# skips phase 1, fetch-redlist-species, plus phases 14-15, upload-range-maps/
+# upload-aoh-maps, which need that same DB access or local-only STAR pipeline
+# output). The Red List data itself stays on its own manual ~6-month refresh
+# cadence (README § Data Sync Pipeline) — this job only refreshes everything
+# downstream of it.
 #
 # Weekly (not monthly) so the resulting PR lands Sunday night and can be
 # reviewed/merged Monday morning. Note the CoL backbone (phases 7-9) refetches

--- a/app/scripts/sync.ts
+++ b/app/scripts/sync.ts
@@ -15,8 +15,8 @@
  *   Phase 11: build-synonym-index   (→ synonym-index.parquet, search)
  *   Phase 12: build-col-taxon-ids   (taxonomy tree + backbone.parquet → src/config/col-taxon-ids.json, committed to git)
  *   Phase 13: build-taxa-summary    (CSVs + CoL artifacts → taxa-summary.json, incl. col counts)
- *   Phase 14: upload-range-maps     (IUCN DB → R2, skips existing)
- *   Phase 15: upload-aoh-maps       (STAR GeoTIFFs → R2, skips existing)
+ *   Phase 14: upload-range-maps     (IUCN DB → R2, skips existing; skipped by --skip-redlist)
+ *   Phase 15: upload-aoh-maps       (STAR GeoTIFFs → R2, skips existing; skipped by --skip-redlist)
  *
  * Prerequisites:
  *   1. DB connectivity to IUCN Postgres — primary is a local restore from
@@ -27,12 +27,16 @@
  * Usage:
  *   npx tsx scripts/sync.ts                     # Full sync, all taxa
  *   npx tsx scripts/sync.ts mammalia aves        # Specific taxa only
- *   npx tsx scripts/sync.ts --skip-redlist       # Skip phase 1 (no DB access needed) —
+ *   npx tsx scripts/sync.ts --skip-redlist       # Skip every DB-dependent phase (1, 14) —
  *                                                # reuses data/redlist/*.csv from the last
- *                                                # fetch. See .github/workflows/weekly-sync.yml,
- *                                                # which runs on a schedule without DB
- *                                                # credentials, refreshing everything phase 1
- *                                                # feeds EXCEPT the Red List data itself.
+ *                                                # fetch, and leaves range maps untouched.
+ *                                                # Phase 15 (AOH maps) is skipped too, since
+ *                                                # it depends on local STAR pipeline output
+ *                                                # that only exists on the same machine. See
+ *                                                # .github/workflows/weekly-sync.yml, which
+ *                                                # runs on a schedule with no DB credentials
+ *                                                # and no STAR data, refreshing everything
+ *                                                # phase 1/14/15 feed EXCEPT those themselves.
  */
 
 import * as fs from "fs";
@@ -65,7 +69,7 @@ async function main() {
   console.log("sync: Full CSV pipeline");
   console.log("=".repeat(60));
   console.log(`Taxa: ${taxaFilter ? taxaFilter.join(", ") : "all"}`);
-  if (skipRedlist) console.log("Phase 1 (fetch-redlist-species): skipped (--skip-redlist)");
+  if (skipRedlist) console.log("Phases 1, 14, 15 (DB/STAR-dependent): skipped (--skip-redlist)");
   console.log();
 
   const startTime = Date.now();
@@ -76,10 +80,11 @@ async function main() {
   try {
     logger.log("sync_start", { taxa: taxaFilter ?? "all", skipRedlist });
 
-    // Phase 1: Red List — the only phase needing IUCN Postgres access. Skippable
-    // for schedule-driven refreshes (e.g. CI, which never has DB credentials)
-    // that only need to pick up new GBIF/CoL data against the existing Red List
-    // snapshot, not a fresh DB pull (that's a separate, manual, ~6-monthly step).
+    // Phase 1: Red List — needs IUCN Postgres access. Skippable for schedule-driven
+    // refreshes (e.g. CI, which never has DB credentials) that only need to pick up
+    // new GBIF/CoL data against the existing Red List snapshot, not a fresh DB pull
+    // (that's a separate, manual, ~6-monthly step). --skip-redlist also skips phases
+    // 14-15 below, which need the same DB access (14) or local-only STAR data (15).
     if (!skipRedlist) {
       console.log("Phase 1: fetch-redlist-species");
       console.log("═".repeat(60));
@@ -152,15 +157,18 @@ async function main() {
     console.log("═".repeat(60));
     await buildTaxaSummary();
 
-    // Phase 14: Upload range maps to R2
-    console.log("\nPhase 14: upload-range-maps");
-    console.log("═".repeat(60));
-    await uploadRangeMaps({ taxa: taxaFilter, logger });
+    // Phases 14-15: uploadRangeMaps needs the same IUCN Postgres access as phase 1;
+    // uploadAohMaps needs local STAR pipeline output that only exists on this machine.
+    // Neither is reachable from CI, so both are skipped alongside phase 1.
+    if (!skipRedlist) {
+      console.log("\nPhase 14: upload-range-maps");
+      console.log("═".repeat(60));
+      await uploadRangeMaps({ taxa: taxaFilter, logger });
 
-    // Phase 15: Upload AOH maps to R2
-    console.log("\nPhase 15: upload-aoh-maps");
-    console.log("═".repeat(60));
-    await uploadAohMaps({ taxa: taxaFilter, logger });
+      console.log("\nPhase 15: upload-aoh-maps");
+      console.log("═".repeat(60));
+      await uploadAohMaps({ taxa: taxaFilter, logger });
+    }
 
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(0);
     const minutes = Math.floor(Number(elapsed) / 60);


### PR DESCRIPTION
## Summary
- The weekly-sync CI job's first live run failed on **Phase 14: upload-range-maps** (`Missing R2_MAPS_BUCKET_NAME`), after ~5h22m of otherwise-successful work (phases 2-13). See run [30219770847](https://github.com/shaneweisz/redlist-dashboard/actions/runs/30219770847).
- The missing secret is a symptom, not the root cause: Phase 14 (`upload-range-maps.ts`) opens a live connection to the IUCN Postgres DB, which the weekly-sync job deliberately never has credentials for (that's the entire reason `--skip-redlist` exists — see PR #370). Phase 15 (`upload-aoh-maps.ts`) similarly depends on local STAR pipeline GeoTIFF output (`/scratch/sw984/star/...`) that only exists on the machine that ran it.
- PR #207 added phases 14-15 to `sync.ts` without extending `--skip-redlist` to cover them, so every weekly-sync run is guaranteed to fail on Phase 14 regardless of secrets configured.
- Fix: `--skip-redlist` now also skips phases 14 and 15, alongside phase 1, since all three need resources the CI runner structurally can't have. No workflow YAML changes needed beyond an updated comment — `weekly-sync.yml` already passes `--skip-redlist`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] Reviewed diff: phases 14-15 now gated behind the same `if (!skipRedlist)` as phase 1; docstring/comments updated to match
- [ ] Next scheduled/manual weekly-sync run completes without a Phase 14 failure (can't verify without triggering a real ~5h run; will confirm on the next scheduled run or a manual `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)