### PR TITLE
Fix wrong species thumbnails for name-ambiguous iNat matches + cache proxy

### DIFF
--- a/app/src/app/api/inat/thumbnail/route.ts
+++ b/app/src/app/api/inat/thumbnail/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { CACHE_1H } from "@/lib/cache-headers";
+
+// Default-photo lookup for the species table's thumbnail column, keyed by
+// scientific name. Proxied (rather than called directly from the browser)
+// so repeat visits share Vercel's edge cache instead of every client hitting
+// iNaturalist directly for the same handful of species on every page load.
+
+interface InatDefaultImage {
+  squareUrl: string | null;
+  mediumUrl: string | null;
+}
+
+export async function GET(request: NextRequest) {
+  const name = request.nextUrl.searchParams.get("name");
+  if (!name) {
+    return NextResponse.json({ error: "name parameter is required" }, { status: 400 });
+  }
+
+  try {
+    // iNat's q= search is fuzzy/relevance-ranked (by observation count), not
+    // an exact lookup — per_page=10 + the exact-name filter below guards
+    // against a rare species losing the top spot to a much more commonly
+    // observed, unrelated taxon that happens to share its epithet (e.g.
+    // "Monachus monachus", the Mediterranean Monk Seal, ranks 10th behind
+    // several unrelated birds sharing "monachus").
+    const taxaResp = await fetch(
+      `https://api.inaturalist.org/v1/taxa?q=${encodeURIComponent(name)}&rank=species&per_page=10`
+    );
+    if (!taxaResp.ok) {
+      return NextResponse.json({ inatDefaultImage: null }, { headers: CACHE_1H });
+    }
+    const taxaData = await taxaResp.json();
+    const exactMatch = (taxaData.results || []).find((t: { name?: string }) => t.name === name);
+    const defaultPhoto = exactMatch?.default_photo;
+
+    const inatDefaultImage: InatDefaultImage | null = defaultPhoto
+      ? {
+          squareUrl: defaultPhoto.square_url || defaultPhoto.url || null,
+          mediumUrl: defaultPhoto.medium_url || defaultPhoto.url || null,
+        }
+      : null;
+
+    return NextResponse.json({ inatDefaultImage }, { headers: CACHE_1H });
+  } catch (error) {
+    console.error("Error fetching iNat thumbnail:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/src/app/api/inat/thumbnail/route.ts
+++ b/app/src/app/api/inat/thumbnail/route.ts
@@ -19,11 +19,21 @@ export async function GET(request: NextRequest) {
 
   try {
     // iNat's q= search is fuzzy/relevance-ranked (by observation count), not
-    // an exact lookup — per_page=10 + the exact-name filter below guards
-    // against a rare species losing the top spot to a much more commonly
-    // observed, unrelated taxon that happens to share its epithet (e.g.
-    // "Monachus monachus", the Mediterranean Monk Seal, ranks 10th behind
-    // several unrelated birds sharing "monachus").
+    // an exact lookup — per_page=10 + the match filter below guards against
+    // a rare species losing the top spot to a much more commonly observed,
+    // unrelated taxon that happens to share its epithet (e.g. "Monachus
+    // monachus", the Mediterranean Monk Seal, ranks 10th behind several
+    // unrelated birds sharing "monachus").
+    //
+    // Match on t.name OR matched_term, not just t.name: our scientific names
+    // (from the Red List) sometimes use an older/synonym spelling that
+    // differs from iNat's current accepted name — e.g. our "Caracal aurata"
+    // vs. iNat's current "Caracal auratus" (gender-agreement change). iNat's
+    // own synonym-aware search still resolves these and reports the matched
+    // synonym via matched_term, so checking it too recovers legitimate
+    // synonym matches without reopening the Monachus-style false-positive
+    // bug (matched_term for the unrelated "monachus" taxa is their own name,
+    // not the full queried binomial).
     const taxaResp = await fetch(
       `https://api.inaturalist.org/v1/taxa?q=${encodeURIComponent(name)}&rank=species&per_page=10`
     );
@@ -31,8 +41,10 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ inatDefaultImage: null }, { headers: CACHE_1H });
     }
     const taxaData = await taxaResp.json();
-    const exactMatch = (taxaData.results || []).find((t: { name?: string }) => t.name === name);
-    const defaultPhoto = exactMatch?.default_photo;
+    const match = (taxaData.results || []).find(
+      (t: { name?: string; matched_term?: string }) => t.name === name || t.matched_term === name
+    );
+    const defaultPhoto = match?.default_photo;
 
     const inatDefaultImage: InatDefaultImage | null = defaultPhoto
       ? {

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2146,21 +2146,11 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
         try {
           // Build parallel fetch list: iNat image + GBIF match check for species not in CSV
           const fetchPromises: [Promise<Response>, Promise<Response | null>] = [
+            // Proxied through our own API route (not called directly against
+            // iNaturalist) so the edge cache is shared across visitors
+            // instead of every browser re-fetching the same species fresh.
             fetch(
-              // per_page=10 + an exact-name filter below, not per_page=1 — iNat's
-              // q= search is fuzzy/relevance-ranked, not an exact lookup, and
-              // ranks by observation count. A rare species whose binomial shares
-              // an epithet with a much more commonly observed, unrelated taxon
-              // can lose the top spot badly: "Monachus monachus" (the
-              // Mediterranean Monk Seal, ~300 iNat observations) ranks 9th
-              // behind four unrelated birds sharing the epithet "monachus",
-              // one of which (Monk Parakeet, ~60k observations) was silently
-              // used as the photo. per_page=5 (matching the exact-match
-              // pattern already used in api/inat/observations and
-              // api/species/[key]/inat-top-observers) stops the wrong photo
-              // but still misses this specific case; 10 recovers it without
-              // a meaningfully larger payload.
-              `https://api.inaturalist.org/v1/taxa?q=${encodeURIComponent(s.scientific_name)}&rank=species&per_page=10`,
+              `/api/inat/thumbnail?name=${encodeURIComponent(s.scientific_name)}`,
               { signal }
             ),
             // Check GBIF match status for species missing from CSV
@@ -2174,14 +2164,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           let inatDefaultImage: InatDefaultImage | null = null;
           if (inatRes.ok) {
             const inatData = await inatRes.json();
-            const exactMatch = inatData.results?.find((t: { name?: string }) => t.name === s.scientific_name);
-            const defaultPhoto = exactMatch?.default_photo;
-            if (defaultPhoto) {
-              inatDefaultImage = {
-                squareUrl: defaultPhoto.square_url || defaultPhoto.url || null,
-                mediumUrl: defaultPhoto.medium_url || defaultPhoto.url || null,
-              };
-            }
+            inatDefaultImage = inatData.inatDefaultImage || null;
           }
 
           let gbifMatchStatus: GbifMatchStatus | null = null;

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2147,7 +2147,20 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           // Build parallel fetch list: iNat image + GBIF match check for species not in CSV
           const fetchPromises: [Promise<Response>, Promise<Response | null>] = [
             fetch(
-              `https://api.inaturalist.org/v1/taxa?q=${encodeURIComponent(s.scientific_name)}&rank=species&per_page=1`,
+              // per_page=10 + an exact-name filter below, not per_page=1 — iNat's
+              // q= search is fuzzy/relevance-ranked, not an exact lookup, and
+              // ranks by observation count. A rare species whose binomial shares
+              // an epithet with a much more commonly observed, unrelated taxon
+              // can lose the top spot badly: "Monachus monachus" (the
+              // Mediterranean Monk Seal, ~300 iNat observations) ranks 9th
+              // behind four unrelated birds sharing the epithet "monachus",
+              // one of which (Monk Parakeet, ~60k observations) was silently
+              // used as the photo. per_page=5 (matching the exact-match
+              // pattern already used in api/inat/observations and
+              // api/species/[key]/inat-top-observers) stops the wrong photo
+              // but still misses this specific case; 10 recovers it without
+              // a meaningfully larger payload.
+              `https://api.inaturalist.org/v1/taxa?q=${encodeURIComponent(s.scientific_name)}&rank=species&per_page=10`,
               { signal }
             ),
             // Check GBIF match status for species missing from CSV
@@ -2161,7 +2174,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           let inatDefaultImage: InatDefaultImage | null = null;
           if (inatRes.ok) {
             const inatData = await inatRes.json();
-            const defaultPhoto = inatData.results?.[0]?.default_photo;
+            const exactMatch = inatData.results?.find((t: { name?: string }) => t.name === s.scientific_name);
+            const defaultPhoto = exactMatch?.default_photo;
             if (defaultPhoto) {
               inatDefaultImage = {
                 squareUrl: defaultPhoto.square_url || defaultPhoto.url || null,


### PR DESCRIPTION
## Summary

Fixes a wrong-thumbnail bug reported live on a Vercel preview: **Monachus monachus (Mediterranean Monk Seal)** was showing a bird photo instead of a seal photo in the species table.

**Root cause**: the per-species iNaturalist thumbnail fetch (`RedListView.tsx`) searched iNat's fuzzy `taxa?q=` name endpoint with `per_page=1` and blindly took the first result's photo. That endpoint ranks by relevance/observation popularity, not exact name match — several unrelated, more-observed taxa share the epithet "monachus" (Monk Parakeet, Cinereous Vulture, Hooded Vulture, etc.), and `Monachus monachus` itself ranks 10th. With `per_page=1`, the seal's actual entry was never even in the response.

This is a systemic issue, not specific to this one species — any species sharing a name epithet with a more "popular" unrelated iNat taxon was at risk of the same mismatch. Two sibling endpoints in this codebase (`api/inat/observations/route.ts`, `api/species/[key]/inat-top-observers/route.ts`) already guard against exactly this by fetching more candidates and filtering for an exact name match — this fetch was the one place that pattern was missing.

## Fix

- Bumped `per_page` from 1 to 10 (Monachus monachus needs at least 10 to appear).
- Added a match filter (`t.name === name || t.matched_term === name`) before reading `default_photo`, instead of taking `results[0]` unconditionally.
  - `t.name` alone (a plain exact-match, same pattern as the two sibling endpoints) turned out to be too strict on its own — see the regression below. `matched_term` is iNat's own record of what it matched the query against, which also covers taxonomic synonyms.

**Caught during review — a regression from the first version of this fix**: matching only on `t.name` broke species whose Red List scientific name is an older/synonym spelling that differs from iNat's *current* accepted name. E.g. our data has "Caracal aurata" (African Golden Cat); iNat's current accepted name is "Caracal auratus" (a gender-agreement change) — `t.name` never matches, so the species lost its thumbnail entirely. iNat's search already resolves this synonym internally and reports it via a `matched_term` field on the result (`matched_term: "Caracal aurata"` for that taxon), so the fix now checks `matched_term` too. Verified this doesn't reopen the Monachus false-positive: none of the unrelated "monachus" taxa have `matched_term` equal to the full queried binomial, only the real seal match does.

## Also in this PR: proxy the thumbnail lookup through an edge-cached API route

The original per-species thumbnail fetch called `api.inaturalist.org` directly from the browser — unlike the two sibling iNat lookups, which already go through a Next.js API route with a Vercel edge cache. That meant every visitor's browser re-fetched the same species fresh, with no sharing across sessions.

Added `src/app/api/inat/thumbnail/route.ts`: same match lookup, now server-side, with a 1h edge cache (`CACHE_1H`, matching `api/species/[key]/inat-top-observers`). Request *count* from the client is unchanged (still one call per visible species), but repeat views of the same species — across pagination, re-visits, or different visitors — are now served from Vercel's CDN instead of hitting iNaturalist again. `RedListView.tsx` now calls `/api/inat/thumbnail?name=...` and reads the already-resolved `inatDefaultImage` from the response, rather than re-doing the match filtering client-side.

## Test plan

- [x] Typecheck passes
- [x] Lint passes on the changed files
- [x] Full test suite passes (708 tests)
- [x] Verified in browser against the exact reported URL (mammals, CR/EN/VU, African countries, threat code 8, species=13653) — Monachus monachus shows its correct seal thumbnail.
- [x] Cross-checked the iNaturalist API response directly: the match for "Monachus monachus" returns photo id `446367736`, exactly what renders in the app (both via direct API and via the new proxy route).
- [x] Caught the `Caracal aurata` synonym regression via a follow-up screenshot review, root-caused it against the raw iNat API response, fixed with the `matched_term` check, and re-verified: spot-checked all 9 species visible in the reported screenshot (Antarctic Fur Seal, Walia Ibex, African Wild Dog, Lion, Black-footed Cat, Seychelles Sheath-tailed Bat, African Golden Cat, Mediterranean Monk Seal, Malagasy Giant Jumping Rat) directly against the proxy route — all resolve correctly — plus a browser screenshot confirming African Golden Cat's thumbnail is back.
- [x] All 52 visible species' thumbnail requests routed through the new proxy, no failed requests, no console errors.

## Screenshots

Mediterranean Monk Seal — correct seal thumbnail (was showing a bird):

![Mediterranean Monk Seal now showing the correct seal thumbnail](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-433-inat-thumbnail-fix/01-monachus-row-fixed.png)

African Golden Cat — thumbnail restored after the `matched_term` fix (this regressed to blank partway through the PR, caught before merge):

![African Golden Cat thumbnail restored](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-433-inat-thumbnail-fix/02-caracal-aurata-fixed.png)
