### PR TITLE
Criteria/Threats/Habitat: bar-chart + inline-pill drilldown, multi-select fixes, renames

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -49,13 +49,16 @@ th.sticky {
    accessibility layer puts tabIndex={0} on that SVG so keyboard users can
    reach the tooltip, but that also makes every mouse click focus it, and the
    browser's default focus ring then outlines the whole chart until the user
-   clicks elsewhere. Suppress it on plain click, keep it on keyboard focus. */
-svg.recharts-surface:focus {
-  outline: none;
-}
-svg.recharts-surface:focus-visible {
-  outline: 2px solid #6366f1;
-  outline-offset: -2px;
+   clicks elsewhere. Unconditional (not just :focus-visible) and !important,
+   since browsers vary on when they treat a click as "focus-visible" for an
+   SVG with a manually-set tabIndex -- Safari in particular still drew the
+   ring on a plain mouse click even with a :focus-visible-scoped rule.
+   -webkit-tap-highlight-color covers the separate translucent tap-highlight
+   box mobile Safari draws on touch, which outline:none does not touch. */
+svg.recharts-surface,
+svg.recharts-surface * {
+  outline: none !important;
+  -webkit-tap-highlight-color: transparent;
 }
 
 /* Shape marker icons: strip default leaflet-div-icon styles */

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -45,6 +45,19 @@ th.sticky {
   box-shadow: 2px 0 4px -2px rgba(0, 0, 0, 0.3);
 }
 
+/* FilterBarChart bars are clickable divs wrapping a recharts SVG; recharts'
+   accessibility layer puts tabIndex={0} on that SVG so keyboard users can
+   reach the tooltip, but that also makes every mouse click focus it, and the
+   browser's default focus ring then outlines the whole chart until the user
+   clicks elsewhere. Suppress it on plain click, keep it on keyboard focus. */
+svg.recharts-surface:focus {
+  outline: none;
+}
+svg.recharts-surface:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: -2px;
+}
+
 /* Shape marker icons: strip default leaflet-div-icon styles */
 .shape-marker-icon {
   background: none !important;

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -1257,12 +1257,12 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   }, [selectedObsRanges]);
 
   // Bucket a species' REASSESSMENT count (total assessments minus the first,
-  // original one) into a chart-bar label. 5+ collapses the long tail (a
+  // original one) into a chart-bar label. 4+ collapses the long tail (a
   // handful of species have 8-9 historical assessments, i.e. 7-8
   // reassessments) into one bar.
   const assessmentCountBucket = useCallback((count: number | null | undefined): string => {
     const reassessments = (count ?? 1) - 1;
-    return reassessments >= 5 ? "5+" : String(reassessments);
+    return reassessments >= 4 ? "4+" : String(reassessments);
   }, []);
 
   // Helper to check if species matches the number-of-assessments filter (#423 item 1)
@@ -1801,10 +1801,9 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       { range: "1", shortRange: "1", count: 0 },
       { range: "2", shortRange: "2", count: 0 },
       { range: "3", shortRange: "3", count: 0 },
-      { range: "4", shortRange: "4", count: 0 },
-      { range: "5+", shortRange: "5+", count: 0 },
+      { range: "4+", shortRange: "4+", count: 0 },
     ];
-    const byBucket: Record<string, number> = { "0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5+": 5 };
+    const byBucket: Record<string, number> = { "0": 0, "1": 1, "2": 2, "3": 3, "4+": 4 };
     taxaFilteredSpecies.forEach(s => {
       if (s.category === "NE") return;
       if (!matchesSearch(s)) return;
@@ -2755,7 +2754,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // "1+" shortcut (#423 item 1): one click selects every bucket except "0",
   // flagging species that have been reassessed at least once. Toggling off
   // clears the selection entirely, mirroring the Outdated shortcut.
-  const ONE_PLUS_BUCKETS = ["1", "2", "3", "4", "5+"];
+  const ONE_PLUS_BUCKETS = ["1", "2", "3", "4+"];
   const isOnePlusSelected = ONE_PLUS_BUCKETS.every(b => selectedAssessmentCounts.has(b)) && selectedAssessmentCounts.size === ONE_PLUS_BUCKETS.length;
   const handleOnePlusClick = () => {
     setSelectedAssessmentCounts(isOnePlusSelected ? new Set() : new Set(ONE_PLUS_BUCKETS));
@@ -3054,9 +3053,9 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     renderPills: (rawCode: string) => React.ReactNode,
     chartProps: Omit<React.ComponentProps<typeof FilterBarChart>, "data">,
     // Per-row pixel height. Default (22) is Threats/Habitat's original sizing;
-    // Criteria passes 38 to match Number of Reassessments' bar thickness, since
-    // that chart sits fixed at 200px for its always-5 buckets (200/5 = 40px
-    // slot, minus FilterBarChart's internal 5px top/bottom margins = 38px).
+    // Criteria passes 32 to match Number of Reassessments' bar thickness, since
+    // that chart sits fixed at 170px for its always-5 buckets (170/5 = 34px
+    // slot, minus FilterBarChart's internal 5px top/bottom margins = 32px).
     rowHeight = 22
   ): React.ReactNode {
     const segments: { bars: DrilldownBarDatum[]; pillsAfter: string | null }[] = [];
@@ -3595,7 +3594,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               rightMargin: 85,
               labelFormatter: (code: string) => CRITERIA_CATEGORIES.find(c => c.code === code)?.label ?? code,
             },
-            38
+            32
           )
         ) : (
           <div style={{ height: 90 }} className="flex items-center justify-center"><span className="text-sm text-zinc-400 dark:text-zinc-500">No criteria data</span></div>
@@ -4110,7 +4109,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                           1+
                         </button>
                       </div>
-                      <div style={{ height: 240 }} className="flex items-center justify-center">
+                      <div style={{ height: 170 }} className="flex items-center justify-center">
                         {speciesLoading && assessedSpecies.length === 0 ? (
                           <Spinner />
                         ) : isSingleSpecies && singleSpecies ? (

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -4028,11 +4028,11 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           )}
 
           {/* Country + Threats are always visible, alongside Charts row 1
-              above — everything past that (Assessment Criteria/Number of Assessments,
-              Realm/Movement/Trend, Habitat/Assessors-Reviewers, Growth Form)
-              lives behind the "More Filters" toggle below. No
-              independently-scrollable panel here anymore — nested
-              scrollbars (the panel's own, inside the page's) read as
+              above — everything past that (Growth Form, Assessment
+              Criteria/Number of Assessments, Realm/Movement/Trend,
+              Habitat/Assessors-Reviewers) lives behind the "More Filters"
+              toggle below. No independently-scrollable panel here anymore
+              — nested scrollbars (the panel's own, inside the page's) read as
               confusing, so this reverts to plain click-to-expand instead. */}
           {!isNewAssessments && (
             <>
@@ -4061,6 +4061,74 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
 
           {!isNewAssessments && moreFiltersOpen && (
             <>
+                {/* Growth Form (plants/fungi only) */}
+                {(() => {
+                  if (speciesLoading && assessedSpecies.length === 0) {
+                    return (
+                      <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
+                        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Growth</span>
+                        <Spinner className="h-4 w-4" />
+                      </div>
+                    );
+                  }
+                  // Compute growth form counts cross-filtered (exclude own filter)
+                  const gfCounts: Record<string, number> = {};
+                  taxaFilteredSpecies.forEach(s => {
+                    if (!s.growth_forms?.length) return;
+                    if (!matchesSearch(s)) return;
+                    if (selectedCategories.size > 0 && !selectedCategories.has(s.category)) return;
+                    if (selectedCountries.size > 0 && !s.countries.some(c => selectedCountries.has(c))) return;
+                    if (s.category !== "NE" && selectedYearRanges.size > 0 && !matchesYearRangeFilter(s.assessment_date, selectedYearRanges)) return;
+                    if (s.category !== "NE" && selectedAssessmentYears.size > 0 && !matchesAssessmentYearFilter(s.assessment_date, selectedAssessmentYears)) return;
+                    if (selectedObsRanges.size > 0 && !matchesObsRangeFilter(s.gbif_occurrence_count, selectedObsRanges)) return;
+                    if (selectedAssessmentCounts.size > 0 && !matchesAssessmentCountFilter(s.assessment_count, selectedAssessmentCounts)) return;
+                    if (selectedSystems.size > 0 && !s.systems?.some(sys => selectedSystems.has(sys))) return;
+                    if (selectedPopulationTrends.size > 0 && (!s.population_trend || !selectedPopulationTrends.has(s.population_trend))) return;
+                    if (selectedMovementPatterns.size > 0 && (!s.movement_pattern || !selectedMovementPatterns.has(s.movement_pattern))) return;
+                    if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
+                    if (selectedCriteria.size > 0 && !parseCriteriaCodes(s.criteria).some(code => Array.from(selectedCriteria).some(sel => code === sel || code.startsWith(sel)))) return;
+                    if (endemicsOnly && s.countries.length !== 1) return;
+                    if (!matchesAssessorsFilter(s)) return;
+                    if (!matchesHabitatFilter(s)) return;
+                    if (!matchesReviewersFilter(s)) return;
+                    for (const gf of s.growth_forms) {
+                      gfCounts[gf] = (gfCounts[gf] || 0) + 1;
+                    }
+                  });
+                  const sorted = Object.entries(gfCounts).sort((a, b) => b[1] - a[1]);
+                  if (sorted.length === 0) return null;
+                  return (
+                    <div className="flex items-start gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
+                      <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20 pt-1">Growth</span>
+                      <div className="flex flex-wrap gap-1.5">
+                        {sorted.map(([gf, count]) => {
+                          const isSelected = selectedGrowthForms.has(gf);
+                          return (
+                            <button
+                              key={gf}
+                              onClick={(e) => {
+                                const isMulti = e.metaKey || e.ctrlKey;
+                                setSelectedGrowthForms(prev => {
+                                  if (isMulti) { const next = new Set(prev); if (next.has(gf)) next.delete(gf); else next.add(gf); return next; }
+                                  if (prev.size === 1 && prev.has(gf)) return new Set();
+                                  return new Set([gf]);
+                                });
+                              }}
+                              className={`px-2 py-1 text-xs rounded-full transition-colors cursor-pointer ${
+                                isSelected
+                                  ? "bg-lime-500 text-white"
+                                  : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                              }`}
+                            >
+                              {gf} ({count.toLocaleString()})
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })()}
+
                 {/* Assessment Criteria alongside Number of Assessments — a row, not a
                     stack (previously stacked in Habitat's right column; moved
                     out once Habitat started pairing with Assessors/Reviewers
@@ -4277,74 +4345,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                     />
                   )}
                 </div>
-
-                {/* Growth Form (plants/fungi only) */}
-                {(() => {
-                  if (speciesLoading && assessedSpecies.length === 0) {
-                    return (
-                      <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
-                        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Growth</span>
-                        <Spinner className="h-4 w-4" />
-                      </div>
-                    );
-                  }
-                  // Compute growth form counts cross-filtered (exclude own filter)
-                  const gfCounts: Record<string, number> = {};
-                  taxaFilteredSpecies.forEach(s => {
-                    if (!s.growth_forms?.length) return;
-                    if (!matchesSearch(s)) return;
-                    if (selectedCategories.size > 0 && !selectedCategories.has(s.category)) return;
-                    if (selectedCountries.size > 0 && !s.countries.some(c => selectedCountries.has(c))) return;
-                    if (s.category !== "NE" && selectedYearRanges.size > 0 && !matchesYearRangeFilter(s.assessment_date, selectedYearRanges)) return;
-                    if (s.category !== "NE" && selectedAssessmentYears.size > 0 && !matchesAssessmentYearFilter(s.assessment_date, selectedAssessmentYears)) return;
-                    if (selectedObsRanges.size > 0 && !matchesObsRangeFilter(s.gbif_occurrence_count, selectedObsRanges)) return;
-                    if (selectedAssessmentCounts.size > 0 && !matchesAssessmentCountFilter(s.assessment_count, selectedAssessmentCounts)) return;
-                    if (selectedSystems.size > 0 && !s.systems?.some(sys => selectedSystems.has(sys))) return;
-                    if (selectedPopulationTrends.size > 0 && (!s.population_trend || !selectedPopulationTrends.has(s.population_trend))) return;
-                    if (selectedMovementPatterns.size > 0 && (!s.movement_pattern || !selectedMovementPatterns.has(s.movement_pattern))) return;
-                    if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
-                    if (selectedCriteria.size > 0 && !parseCriteriaCodes(s.criteria).some(code => Array.from(selectedCriteria).some(sel => code === sel || code.startsWith(sel)))) return;
-                    if (endemicsOnly && s.countries.length !== 1) return;
-                    if (!matchesAssessorsFilter(s)) return;
-                    if (!matchesHabitatFilter(s)) return;
-                    if (!matchesReviewersFilter(s)) return;
-                    for (const gf of s.growth_forms) {
-                      gfCounts[gf] = (gfCounts[gf] || 0) + 1;
-                    }
-                  });
-                  const sorted = Object.entries(gfCounts).sort((a, b) => b[1] - a[1]);
-                  if (sorted.length === 0) return null;
-                  return (
-                    <div className="flex items-start gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
-                      <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20 pt-1">Growth</span>
-                      <div className="flex flex-wrap gap-1.5">
-                        {sorted.map(([gf, count]) => {
-                          const isSelected = selectedGrowthForms.has(gf);
-                          return (
-                            <button
-                              key={gf}
-                              onClick={(e) => {
-                                const isMulti = e.metaKey || e.ctrlKey;
-                                setSelectedGrowthForms(prev => {
-                                  if (isMulti) { const next = new Set(prev); if (next.has(gf)) next.delete(gf); else next.add(gf); return next; }
-                                  if (prev.size === 1 && prev.has(gf)) return new Set();
-                                  return new Set([gf]);
-                                });
-                              }}
-                              className={`px-2 py-1 text-xs rounded-full transition-colors cursor-pointer ${
-                                isSelected
-                                  ? "bg-lime-500 text-white"
-                                  : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
-                              }`}
-                            >
-                              {gf} ({count.toLocaleString()})
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  );
-                })()}
 
             </>
           )}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3044,9 +3044,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           .sort((a, b) => b.count - a.count)
       : [];
     const isDrilled = drillCat !== null && drillSubData.length > 0;
-    const drillSelectedSubLabels = drillCat ? new Set(
-      Array.from(selectedThreats).map(code => drillCat.children.find(c => c.code === code)?.label).filter(Boolean) as string[]
-    ) : new Set<string>();
     // The card content area is a constant height (independent of how many
     // categories are present) so the card never resizes — neither when the
     // filter changes the category count nor when drilling in — which would
@@ -3107,27 +3104,32 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                     </button>
                   </div>
                   <div className="min-h-0 overflow-y-auto">
-                    <div style={{ height: Math.max(80, drillSubData.length * 18 + 30) }}>
-                      <FilterBarChart
-                        data={drillSubData}
-                        dataKey="code"
-                        selectedItems={drillSelectedSubLabels}
-                        onBarClick={(data: { payload?: { code?: string } }, event: React.MouseEvent) => {
-                          const label = data.payload?.code;
-                          const child = drillCat!.children.find(c => c.label === label);
-                          if (!child) return;
-                          const isMulti = event.metaKey || event.ctrlKey;
-                          setSelectedThreats(prev => {
-                            if (isMulti) { const next = new Set(prev); if (next.has(child.code)) next.delete(child.code); else next.add(child.code); return next; }
-                            if (prev.size === 1 && prev.has(child.code)) return new Set();
-                            return new Set([child.code]);
-                          });
-                        }}
-                        barColor="#a78bfa"
-                        yAxisWidth={170}
-                        rightMargin={80}
-                        yAxisTickMaxLength={24}
-                      />
+                    <div className="flex flex-wrap gap-1.5">
+                      {drillCat!.children.map(child => {
+                        const count = threatCounts[child.code] ?? 0;
+                        if (count === 0) return null;
+                        const isSelected = selectedThreats.has(child.code);
+                        return (
+                          <button
+                            key={child.code}
+                            onClick={(e) => {
+                              const isMulti = e.metaKey || e.ctrlKey;
+                              setSelectedThreats(prev => {
+                                if (isMulti) { const next = new Set(prev); if (next.has(child.code)) next.delete(child.code); else next.add(child.code); return next; }
+                                if (prev.size === 1 && prev.has(child.code)) return new Set();
+                                return new Set([child.code]);
+                              });
+                            }}
+                            className={`px-2 py-1 text-xs rounded-full transition-colors cursor-pointer ${
+                              isSelected
+                                ? "bg-violet-500 text-white"
+                                : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                            }`}
+                          >
+                            {child.label} ({count.toLocaleString()})
+                          </button>
+                        );
+                      })}
                     </div>
                   </div>
                 </div>
@@ -3168,9 +3170,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           .sort((a, b) => b.count - a.count)
       : [];
     const isDrilled = drillCat !== null && drillSubData.length > 0;
-    const drillSelectedSubLabels = drillCat ? new Set(
-      Array.from(selectedHabitat).map(code => drillCat.children.find(c => c.code === code)?.label).filter(Boolean) as string[]
-    ) : new Set<string>();
     const HABITAT_AREA_HEIGHT = 266;
     const chartHeight = Math.max(150, pagedHabitatBarData.length * 18 + 30);
     const loading = speciesLoading && assessedSpecies.length === 0;
@@ -3402,27 +3401,32 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                     </button>
                   </div>
                   <div className="min-h-0 overflow-y-auto">
-                    <div style={{ height: Math.max(80, drillSubData.length * 18 + 30) }}>
-                      <FilterBarChart
-                        data={drillSubData}
-                        dataKey="code"
-                        selectedItems={drillSelectedSubLabels}
-                        onBarClick={(data: { payload?: { code?: string } }, event: React.MouseEvent) => {
-                          const label = data.payload?.code;
-                          const child = drillCat!.children.find(c => c.label === label);
-                          if (!child) return;
-                          const isMulti = event.metaKey || event.ctrlKey;
-                          setSelectedHabitat(prev => {
-                            if (isMulti) { const next = new Set(prev); if (next.has(child.code)) next.delete(child.code); else next.add(child.code); return next; }
-                            if (prev.size === 1 && prev.has(child.code)) return new Set();
-                            return new Set([child.code]);
-                          });
-                        }}
-                        barColor="#5eead4"
-                        yAxisWidth={170}
-                        rightMargin={80}
-                        yAxisTickMaxLength={24}
-                      />
+                    <div className="flex flex-wrap gap-1.5">
+                      {drillCat!.children.map(child => {
+                        const count = habitatCounts[child.code] ?? 0;
+                        if (count === 0) return null;
+                        const isSelected = selectedHabitat.has(child.code);
+                        return (
+                          <button
+                            key={child.code}
+                            onClick={(e) => {
+                              const isMulti = e.metaKey || e.ctrlKey;
+                              setSelectedHabitat(prev => {
+                                if (isMulti) { const next = new Set(prev); if (next.has(child.code)) next.delete(child.code); else next.add(child.code); return next; }
+                                if (prev.size === 1 && prev.has(child.code)) return new Set();
+                                return new Set([child.code]);
+                              });
+                            }}
+                            className={`px-2 py-1 text-xs rounded-full transition-colors cursor-pointer ${
+                              isSelected
+                                ? "bg-teal-500 text-white"
+                                : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                            }`}
+                          >
+                            {child.label} ({count.toLocaleString()})
+                          </button>
+                        );
+                      })}
                     </div>
                   </div>
                 </div>
@@ -3497,6 +3501,72 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       ))}
     </React.Fragment>
   );
+
+  // Criteria card (#436): top-level A-E as a bar chart, same interaction as
+  // Threats/Habitat's top-level chart — a bar click both selects the code and
+  // toggles that branch's membership in expandedCriteria. Deliberately NOT
+  // sorted by count (unlike Threats/Habitat) — A-E is a standardized, widely
+  // recognized IUCN ordering, and reshuffling it by count would work against
+  // that familiarity. Deeper levels stay exactly as before: renderCriteriaLevel's
+  // recursive pill rows, unchanged — the issue's "opens pills not nested bars"
+  // ask was already true for Criteria beyond the top level.
+  const criteriaCard = (() => {
+    const criteriaLabelToCode = new Map(CRITERIA_CATEGORIES.map(c => [c.label, c.code]));
+    const criteriaBarData = CRITERIA_CATEGORIES
+      .map(({ code, label }) => ({ code: label, criteriaCode: code, count: criteriaCounts[code] ?? 0, label: (criteriaCounts[code] ?? 0).toLocaleString() }))
+      .filter(d => d.count > 0 || selectedCriteria.has(d.criteriaCode));
+    const selectedCriteriaLabels = new Set(
+      Array.from(selectedCriteria).map(code => CRITERIA_CATEGORIES.find(c => c.code === code)?.label).filter(Boolean) as string[]
+    );
+    const CRITERIA_TOP_HEIGHT = Math.max(90, criteriaBarData.length * 24 + 20);
+    const loading = speciesLoading && assessedSpecies.length === 0;
+    return (
+      <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
+        <div className="flex items-center justify-between mb-1 min-h-[24px]">
+          <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Criteria</span>
+        </div>
+        {loading ? (
+          <div style={{ height: CRITERIA_TOP_HEIGHT }} className="flex items-center justify-center"><Spinner className="h-4 w-4" /></div>
+        ) : criteriaBarData.length > 0 ? (
+          <>
+            <div style={{ height: CRITERIA_TOP_HEIGHT }}>
+              <FilterBarChart
+                data={criteriaBarData}
+                dataKey="code"
+                selectedItems={selectedCriteriaLabels}
+                onBarClick={(data: { payload?: { code?: string } }, event: React.MouseEvent) => {
+                  const label = data.payload?.code;
+                  const code = label ? criteriaLabelToCode.get(label) : undefined;
+                  if (!code) return;
+                  const isMulti = event.metaKey || event.ctrlKey;
+                  if (isMulti) {
+                    setSelectedCriteria(prev => { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; });
+                  } else {
+                    setSelectedCriteria(prev => (prev.size === 1 && prev.has(code)) ? new Set() : new Set([code]));
+                  }
+                  const node = CRITERIA_CATEGORIES.find(n => n.code === code);
+                  if (node && node.children.length > 0) {
+                    setExpandedCriteria(prev => { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; });
+                  }
+                }}
+                barColor="#6366f1"
+                yAxisWidth={100}
+                rightMargin={60}
+                yAxisTickMaxLength={14}
+              />
+            </div>
+            {CRITERIA_CATEGORIES.map(node => (
+              expandedCriteria.has(node.code) && node.children.length > 0 ? (
+                <React.Fragment key={node.code}>{renderCriteriaLevel(node.children, 1)}</React.Fragment>
+              ) : null
+            ))}
+          </>
+        ) : (
+          <div style={{ height: CRITERIA_TOP_HEIGHT }} className="flex items-center justify-center"><span className="text-sm text-zinc-400 dark:text-zinc-500">No criteria data</span></div>
+        )}
+      </div>
+    );
+  })();
 
   return (
     <div className="space-y-1 min-w-0 flex-1 flex flex-col min-h-0">
@@ -4010,40 +4080,22 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                       </div>
                     )}
 
-                    {/* Criteria — top-level A-E pills; clicking one both
-                        selects it as a filter AND expands its next level
-                        below (number -> sub-clause -> roman numeral, as deep
-                        as that branch goes — mirrors the Threats chart's
-                        category/sub-category drill-down, generalized to
-                        arbitrary depth via renderCriteriaLevel since
-                        criteria nests up to 4 levels vs. threats' 2).
-                        Cmd/ctrl-click for real multi-select — any number of
-                        branches can be drilled into and selected
-                        simultaneously (e.g. B1b(iii) AND C2a(i) together),
-                        each independently expanded via expandedCriteria (a
-                        Set, not a single "last expanded" value). A species
-                        can satisfy multiple codes under the same letter too
-                        (e.g. B1+B2, or B1a and B1b together), so selecting
-                        any code matches species with that code OR a more
-                        specific one beneath it (see parseCriteriaCodes'
-                        startsWith-based matching). */}
-                    {!isNewAssessments && (
-                      <div className="flex flex-col gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
-                        <div className="flex items-center gap-2">
-                          <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Criteria</span>
-                          {speciesLoading && assessedSpecies.length === 0 ? (
-                            <Spinner className="h-4 w-4" />
-                          ) : (
-                            renderCriteriaRow(CRITERIA_CATEGORIES, false)
-                          )}
-                        </div>
-                        {!(speciesLoading && assessedSpecies.length === 0) && CRITERIA_CATEGORIES.map(node => (
-                          expandedCriteria.has(node.code) && node.children.length > 0 ? (
-                            <React.Fragment key={node.code}>{renderCriteriaLevel(node.children, 1)}</React.Fragment>
-                          ) : null
-                        ))}
-                      </div>
-                    )}
+                    {/* Criteria — top-level A-E bar chart (see criteriaCard);
+                        clicking a bar both selects it as a filter AND expands
+                        its next level below (number -> sub-clause -> roman
+                        numeral, as deep as that branch goes) as pill rows via
+                        renderCriteriaLevel, since criteria nests up to 4
+                        levels vs. Threats/Habitat's 2. Cmd/ctrl-click for real
+                        multi-select — any number of branches can be drilled
+                        into and selected simultaneously (e.g. B1b(iii) AND
+                        C2a(i) together), each independently expanded via
+                        expandedCriteria (a Set, not a single "last expanded"
+                        value). A species can satisfy multiple codes under the
+                        same letter too (e.g. B1+B2, or B1a and B1b together),
+                        so selecting any code matches species with that code
+                        OR a more specific one beneath it (see
+                        parseCriteriaCodes' startsWith-based matching). */}
+                    {!isNewAssessments && criteriaCard}
                   </div>
                 </div>
 

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3061,11 +3061,18 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       }
     }
     if (current.length > 0) segments.push({ bars: current, pillsAfter: null });
+    // Each segment is a separate <FilterBarChart>, so without a shared xAxisMax
+    // every segment auto-scales its bars to its OWN local max count — the
+    // segment after the pills would then stretch its bars to fill the width
+    // even though they represent smaller counts than bars in the segment
+    // before it. Fix the domain to the full dataset's max so bar length stays
+    // comparable across segments, same as it was before the split existed.
+    const globalMax = data.length > 0 ? Math.max(...data.map(d => d.count)) : 0;
     return segments.map((seg, i) => (
       <React.Fragment key={i}>
         {seg.bars.length > 0 && (
           <div style={{ height: Math.max(30, seg.bars.length * 22 + 8) }}>
-            <FilterBarChart data={seg.bars} {...chartProps} />
+            <FilterBarChart data={seg.bars} xAxisMax={globalMax} {...chartProps} />
           </div>
         )}
         {seg.pillsAfter && renderPills(seg.pillsAfter)}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3232,7 +3232,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 }}
                 className={`px-1.5 py-0.5 text-[11px] rounded-full transition-colors cursor-pointer ${
                   isSelected
-                    ? "bg-teal-500 text-white"
+                    ? "bg-teal-600 text-white"
                     : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
                 }`}
               >

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -968,6 +968,13 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   const [habitatPage, setHabitatPage] = useState(0);
   const HABITAT_PAGE_SIZE = 10;
 
+  // Assessors/Reviewers chart: one merged, toggleable chart (like an earlier
+  // version of this page had) instead of two permanently side-by-side charts
+  // — halves the vertical space these together take up, at the cost of one
+  // click to see the other list. Local-only UI state, not URL-synced (same as
+  // e.g. habitatPage above) since it's a view toggle, not a filter.
+  const [assessorReviewerMode, setAssessorReviewerMode] = useState<"assessors" | "reviewers">("assessors");
+
   // Breadth/Importance/Season/Suitability dropdown menus in the Habitat card header
   // (replacing a wall of individual toggle buttons — Breadth is a single-select
   // Specialist/Generalist choice, Exclude minor a single checkbox, Season a
@@ -3014,6 +3021,46 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     </div>
   );
 
+  // Shared by Criteria/Threats/Habitat (#436 follow-up): renders a bar chart
+  // with pills inserted directly below whichever bar(s) are currently
+  // expanded, instead of a separate section below the WHOLE chart. Splits
+  // `data` into segments at each expanded item's position — one FilterBarChart
+  // per segment — with that item's pills sandwiched right after its own
+  // segment. Each segment sizes to its own bar count (no fixed height/scroll);
+  // the card just grows to fit, since drill-down height is now unpredictable
+  // (could land after any bar, not just "below everything"). Criteria can have
+  // multiple simultaneously-expanded top-level letters (Set-based), so this
+  // produces more than 2 segments in that case; Threats/Habitat only ever
+  // have one expanded category, so at most 2.
+  type DrilldownBarDatum = { code: string; rawCode: string; count: number; label: string };
+  function renderInlineDrilldown(
+    data: DrilldownBarDatum[],
+    isExpanded: (rawCode: string) => boolean,
+    renderPills: (rawCode: string) => React.ReactNode,
+    chartProps: Omit<React.ComponentProps<typeof FilterBarChart>, "data">
+  ): React.ReactNode {
+    const segments: { bars: DrilldownBarDatum[]; pillsAfter: string | null }[] = [];
+    let current: DrilldownBarDatum[] = [];
+    for (const item of data) {
+      current.push(item);
+      if (isExpanded(item.rawCode)) {
+        segments.push({ bars: current, pillsAfter: item.rawCode });
+        current = [];
+      }
+    }
+    if (current.length > 0) segments.push({ bars: current, pillsAfter: null });
+    return segments.map((seg, i) => (
+      <React.Fragment key={i}>
+        {seg.bars.length > 0 && (
+          <div style={{ height: Math.max(30, seg.bars.length * 22 + 8) }}>
+            <FilterBarChart data={seg.bars} {...chartProps} />
+          </div>
+        )}
+        {seg.pillsAfter && renderPills(seg.pillsAfter)}
+      </React.Fragment>
+    ));
+  }
+
   // Threats card — reassessments mode only (new-assessments shows Geospatial
   // GBIF Records instead, in Charts row 2). Lives in More Filters, not the
   // primary view — see the More Filters section below.
@@ -3024,121 +3071,84 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     const threatBarLabel = (count: number) =>
       `${count.toLocaleString()} (${threatTotal > 0 ? Math.round((count / threatTotal) * 100) : 0}%)`;
     // Use label as `code` field so it displays on y-axis, sorted by count desc
-    const threatBarData = THREAT_CATEGORIES
-      .map(({ code, label }) => ({ code: label, threatCode: code, count: threatCounts[code] ?? 0, label: threatBarLabel(threatCounts[code] ?? 0) }))
+    const threatBarData: DrilldownBarDatum[] = THREAT_CATEGORIES
+      .map(({ code, label }) => ({ code: label, rawCode: code, count: threatCounts[code] ?? 0, label: threatBarLabel(threatCounts[code] ?? 0) }))
       .filter(d => d.count > 0)
       .sort((a, b) => b.count - a.count);
     // selectedItems needs to use labels too for dimming
     const selectedThreatLabels = new Set(
       Array.from(selectedThreats).map(code => THREAT_CATEGORIES.find(c => c.code === code)?.label).filter(Boolean) as string[]
     );
-    // Drill-down: when a top-level category is expanded, its sub-categories
-    // appear in a split pane below the main chart (rather than expanding the
-    // card downward) so the card height stays constant — both charts share a
-    // fixed-height area and scroll internally.
-    const drillCat = expandedThreat ? THREAT_CATEGORIES.find(c => c.code === expandedThreat) ?? null : null;
-    const drillSubData = drillCat
-      ? drillCat.children
-          .map(child => ({ code: child.label, threatCode: child.code, count: threatCounts[child.code] ?? 0, label: threatBarLabel(threatCounts[child.code] ?? 0) }))
-          .filter(d => d.count > 0)
-          .sort((a, b) => b.count - a.count)
-      : [];
-    const isDrilled = drillCat !== null && drillSubData.length > 0;
-    // The card content area is a constant height (independent of how many
-    // categories are present) so the card never resizes — neither when the
-    // filter changes the category count nor when drilling in — which would
-    // otherwise bump the country map sharing this grid row. The base chart
-    // keeps its natural per-bar height and scrolls within the fixed area.
-    // 266 = the country map card's 320px height minus this card's header +
-    // padding (~54px), so both cards (and their loading skeletons) match.
-    const THREATS_AREA_HEIGHT = 266;
-    const chartHeight = Math.max(200, threatBarData.length * 18 + 30);
     const loading = speciesLoading && assessedSpecies.length === 0;
+    const renderThreatPills = (rawCode: string) => {
+      const drillCat = THREAT_CATEGORIES.find(c => c.code === rawCode);
+      if (!drillCat) return null;
+      return (
+        <div className="flex flex-wrap gap-1 pl-2 pb-1">
+          {drillCat.children.map(child => {
+            const count = threatCounts[child.code] ?? 0;
+            if (count === 0) return null;
+            const isSelected = selectedThreats.has(child.code);
+            return (
+              <button
+                key={child.code}
+                onClick={(e) => {
+                  const isMulti = e.metaKey || e.ctrlKey;
+                  setSelectedThreats(prev => {
+                    if (isMulti) { const next = new Set(prev); if (next.has(child.code)) next.delete(child.code); else next.add(child.code); return next; }
+                    if (prev.size === 1 && prev.has(child.code)) return new Set();
+                    return new Set([child.code]);
+                  });
+                }}
+                className={`px-1.5 py-0.5 text-[11px] rounded-full transition-colors cursor-pointer ${
+                  isSelected
+                    ? "bg-violet-500 text-white"
+                    : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                }`}
+              >
+                {child.label} ({count.toLocaleString()})
+              </button>
+            );
+          })}
+        </div>
+      );
+    };
     return (
       <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
         <div className="flex items-center justify-between mb-1 min-h-[24px]">
           <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Threats</span>
         </div>
-        <div style={{ height: THREATS_AREA_HEIGHT }} className="flex flex-col overflow-hidden">
-          {loading ? (
-            <div className="h-full flex items-center justify-center"><Spinner /></div>
-          ) : threatBarData.length > 0 ? (
-            <>
-              {/* Top-level categories — always visible; scrolls if it overflows the shared height */}
-              <div className="flex-1 min-h-0 overflow-y-auto">
-                <div style={{ height: chartHeight }}>
-                  <FilterBarChart
-                    data={threatBarData}
-                    dataKey="code"
-                    selectedItems={selectedThreatLabels}
-                    onBarClick={(data: { payload?: { code?: string; threatCode?: string } }, event: React.MouseEvent) => {
-                      const label = data.payload?.code;
-                      const code = label ? threatLabelToCode.get(label) : undefined;
-                      if (!code) return;
-                      const isMulti = event.metaKey || event.ctrlKey;
-                      setSelectedThreats(prev => {
-                        if (isMulti) { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; }
-                        if (prev.size === 1 && prev.has(code)) return new Set();
-                        return new Set([code]);
-                      });
-                      setExpandedThreat(prev => prev === code ? null : code);
-                    }}
-                    barColor="#8b5cf6"
-                    yAxisWidth={155}
-                    rightMargin={80}
-                    yAxisTickMaxLength={22}
-                  />
-                </div>
-              </div>
-              {/* Sub-categories of the drilled-into category — shares the fixed height */}
-              {isDrilled && (
-                <div className="shrink-0 mt-2 pt-2 border-t border-zinc-200 dark:border-zinc-800 flex flex-col" style={{ maxHeight: "50%" }}>
-                  <div className="flex items-center justify-between mb-1">
-                    <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 truncate">{drillCat!.label}</span>
-                    <button
-                      onClick={() => setExpandedThreat(null)}
-                      className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                      aria-label="Close sub-categories"
-                    >
-                      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
-                    </button>
-                  </div>
-                  <div className="min-h-0 overflow-y-auto">
-                    <div className="flex flex-wrap gap-1.5">
-                      {drillCat!.children.map(child => {
-                        const count = threatCounts[child.code] ?? 0;
-                        if (count === 0) return null;
-                        const isSelected = selectedThreats.has(child.code);
-                        return (
-                          <button
-                            key={child.code}
-                            onClick={(e) => {
-                              const isMulti = e.metaKey || e.ctrlKey;
-                              setSelectedThreats(prev => {
-                                if (isMulti) { const next = new Set(prev); if (next.has(child.code)) next.delete(child.code); else next.add(child.code); return next; }
-                                if (prev.size === 1 && prev.has(child.code)) return new Set();
-                                return new Set([child.code]);
-                              });
-                            }}
-                            className={`px-2 py-1 text-xs rounded-full transition-colors cursor-pointer ${
-                              isSelected
-                                ? "bg-violet-500 text-white"
-                                : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
-                            }`}
-                          >
-                            {child.label} ({count.toLocaleString()})
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
-              )}
-            </>
-          ) : (
-            <div className="h-full flex items-center justify-center"><span className="text-sm text-zinc-400 dark:text-zinc-500">No threat data</span></div>
-          )}
-        </div>
+        {loading ? (
+          <div style={{ height: 200 }} className="flex items-center justify-center"><Spinner /></div>
+        ) : threatBarData.length > 0 ? (
+          renderInlineDrilldown(
+            threatBarData,
+            (rawCode) => expandedThreat === rawCode,
+            renderThreatPills,
+            {
+              dataKey: "code",
+              selectedItems: selectedThreatLabels,
+              onBarClick: (data: { payload?: { code?: string } }, event: React.MouseEvent) => {
+                const label = data.payload?.code;
+                const code = label ? threatLabelToCode.get(label) : undefined;
+                if (!code) return;
+                const isMulti = event.metaKey || event.ctrlKey;
+                setSelectedThreats(prev => {
+                  if (isMulti) { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; }
+                  if (prev.size === 1 && prev.has(code)) return new Set();
+                  return new Set([code]);
+                });
+                setExpandedThreat(prev => prev === code ? null : code);
+              },
+              barColor: "#8b5cf6",
+              yAxisWidth: 155,
+              rightMargin: 80,
+              yAxisTickMaxLength: 22,
+            }
+          )
+        ) : (
+          <div style={{ height: 200 }} className="flex items-center justify-center"><span className="text-sm text-zinc-400 dark:text-zinc-500">No threat data</span></div>
+        )}
       </div>
     );
   })();
@@ -3152,8 +3162,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // multi-select dimension, since each is a binary refinement, not a category.
   const habitatCard = (() => {
     const habitatLabelToCode = new Map(HABITAT_CATEGORIES.map(c => [c.label, c.code]));
-    const habitatBarData = HABITAT_CATEGORIES
-      .map(({ code, label }) => ({ code: label, habitatCode: code, count: habitatCounts[code] ?? 0, label: (habitatCounts[code] ?? 0).toLocaleString() }))
+    const habitatBarData: DrilldownBarDatum[] = HABITAT_CATEGORIES
+      .map(({ code, label }) => ({ code: label, rawCode: code, count: habitatCounts[code] ?? 0, label: (habitatCounts[code] ?? 0).toLocaleString() }))
       .filter(d => d.count > 0)
       .sort((a, b) => b.count - a.count);
     const habitatTotalPages = Math.max(1, Math.ceil(habitatBarData.length / HABITAT_PAGE_SIZE));
@@ -3162,17 +3172,40 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     const selectedHabitatLabels = new Set(
       Array.from(selectedHabitat).map(code => HABITAT_CATEGORIES.find(c => c.code === code)?.label).filter(Boolean) as string[]
     );
-    const drillCat = expandedHabitat ? HABITAT_CATEGORIES.find(c => c.code === expandedHabitat) ?? null : null;
-    const drillSubData = drillCat
-      ? drillCat.children
-          .map(child => ({ code: child.label, habitatCode: child.code, count: habitatCounts[child.code] ?? 0, label: (habitatCounts[child.code] ?? 0).toLocaleString() }))
-          .filter(d => d.count > 0)
-          .sort((a, b) => b.count - a.count)
-      : [];
-    const isDrilled = drillCat !== null && drillSubData.length > 0;
-    const HABITAT_AREA_HEIGHT = 266;
-    const chartHeight = Math.max(150, pagedHabitatBarData.length * 18 + 30);
     const loading = speciesLoading && assessedSpecies.length === 0;
+    const renderHabitatPills = (rawCode: string) => {
+      const drillCat = HABITAT_CATEGORIES.find(c => c.code === rawCode);
+      if (!drillCat) return null;
+      return (
+        <div className="flex flex-wrap gap-1 pl-2 pb-1">
+          {drillCat.children.map(child => {
+            const count = habitatCounts[child.code] ?? 0;
+            if (count === 0) return null;
+            const isSelected = selectedHabitat.has(child.code);
+            return (
+              <button
+                key={child.code}
+                onClick={(e) => {
+                  const isMulti = e.metaKey || e.ctrlKey;
+                  setSelectedHabitat(prev => {
+                    if (isMulti) { const next = new Set(prev); if (next.has(child.code)) next.delete(child.code); else next.add(child.code); return next; }
+                    if (prev.size === 1 && prev.has(child.code)) return new Set();
+                    return new Set([child.code]);
+                  });
+                }}
+                className={`px-1.5 py-0.5 text-[11px] rounded-full transition-colors cursor-pointer ${
+                  isSelected
+                    ? "bg-teal-500 text-white"
+                    : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                }`}
+              >
+                {child.label} ({count.toLocaleString()})
+              </button>
+            );
+          })}
+        </div>
+      );
+    };
     const toggleClass = (active: boolean) => `px-2 py-0.5 text-xs font-semibold rounded transition-colors ${
       active ? "bg-teal-600 text-white shadow-sm" : "bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"
     }`;
@@ -3337,123 +3370,78 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             </div>
           </div>
         </div>
-        <div style={{ height: HABITAT_AREA_HEIGHT }} className="flex flex-col overflow-hidden">
-          {loading ? (
-            <div className="h-full flex items-center justify-center"><Spinner /></div>
-          ) : habitatBarData.length > 0 ? (
-            <>
-              <div className="flex-1 min-h-0 flex flex-col">
-                <div className="flex-1 min-h-0 overflow-y-auto">
-                  <div style={{ height: chartHeight }}>
-                    <FilterBarChart
-                      data={pagedHabitatBarData}
-                      dataKey="code"
-                      selectedItems={selectedHabitatLabels}
-                      onBarClick={(data: { payload?: { code?: string; habitatCode?: string } }, event: React.MouseEvent) => {
-                        const label = data.payload?.code;
-                        const code = label ? habitatLabelToCode.get(label) : undefined;
-                        if (!code) return;
-                        const isMulti = event.metaKey || event.ctrlKey;
-                        setSelectedHabitat(prev => {
-                          if (isMulti) { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; }
-                          if (prev.size === 1 && prev.has(code)) return new Set();
-                          return new Set([code]);
-                        });
-                        setExpandedHabitat(prev => prev === code ? null : code);
-                      }}
-                      barColor="#0d9488"
-                      yAxisWidth={155}
-                      rightMargin={80}
-                      yAxisTickMaxLength={22}
-                    />
-                  </div>
-                </div>
-                {habitatTotalPages > 1 && (
-                  <div className="shrink-0 flex items-center justify-between pt-1 text-[10px] text-zinc-400 dark:text-zinc-500">
-                    <button
-                      onClick={() => setHabitatPage(p => Math.max(0, p - 1))}
-                      disabled={safeHabitatPage === 0}
-                      className="px-1.5 py-0.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800 disabled:opacity-30 disabled:cursor-not-allowed"
-                    >
-                      Prev
-                    </button>
-                    <span className="tabular-nums">Page {safeHabitatPage + 1} of {habitatTotalPages}</span>
-                    <button
-                      onClick={() => setHabitatPage(p => Math.min(habitatTotalPages - 1, p + 1))}
-                      disabled={safeHabitatPage >= habitatTotalPages - 1}
-                      className="px-1.5 py-0.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800 disabled:opacity-30 disabled:cursor-not-allowed"
-                    >
-                      Next
-                    </button>
-                  </div>
-                )}
+        {loading ? (
+          <div style={{ height: 200 }} className="flex items-center justify-center"><Spinner /></div>
+        ) : habitatBarData.length > 0 ? (
+          <>
+            {renderInlineDrilldown(
+              pagedHabitatBarData,
+              (rawCode) => expandedHabitat === rawCode,
+              renderHabitatPills,
+              {
+                dataKey: "code",
+                selectedItems: selectedHabitatLabels,
+                onBarClick: (data: { payload?: { code?: string } }, event: React.MouseEvent) => {
+                  const label = data.payload?.code;
+                  const code = label ? habitatLabelToCode.get(label) : undefined;
+                  if (!code) return;
+                  const isMulti = event.metaKey || event.ctrlKey;
+                  setSelectedHabitat(prev => {
+                    if (isMulti) { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; }
+                    if (prev.size === 1 && prev.has(code)) return new Set();
+                    return new Set([code]);
+                  });
+                  setExpandedHabitat(prev => prev === code ? null : code);
+                },
+                barColor: "#0d9488",
+                yAxisWidth: 155,
+                rightMargin: 80,
+                yAxisTickMaxLength: 22,
+              }
+            )}
+            {habitatTotalPages > 1 && (
+              <div className="shrink-0 flex items-center justify-between pt-1 text-[10px] text-zinc-400 dark:text-zinc-500">
+                <button
+                  onClick={() => setHabitatPage(p => Math.max(0, p - 1))}
+                  disabled={safeHabitatPage === 0}
+                  className="px-1.5 py-0.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800 disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                  Prev
+                </button>
+                <span className="tabular-nums">Page {safeHabitatPage + 1} of {habitatTotalPages}</span>
+                <button
+                  onClick={() => setHabitatPage(p => Math.min(habitatTotalPages - 1, p + 1))}
+                  disabled={safeHabitatPage >= habitatTotalPages - 1}
+                  className="px-1.5 py-0.5 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800 disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                  Next
+                </button>
               </div>
-              {isDrilled && (
-                <div className="shrink-0 mt-2 pt-2 border-t border-zinc-200 dark:border-zinc-800 flex flex-col" style={{ maxHeight: "50%" }}>
-                  <div className="flex items-center justify-between mb-1">
-                    <span className="text-xs font-medium text-zinc-500 dark:text-zinc-400 truncate">{drillCat!.label}</span>
-                    <button
-                      onClick={() => setExpandedHabitat(null)}
-                      className="shrink-0 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors"
-                      aria-label="Close sub-habitats"
-                    >
-                      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
-                    </button>
-                  </div>
-                  <div className="min-h-0 overflow-y-auto">
-                    <div className="flex flex-wrap gap-1.5">
-                      {drillCat!.children.map(child => {
-                        const count = habitatCounts[child.code] ?? 0;
-                        if (count === 0) return null;
-                        const isSelected = selectedHabitat.has(child.code);
-                        return (
-                          <button
-                            key={child.code}
-                            onClick={(e) => {
-                              const isMulti = e.metaKey || e.ctrlKey;
-                              setSelectedHabitat(prev => {
-                                if (isMulti) { const next = new Set(prev); if (next.has(child.code)) next.delete(child.code); else next.add(child.code); return next; }
-                                if (prev.size === 1 && prev.has(child.code)) return new Set();
-                                return new Set([child.code]);
-                              });
-                            }}
-                            className={`px-2 py-1 text-xs rounded-full transition-colors cursor-pointer ${
-                              isSelected
-                                ? "bg-teal-500 text-white"
-                                : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
-                            }`}
-                          >
-                            {child.label} ({count.toLocaleString()})
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
-              )}
-            </>
-          ) : (
-            <div className="h-full flex items-center justify-center"><span className="text-sm text-zinc-400 dark:text-zinc-500">No habitat data</span></div>
-          )}
-        </div>
+            )}
+          </>
+        ) : (
+          <div style={{ height: 200 }} className="flex items-center justify-center"><span className="text-sm text-zinc-400 dark:text-zinc-500">No habitat data</span></div>
+        )}
       </div>
     );
   })();
 
-  // Renders one pill row for a level of the Criteria drill-down (top-level A-E, then
-  // number, sub-clause, or roman-numeral rows as the user drills deeper — see
-  // CRITERIA_CATEGORIES' doc comment for why the depth varies per branch). A plain
-  // click replaces the whole selection with just this code (or clears it, if it was
-  // already the sole selection) — the same single-select convention every other
-  // filter chip in this file uses. Cmd/ctrl-click instead TOGGLES this code in/out of
-  // selectedCriteria without touching the rest, for real multi-select across branches
-  // (e.g. B1b(iii) AND C2a(i) together). Independently, clicking a node with children
-  // toggles ITS OWN membership in expandedCriteria (not a single shared "last expanded"
-  // value), so drilling into one branch never collapses another branch you already
-  // had open — mirrors the Threats chart's category/sub-category drill-down,
-  // generalized to arbitrary depth and to multiple simultaneously-open branches.
-  const renderCriteriaRow = (nodes: CriteriaNode[], indent: boolean) => (
-    <div className={`flex flex-wrap gap-1.5 ${indent ? "pl-0 sm:pl-[88px]" : ""}`}>
+  // Renders one small pill row for a level of the Criteria drill-down (number,
+  // sub-clause, or roman-numeral rows as the user drills deeper below the
+  // top-level A-E bar chart — see CRITERIA_CATEGORIES' doc comment for why the
+  // depth varies per branch). Indents a little more per level so a deep drill
+  // (B -> B1 -> B1b -> B1b(iii)) still reads as a staircase, not a flat list.
+  // A plain click replaces the whole selection with just this code (or clears
+  // it, if it was already the sole selection) — the same single-select
+  // convention every other filter chip in this file uses. Cmd/ctrl-click
+  // instead TOGGLES this code in/out of selectedCriteria without touching the
+  // rest, for real multi-select across branches (e.g. B1b(iii) AND C2a(i)
+  // together). Independently, clicking a node with children toggles ITS OWN
+  // membership in expandedCriteria (not a single shared "last expanded"
+  // value), so drilling into one branch never collapses another branch you
+  // already had open.
+  const renderCriteriaRow = (nodes: CriteriaNode[], depth: number) => (
+    <div className="flex flex-wrap gap-1" style={{ paddingLeft: depth * 10 }}>
       {nodes.map(node => {
         const isSelected = selectedCriteria.has(node.code);
         const count = criteriaCounts[node.code] ?? 0;
@@ -3472,12 +3460,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 setExpandedCriteria(prev => { const next = new Set(prev); if (next.has(node.code)) next.delete(node.code); else next.add(node.code); return next; });
               }
             }}
-            className={`px-2 py-1 text-xs rounded-full transition-colors cursor-pointer ${
+            className={`px-1.5 py-0.5 text-[11px] rounded-full transition-colors cursor-pointer ${
               isSelected
-                ? indent ? "bg-indigo-300 text-indigo-900 dark:bg-indigo-400 dark:text-indigo-950" : "bg-indigo-500 text-white"
-                : indent
-                  ? "bg-white text-zinc-600 border border-zinc-200 hover:bg-zinc-100 dark:bg-zinc-900 dark:text-zinc-400 dark:border-zinc-700 dark:hover:bg-zinc-800"
-                  : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                ? "bg-indigo-500 text-white"
+                : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
             }`}
             title={node.label}
           >
@@ -3491,9 +3477,9 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // Recursively renders a level and, for every node in it that's currently expanded,
   // that node's children level right after — so any number of branches (at any depth)
   // can be open simultaneously, not just one linear drill path.
-  const renderCriteriaLevel = (nodes: CriteriaNode[], depth = 0): React.ReactNode => (
+  const renderCriteriaLevel = (nodes: CriteriaNode[], depth: number): React.ReactNode => (
     <React.Fragment>
-      {renderCriteriaRow(nodes, depth > 0)}
+      {renderCriteriaRow(nodes, depth)}
       {nodes.map(node => (
         expandedCriteria.has(node.code) && node.children.length > 0 ? (
           <React.Fragment key={`${node.code}-children`}>{renderCriteriaLevel(node.children, depth + 1)}</React.Fragment>
@@ -3512,57 +3498,56 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // ask was already true for Criteria beyond the top level.
   const criteriaCard = (() => {
     const criteriaLabelToCode = new Map(CRITERIA_CATEGORIES.map(c => [c.label, c.code]));
-    const criteriaBarData = CRITERIA_CATEGORIES
-      .map(({ code, label }) => ({ code: label, criteriaCode: code, count: criteriaCounts[code] ?? 0, label: (criteriaCounts[code] ?? 0).toLocaleString() }))
-      .filter(d => d.count > 0 || selectedCriteria.has(d.criteriaCode));
+    const criteriaBarData: DrilldownBarDatum[] = CRITERIA_CATEGORIES
+      .map(({ code, label }) => ({ code: label, rawCode: code, count: criteriaCounts[code] ?? 0, label: (criteriaCounts[code] ?? 0).toLocaleString() }))
+      .filter(d => d.count > 0 || selectedCriteria.has(d.rawCode));
     const selectedCriteriaLabels = new Set(
       Array.from(selectedCriteria).map(code => CRITERIA_CATEGORIES.find(c => c.code === code)?.label).filter(Boolean) as string[]
     );
-    const CRITERIA_TOP_HEIGHT = Math.max(90, criteriaBarData.length * 24 + 20);
     const loading = speciesLoading && assessedSpecies.length === 0;
+    const renderCriteriaPills = (rawCode: string) => {
+      const node = CRITERIA_CATEGORIES.find(n => n.code === rawCode);
+      if (!node) return null;
+      return <div className="pb-1">{renderCriteriaLevel(node.children, 1)}</div>;
+    };
     return (
       <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
         <div className="flex items-center justify-between mb-1 min-h-[24px]">
           <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Criteria</span>
         </div>
         {loading ? (
-          <div style={{ height: CRITERIA_TOP_HEIGHT }} className="flex items-center justify-center"><Spinner className="h-4 w-4" /></div>
+          <div style={{ height: 90 }} className="flex items-center justify-center"><Spinner className="h-4 w-4" /></div>
         ) : criteriaBarData.length > 0 ? (
-          <>
-            <div style={{ height: CRITERIA_TOP_HEIGHT }}>
-              <FilterBarChart
-                data={criteriaBarData}
-                dataKey="code"
-                selectedItems={selectedCriteriaLabels}
-                onBarClick={(data: { payload?: { code?: string } }, event: React.MouseEvent) => {
-                  const label = data.payload?.code;
-                  const code = label ? criteriaLabelToCode.get(label) : undefined;
-                  if (!code) return;
-                  const isMulti = event.metaKey || event.ctrlKey;
-                  if (isMulti) {
-                    setSelectedCriteria(prev => { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; });
-                  } else {
-                    setSelectedCriteria(prev => (prev.size === 1 && prev.has(code)) ? new Set() : new Set([code]));
-                  }
-                  const node = CRITERIA_CATEGORIES.find(n => n.code === code);
-                  if (node && node.children.length > 0) {
-                    setExpandedCriteria(prev => { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; });
-                  }
-                }}
-                barColor="#6366f1"
-                yAxisWidth={100}
-                rightMargin={60}
-                yAxisTickMaxLength={14}
-              />
-            </div>
-            {CRITERIA_CATEGORIES.map(node => (
-              expandedCriteria.has(node.code) && node.children.length > 0 ? (
-                <React.Fragment key={node.code}>{renderCriteriaLevel(node.children, 1)}</React.Fragment>
-              ) : null
-            ))}
-          </>
+          renderInlineDrilldown(
+            criteriaBarData,
+            (rawCode) => expandedCriteria.has(rawCode),
+            renderCriteriaPills,
+            {
+              dataKey: "code",
+              selectedItems: selectedCriteriaLabels,
+              onBarClick: (data: { payload?: { code?: string } }, event: React.MouseEvent) => {
+                const label = data.payload?.code;
+                const code = label ? criteriaLabelToCode.get(label) : undefined;
+                if (!code) return;
+                const isMulti = event.metaKey || event.ctrlKey;
+                if (isMulti) {
+                  setSelectedCriteria(prev => { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; });
+                } else {
+                  setSelectedCriteria(prev => (prev.size === 1 && prev.has(code)) ? new Set() : new Set([code]));
+                }
+                const node = CRITERIA_CATEGORIES.find(n => n.code === code);
+                if (node && node.children.length > 0) {
+                  setExpandedCriteria(prev => { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; });
+                }
+              },
+              barColor: "#6366f1",
+              yAxisWidth: 100,
+              rightMargin: 60,
+              yAxisTickMaxLength: 14,
+            }
+          )
         ) : (
-          <div style={{ height: CRITERIA_TOP_HEIGHT }} className="flex items-center justify-center"><span className="text-sm text-zinc-400 dark:text-zinc-500">No criteria data</span></div>
+          <div style={{ height: 90 }} className="flex items-center justify-center"><span className="text-sm text-zinc-400 dark:text-zinc-500">No criteria data</span></div>
         )}
       </div>
     );
@@ -4027,146 +4012,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
 
           {!isNewAssessments && moreFiltersOpen && (
             <>
-                {/* Habitat (left) alongside Number of Assessments stacked above
-                    Criteria (right) — Number of Assessments' chart is taller
-                    than its original 150px so the combined stack's bottom edge
-                    roughly lines up with Habitat's. */}
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                  {habitatCard}
-                  <div className="flex flex-col gap-3">
-                    {/* Number of Assessments (#423 item 1) — how many times a
-                        species has been assessed, with a "Reassessed" shortcut
-                        selecting every bucket >= 2 in one click (flags species
-                        reassessed at least once, per the issue's explicit ask),
-                        same shape as the Outdated shortcut next to Years Since
-                        Assessed. */}
-                    {!isNewAssessments && (
-                      <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
-                        <div className="flex items-center justify-between mb-1">
-                          <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Number of Assessments</span>
-                          <button
-                            type="button"
-                            onClick={handleReassessedClick}
-                            className={`px-2 py-0.5 text-xs font-semibold rounded transition-colors ${
-                              isReassessedSelected
-                                ? "bg-red-600 text-white shadow-sm"
-                                : "bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"
-                            }`}
-                            aria-pressed={isReassessedSelected}
-                            title="Filter to species assessed 2 or more times (reassessed at least once)"
-                          >
-                            Reassessed
-                          </button>
-                        </div>
-                        <div style={{ height: 216 }} className="flex items-center justify-center">
-                          {speciesLoading && assessedSpecies.length === 0 ? (
-                            <Spinner />
-                          ) : isSingleSpecies && singleSpecies ? (
-                            <span className="text-4xl font-bold text-zinc-900 dark:text-zinc-100">
-                              {assessmentCountBucket(singleSpecies.assessment_count)}
-                            </span>
-                          ) : assessmentCountData.length > 0 ? (
-                            <FilterBarChart
-                              data={assessmentCountData}
-                              dataKey="shortRange"
-                              selectedItems={selectedAssessmentCounts}
-                              onBarClick={handleAssessmentCountClick}
-                              barColor="#8b5cf6"
-                              yAxisWidth={42}
-                              rightMargin={85}
-                            />
-                          ) : null}
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Criteria — top-level A-E bar chart (see criteriaCard);
-                        clicking a bar both selects it as a filter AND expands
-                        its next level below (number -> sub-clause -> roman
-                        numeral, as deep as that branch goes) as pill rows via
-                        renderCriteriaLevel, since criteria nests up to 4
-                        levels vs. Threats/Habitat's 2. Cmd/ctrl-click for real
-                        multi-select — any number of branches can be drilled
-                        into and selected simultaneously (e.g. B1b(iii) AND
-                        C2a(i) together), each independently expanded via
-                        expandedCriteria (a Set, not a single "last expanded"
-                        value). A species can satisfy multiple codes under the
-                        same letter too (e.g. B1+B2, or B1a and B1b together),
-                        so selecting any code matches species with that code
-                        OR a more specific one beneath it (see
-                        parseCriteriaCodes' startsWith-based matching). */}
-                    {!isNewAssessments && criteriaCard}
-                  </div>
-                </div>
-
-                {/* Growth Form (plants/fungi only) */}
-                {(() => {
-                  if (speciesLoading && assessedSpecies.length === 0) {
-                    return (
-                      <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
-                        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Growth</span>
-                        <Spinner className="h-4 w-4" />
-                      </div>
-                    );
-                  }
-                  // Compute growth form counts cross-filtered (exclude own filter)
-                  const gfCounts: Record<string, number> = {};
-                  taxaFilteredSpecies.forEach(s => {
-                    if (!s.growth_forms?.length) return;
-                    if (!matchesSearch(s)) return;
-                    if (selectedCategories.size > 0 && !selectedCategories.has(s.category)) return;
-                    if (selectedCountries.size > 0 && !s.countries.some(c => selectedCountries.has(c))) return;
-                    if (s.category !== "NE" && selectedYearRanges.size > 0 && !matchesYearRangeFilter(s.assessment_date, selectedYearRanges)) return;
-                    if (s.category !== "NE" && selectedAssessmentYears.size > 0 && !matchesAssessmentYearFilter(s.assessment_date, selectedAssessmentYears)) return;
-                    if (selectedObsRanges.size > 0 && !matchesObsRangeFilter(s.gbif_occurrence_count, selectedObsRanges)) return;
-                    if (selectedAssessmentCounts.size > 0 && !matchesAssessmentCountFilter(s.assessment_count, selectedAssessmentCounts)) return;
-                    if (selectedSystems.size > 0 && !s.systems?.some(sys => selectedSystems.has(sys))) return;
-                    if (selectedPopulationTrends.size > 0 && (!s.population_trend || !selectedPopulationTrends.has(s.population_trend))) return;
-                    if (selectedMovementPatterns.size > 0 && (!s.movement_pattern || !selectedMovementPatterns.has(s.movement_pattern))) return;
-                    if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
-                    if (selectedCriteria.size > 0 && !parseCriteriaCodes(s.criteria).some(code => Array.from(selectedCriteria).some(sel => code === sel || code.startsWith(sel)))) return;
-                    if (endemicsOnly && s.countries.length !== 1) return;
-                    if (!matchesAssessorsFilter(s)) return;
-                    if (!matchesHabitatFilter(s)) return;
-                    if (!matchesReviewersFilter(s)) return;
-                    for (const gf of s.growth_forms) {
-                      gfCounts[gf] = (gfCounts[gf] || 0) + 1;
-                    }
-                  });
-                  const sorted = Object.entries(gfCounts).sort((a, b) => b[1] - a[1]);
-                  if (sorted.length === 0) return null;
-                  return (
-                    <div className="flex items-start gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
-                      <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20 pt-1">Growth</span>
-                      <div className="flex flex-wrap gap-1.5">
-                        {sorted.map(([gf, count]) => {
-                          const isSelected = selectedGrowthForms.has(gf);
-                          return (
-                            <button
-                              key={gf}
-                              onClick={(e) => {
-                                const isMulti = e.metaKey || e.ctrlKey;
-                                setSelectedGrowthForms(prev => {
-                                  if (isMulti) { const next = new Set(prev); if (next.has(gf)) next.delete(gf); else next.add(gf); return next; }
-                                  if (prev.size === 1 && prev.has(gf)) return new Set();
-                                  return new Set([gf]);
-                                });
-                              }}
-                              className={`px-2 py-1 text-xs rounded-full transition-colors cursor-pointer ${
-                                isSelected
-                                  ? "bg-lime-500 text-white"
-                                  : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
-                              }`}
-                            >
-                              {gf} ({count.toLocaleString()})
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  );
-                })()}
-
                 {/* Realm, Movement, and Trend as three columns in one row. */}
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                   {/* Realm */}
@@ -4274,57 +4119,184 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   </div>
                 </div>
 
-                {/* Assessors and Reviewers, shown side by side */}
-                {isSingleSpecies && singleSpecies ? (
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                    {([
-                      { title: "Assessors", names: singleSpeciesAssessors },
-                      { title: "Reviewers", names: singleSpeciesReviewers },
-                    ] as const).map(({ title, names }) => (
-                      <div key={title} className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
-                        <div className="flex items-center justify-between mb-1">
-                          <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">{title}</span>
-                        </div>
-                        <div className="overflow-y-auto mt-2" style={{ maxHeight: 260 }}>
-                          {names.length > 0 ? (
-                            <div className="flex flex-wrap gap-2">
-                              {names.map((name) => (
-                                <span key={name} className="inline-block px-3 py-1.5 text-sm rounded-lg bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300">{name}</span>
-                              ))}
-                            </div>
-                          ) : (
-                            <span className="text-sm text-zinc-400 dark:text-zinc-500">None listed</span>
-                          )}
-                        </div>
+                {/* Criteria alongside Number of Assessments — a row, not a
+                    stack (previously stacked in Habitat's right column; moved
+                    out once Habitat started pairing with Assessors/Reviewers
+                    instead). */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  {/* Criteria — top-level A-E bar chart (see criteriaCard);
+                      clicking a bar both selects it as a filter AND expands
+                      its next level below (number -> sub-clause -> roman
+                      numeral, as deep as that branch goes) as pill rows via
+                      renderCriteriaLevel, since criteria nests up to 4
+                      levels vs. Threats/Habitat's 2. Cmd/ctrl-click for real
+                      multi-select — any number of branches can be drilled
+                      into and selected simultaneously (e.g. B1b(iii) AND
+                      C2a(i) together), each independently expanded via
+                      expandedCriteria (a Set, not a single "last expanded"
+                      value). A species can satisfy multiple codes under the
+                      same letter too (e.g. B1+B2, or B1a and B1b together),
+                      so selecting any code matches species with that code
+                      OR a more specific one beneath it (see
+                      parseCriteriaCodes' startsWith-based matching). */}
+                  {!isNewAssessments && criteriaCard}
+
+                  {/* Number of Assessments (#423 item 1) — how many times a
+                      species has been assessed, with a "Reassessed" shortcut
+                      selecting every bucket >= 2 in one click (flags species
+                      reassessed at least once, per the issue's explicit ask),
+                      same shape as the Outdated shortcut next to Years Since
+                      Assessed. */}
+                  {!isNewAssessments && (
+                    <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Number of Assessments</span>
+                        <button
+                          type="button"
+                          onClick={handleReassessedClick}
+                          className={`px-2 py-0.5 text-xs font-semibold rounded transition-colors ${
+                            isReassessedSelected
+                              ? "bg-red-600 text-white shadow-sm"
+                              : "bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"
+                          }`}
+                          aria-pressed={isReassessedSelected}
+                          title="Filter to species assessed 2 or more times (reassessed at least once)"
+                        >
+                          Reassessed
+                        </button>
                       </div>
-                    ))}
-                  </div>
-                ) : (
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                      <div style={{ height: 200 }} className="flex items-center justify-center">
+                        {speciesLoading && assessedSpecies.length === 0 ? (
+                          <Spinner />
+                        ) : isSingleSpecies && singleSpecies ? (
+                          <span className="text-4xl font-bold text-zinc-900 dark:text-zinc-100">
+                            {assessmentCountBucket(singleSpecies.assessment_count)}
+                          </span>
+                        ) : assessmentCountData.length > 0 ? (
+                          <FilterBarChart
+                            data={assessmentCountData}
+                            dataKey="shortRange"
+                            selectedItems={selectedAssessmentCounts}
+                            onBarClick={handleAssessmentCountClick}
+                            barColor="#8b5cf6"
+                            yAxisWidth={42}
+                            rightMargin={85}
+                          />
+                        ) : null}
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* Habitat alongside Assessors/Reviewers. */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  {habitatCard}
+                  {isSingleSpecies && singleSpecies ? (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                      {([
+                        { title: "Assessors", names: singleSpeciesAssessors },
+                        { title: "Reviewers", names: singleSpeciesReviewers },
+                      ] as const).map(({ title, names }) => (
+                        <div key={title} className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
+                          <div className="flex items-center justify-between mb-1">
+                            <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">{title}</span>
+                          </div>
+                          <div className="overflow-y-auto mt-2" style={{ maxHeight: 260 }}>
+                            {names.length > 0 ? (
+                              <div className="flex flex-wrap gap-2">
+                                {names.map((name) => (
+                                  <span key={name} className="inline-block px-3 py-1.5 text-sm rounded-lg bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300">{name}</span>
+                                ))}
+                              </div>
+                            ) : (
+                              <span className="text-sm text-zinc-400 dark:text-zinc-500">None listed</span>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
                     <ReviewerChart
                       allAssessors={assessorChartData}
                       allReviewers={reviewerChartData}
-                      viewMode="assessors"
-                      showToggle={false}
-                      title="Assessors"
-                      selectedItems={selectedAssessors}
-                      onBarClick={makeAssessorClick(setSelectedAssessors)}
-                      onItemToggle={makeAssessorToggle(setSelectedAssessors)}
+                      viewMode={assessorReviewerMode}
+                      onViewModeChange={setAssessorReviewerMode}
+                      selectedItems={assessorReviewerMode === "assessors" ? selectedAssessors : selectedReviewers}
+                      onBarClick={makeAssessorClick(assessorReviewerMode === "assessors" ? setSelectedAssessors : setSelectedReviewers)}
+                      onItemToggle={makeAssessorToggle(assessorReviewerMode === "assessors" ? setSelectedAssessors : setSelectedReviewers)}
                       loading={speciesLoading && assessedSpecies.length === 0}
                     />
-                    <ReviewerChart
-                      allAssessors={assessorChartData}
-                      allReviewers={reviewerChartData}
-                      viewMode="reviewers"
-                      showToggle={false}
-                      title="Reviewers"
-                      selectedItems={selectedReviewers}
-                      onBarClick={makeAssessorClick(setSelectedReviewers)}
-                      onItemToggle={makeAssessorToggle(setSelectedReviewers)}
-                      loading={speciesLoading && assessedSpecies.length === 0}
-                    />
-                  </div>
-                )}
+                  )}
+                </div>
+
+                {/* Growth Form (plants/fungi only) */}
+                {(() => {
+                  if (speciesLoading && assessedSpecies.length === 0) {
+                    return (
+                      <div className="flex items-center gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
+                        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20">Growth</span>
+                        <Spinner className="h-4 w-4" />
+                      </div>
+                    );
+                  }
+                  // Compute growth form counts cross-filtered (exclude own filter)
+                  const gfCounts: Record<string, number> = {};
+                  taxaFilteredSpecies.forEach(s => {
+                    if (!s.growth_forms?.length) return;
+                    if (!matchesSearch(s)) return;
+                    if (selectedCategories.size > 0 && !selectedCategories.has(s.category)) return;
+                    if (selectedCountries.size > 0 && !s.countries.some(c => selectedCountries.has(c))) return;
+                    if (s.category !== "NE" && selectedYearRanges.size > 0 && !matchesYearRangeFilter(s.assessment_date, selectedYearRanges)) return;
+                    if (s.category !== "NE" && selectedAssessmentYears.size > 0 && !matchesAssessmentYearFilter(s.assessment_date, selectedAssessmentYears)) return;
+                    if (selectedObsRanges.size > 0 && !matchesObsRangeFilter(s.gbif_occurrence_count, selectedObsRanges)) return;
+                    if (selectedAssessmentCounts.size > 0 && !matchesAssessmentCountFilter(s.assessment_count, selectedAssessmentCounts)) return;
+                    if (selectedSystems.size > 0 && !s.systems?.some(sys => selectedSystems.has(sys))) return;
+                    if (selectedPopulationTrends.size > 0 && (!s.population_trend || !selectedPopulationTrends.has(s.population_trend))) return;
+                    if (selectedMovementPatterns.size > 0 && (!s.movement_pattern || !selectedMovementPatterns.has(s.movement_pattern))) return;
+                    if (selectedThreats.size > 0 && !s.threat_codes?.some(tc => Array.from(selectedThreats).some(sel => tc === sel || tc.startsWith(sel + ".")))) return;
+                    if (selectedCriteria.size > 0 && !parseCriteriaCodes(s.criteria).some(code => Array.from(selectedCriteria).some(sel => code === sel || code.startsWith(sel)))) return;
+                    if (endemicsOnly && s.countries.length !== 1) return;
+                    if (!matchesAssessorsFilter(s)) return;
+                    if (!matchesHabitatFilter(s)) return;
+                    if (!matchesReviewersFilter(s)) return;
+                    for (const gf of s.growth_forms) {
+                      gfCounts[gf] = (gfCounts[gf] || 0) + 1;
+                    }
+                  });
+                  const sorted = Object.entries(gfCounts).sort((a, b) => b[1] - a[1]);
+                  if (sorted.length === 0) return null;
+                  return (
+                    <div className="flex items-start gap-2 bg-zinc-50 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg px-3 py-2">
+                      <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0 w-20 pt-1">Growth</span>
+                      <div className="flex flex-wrap gap-1.5">
+                        {sorted.map(([gf, count]) => {
+                          const isSelected = selectedGrowthForms.has(gf);
+                          return (
+                            <button
+                              key={gf}
+                              onClick={(e) => {
+                                const isMulti = e.metaKey || e.ctrlKey;
+                                setSelectedGrowthForms(prev => {
+                                  if (isMulti) { const next = new Set(prev); if (next.has(gf)) next.delete(gf); else next.add(gf); return next; }
+                                  if (prev.size === 1 && prev.has(gf)) return new Set();
+                                  return new Set([gf]);
+                                });
+                              }}
+                              className={`px-2 py-1 text-xs rounded-full transition-colors cursor-pointer ${
+                                isSelected
+                                  ? "bg-lime-500 text-white"
+                                  : "bg-zinc-100 text-zinc-600 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-400 dark:hover:bg-zinc-700"
+                              }`}
+                            >
+                              {gf} ({count.toLocaleString()})
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })()}
+
             </>
           )}
 

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -4027,12 +4027,12 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           )}
 
           {/* Country + Threats are always visible, alongside Charts row 1
-              above — everything past that (Growth Form, Habitat + Realm/
-              Movement/Trend/Criteria, Assessors/Reviewers) lives behind the
-              "More Filters" toggle below. No independently-scrollable panel
-              here anymore — nested scrollbars (the panel's own, inside the
-              page's) read as confusing, so this reverts to plain
-              click-to-expand instead. */}
+              above — everything past that (Criteria/Number of Assessments,
+              Realm/Movement/Trend, Habitat/Assessors-Reviewers, Growth Form)
+              lives behind the "More Filters" toggle below. No
+              independently-scrollable panel here anymore — nested
+              scrollbars (the panel's own, inside the page's) read as
+              confusing, so this reverts to plain click-to-expand instead. */}
           {!isNewAssessments && (
             <>
                 {/* Country, Threats — paired side by side. */}
@@ -4060,6 +4060,75 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
 
           {!isNewAssessments && moreFiltersOpen && (
             <>
+                {/* Criteria alongside Number of Assessments — a row, not a
+                    stack (previously stacked in Habitat's right column; moved
+                    out once Habitat started pairing with Assessors/Reviewers
+                    instead). */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  {/* Criteria — top-level A-E bar chart (see criteriaCard);
+                      clicking a bar both selects it as a filter AND expands
+                      its next level below (number -> sub-clause -> roman
+                      numeral, as deep as that branch goes) as pill rows via
+                      renderCriteriaLevel, since criteria nests up to 4
+                      levels vs. Threats/Habitat's 2. Cmd/ctrl-click for real
+                      multi-select — any number of branches can be drilled
+                      into and selected simultaneously (e.g. B1b(iii) AND
+                      C2a(i) together), each independently expanded via
+                      expandedCriteria (a Set, not a single "last expanded"
+                      value). A species can satisfy multiple codes under the
+                      same letter too (e.g. B1+B2, or B1a and B1b together),
+                      so selecting any code matches species with that code
+                      OR a more specific one beneath it (see
+                      parseCriteriaCodes' startsWith-based matching). */}
+                  {!isNewAssessments && criteriaCard}
+
+                  {/* Number of Assessments (#423 item 1) — how many times a
+                      species has been assessed, with a "Reassessed" shortcut
+                      selecting every bucket >= 2 in one click (flags species
+                      reassessed at least once, per the issue's explicit ask),
+                      same shape as the Outdated shortcut next to Years Since
+                      Assessed. */}
+                  {!isNewAssessments && (
+                    <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Number of Assessments</span>
+                        <button
+                          type="button"
+                          onClick={handleReassessedClick}
+                          className={`px-2 py-0.5 text-xs font-semibold rounded transition-colors ${
+                            isReassessedSelected
+                              ? "bg-red-600 text-white shadow-sm"
+                              : "bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"
+                          }`}
+                          aria-pressed={isReassessedSelected}
+                          title="Filter to species assessed 2 or more times (reassessed at least once)"
+                        >
+                          Reassessed
+                        </button>
+                      </div>
+                      <div style={{ height: 200 }} className="flex items-center justify-center">
+                        {speciesLoading && assessedSpecies.length === 0 ? (
+                          <Spinner />
+                        ) : isSingleSpecies && singleSpecies ? (
+                          <span className="text-4xl font-bold text-zinc-900 dark:text-zinc-100">
+                            {assessmentCountBucket(singleSpecies.assessment_count)}
+                          </span>
+                        ) : assessmentCountData.length > 0 ? (
+                          <FilterBarChart
+                            data={assessmentCountData}
+                            dataKey="shortRange"
+                            selectedItems={selectedAssessmentCounts}
+                            onBarClick={handleAssessmentCountClick}
+                            barColor="#8b5cf6"
+                            yAxisWidth={42}
+                            rightMargin={85}
+                          />
+                        ) : null}
+                      </div>
+                    </div>
+                  )}
+                </div>
+
                 {/* Realm, Movement, and Trend as three columns in one row. */}
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                   {/* Realm */}
@@ -4165,75 +4234,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                       })}
                     </div>
                   </div>
-                </div>
-
-                {/* Criteria alongside Number of Assessments — a row, not a
-                    stack (previously stacked in Habitat's right column; moved
-                    out once Habitat started pairing with Assessors/Reviewers
-                    instead). */}
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                  {/* Criteria — top-level A-E bar chart (see criteriaCard);
-                      clicking a bar both selects it as a filter AND expands
-                      its next level below (number -> sub-clause -> roman
-                      numeral, as deep as that branch goes) as pill rows via
-                      renderCriteriaLevel, since criteria nests up to 4
-                      levels vs. Threats/Habitat's 2. Cmd/ctrl-click for real
-                      multi-select — any number of branches can be drilled
-                      into and selected simultaneously (e.g. B1b(iii) AND
-                      C2a(i) together), each independently expanded via
-                      expandedCriteria (a Set, not a single "last expanded"
-                      value). A species can satisfy multiple codes under the
-                      same letter too (e.g. B1+B2, or B1a and B1b together),
-                      so selecting any code matches species with that code
-                      OR a more specific one beneath it (see
-                      parseCriteriaCodes' startsWith-based matching). */}
-                  {!isNewAssessments && criteriaCard}
-
-                  {/* Number of Assessments (#423 item 1) — how many times a
-                      species has been assessed, with a "Reassessed" shortcut
-                      selecting every bucket >= 2 in one click (flags species
-                      reassessed at least once, per the issue's explicit ask),
-                      same shape as the Outdated shortcut next to Years Since
-                      Assessed. */}
-                  {!isNewAssessments && (
-                    <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
-                      <div className="flex items-center justify-between mb-1">
-                        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Number of Assessments</span>
-                        <button
-                          type="button"
-                          onClick={handleReassessedClick}
-                          className={`px-2 py-0.5 text-xs font-semibold rounded transition-colors ${
-                            isReassessedSelected
-                              ? "bg-red-600 text-white shadow-sm"
-                              : "bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"
-                          }`}
-                          aria-pressed={isReassessedSelected}
-                          title="Filter to species assessed 2 or more times (reassessed at least once)"
-                        >
-                          Reassessed
-                        </button>
-                      </div>
-                      <div style={{ height: 200 }} className="flex items-center justify-center">
-                        {speciesLoading && assessedSpecies.length === 0 ? (
-                          <Spinner />
-                        ) : isSingleSpecies && singleSpecies ? (
-                          <span className="text-4xl font-bold text-zinc-900 dark:text-zinc-100">
-                            {assessmentCountBucket(singleSpecies.assessment_count)}
-                          </span>
-                        ) : assessmentCountData.length > 0 ? (
-                          <FilterBarChart
-                            data={assessmentCountData}
-                            dataKey="shortRange"
-                            selectedItems={selectedAssessmentCounts}
-                            onBarClick={handleAssessmentCountClick}
-                            barColor="#8b5cf6"
-                            yAxisWidth={42}
-                            rightMargin={85}
-                          />
-                        ) : null}
-                      </div>
-                    </div>
-                  )}
                 </div>
 
                 {/* Habitat alongside Assessors/Reviewers. */}

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3049,7 +3049,12 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     data: DrilldownBarDatum[],
     isExpanded: (rawCode: string) => boolean,
     renderPills: (rawCode: string) => React.ReactNode,
-    chartProps: Omit<React.ComponentProps<typeof FilterBarChart>, "data">
+    chartProps: Omit<React.ComponentProps<typeof FilterBarChart>, "data">,
+    // Per-row pixel height. Default (22) is Threats/Habitat's original sizing;
+    // Criteria passes 38 to match Number of Assessments' bar thickness, since
+    // that chart sits fixed at 200px for its always-5 buckets (200/5 = 40px
+    // slot, minus FilterBarChart's internal 5px top/bottom margins = 38px).
+    rowHeight = 22
   ): React.ReactNode {
     const segments: { bars: DrilldownBarDatum[]; pillsAfter: string | null }[] = [];
     let current: DrilldownBarDatum[] = [];
@@ -3071,7 +3076,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     return segments.map((seg, i) => (
       <React.Fragment key={i}>
         {seg.bars.length > 0 && (
-          <div style={{ height: Math.max(30, seg.bars.length * 22 + 8) }}>
+          <div style={{ height: Math.max(30, seg.bars.length * rowHeight + 8) }}>
             <FilterBarChart data={seg.bars} xAxisMax={globalMax} {...chartProps} />
           </div>
         )}
@@ -3586,7 +3591,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
               yAxisWidth: 42,
               rightMargin: 85,
               labelFormatter: (code: string) => CRITERIA_CATEGORIES.find(c => c.code === code)?.label ?? code,
-            }
+            },
+            38
           )
         ) : (
           <div style={{ height: 90 }} className="flex items-center justify-center"><span className="text-sm text-zinc-400 dark:text-zinc-500">No criteria data</span></div>

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -1256,13 +1256,11 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     return false;
   }, [selectedObsRanges]);
 
-  // Bucket a species' REASSESSMENT count (total assessments minus the first,
-  // original one) into a chart-bar label. 4+ collapses the long tail (a
-  // handful of species have 8-9 historical assessments, i.e. 7-8
-  // reassessments) into one bar.
+  // Bucket a species' assessment_count into a chart-bar label. 5+ collapses the
+  // long tail (a handful of species have 8-9 historical assessments) into one bar.
   const assessmentCountBucket = useCallback((count: number | null | undefined): string => {
-    const reassessments = (count ?? 1) - 1;
-    return reassessments >= 4 ? "4+" : String(reassessments);
+    const n = count ?? 1;
+    return n >= 5 ? "5+" : String(n);
   }, []);
 
   // Helper to check if species matches the number-of-assessments filter (#423 item 1)
@@ -1791,19 +1789,19 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     }));
   }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedYearRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, selectedCriteria, matchesHabitatFilter, endemicsOnly, selectedGrowthForms, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesYearRangeFilter, selectedAssessmentYears, matchesAssessmentYearFilter]);
 
-  // Number of Reassessments chart (#423 item 1): apply all filters EXCEPT the
-  // reassessment-count selection itself. NE species have no assessment history
+  // Number of Assessments chart (#423 item 1): apply all filters EXCEPT the
+  // assessment-count selection itself. NE species have no assessment history
   // (assessment_count is null) so they're excluded, same as other
   // assessment-only charts.
   const assessmentCountData = useMemo(() => {
     const buckets = [
-      { range: "0", shortRange: "0", count: 0 },
       { range: "1", shortRange: "1", count: 0 },
       { range: "2", shortRange: "2", count: 0 },
       { range: "3", shortRange: "3", count: 0 },
-      { range: "4+", shortRange: "4+", count: 0 },
+      { range: "4", shortRange: "4", count: 0 },
+      { range: "5+", shortRange: "5+", count: 0 },
     ];
-    const byBucket: Record<string, number> = { "0": 0, "1": 1, "2": 2, "3": 3, "4+": 4 };
+    const byBucket: Record<string, number> = { "1": 0, "2": 1, "3": 2, "4": 3, "5+": 4 };
     taxaFilteredSpecies.forEach(s => {
       if (s.category === "NE") return;
       if (!matchesSearch(s)) return;
@@ -2733,7 +2731,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     });
   };
 
-  // Handle Number of Reassessments bar click
+  // Handle Number of Assessments bar click
   const handleAssessmentCountClick = (data: { payload?: { range?: string } }, event: React.MouseEvent) => {
     const range = data.payload?.range;
     if (!range) return;
@@ -2751,13 +2749,14 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     });
   };
 
-  // "1+" shortcut (#423 item 1): one click selects every bucket except "0",
-  // flagging species that have been reassessed at least once. Toggling off
-  // clears the selection entirely, mirroring the Outdated shortcut.
-  const ONE_PLUS_BUCKETS = ["1", "2", "3", "4+"];
-  const isOnePlusSelected = ONE_PLUS_BUCKETS.every(b => selectedAssessmentCounts.has(b)) && selectedAssessmentCounts.size === ONE_PLUS_BUCKETS.length;
-  const handleOnePlusClick = () => {
-    setSelectedAssessmentCounts(isOnePlusSelected ? new Set() : new Set(ONE_PLUS_BUCKETS));
+  // "Reassessed" shortcut (#423 item 1): one click selects every bucket >= 2,
+  // flagging species that have been reassessed at least once (1+ reassessment
+  // = 2+ total assessments). Toggling off clears the selection entirely,
+  // mirroring the Outdated shortcut.
+  const REASSESSED_BUCKETS = ["2", "3", "4", "5+"];
+  const isReassessedSelected = REASSESSED_BUCKETS.every(b => selectedAssessmentCounts.has(b)) && selectedAssessmentCounts.size === REASSESSED_BUCKETS.length;
+  const handleReassessedClick = () => {
+    setSelectedAssessmentCounts(isReassessedSelected ? new Set() : new Set(REASSESSED_BUCKETS));
   };
 
   // Handle Year Described bucket bar click
@@ -3053,7 +3052,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     renderPills: (rawCode: string) => React.ReactNode,
     chartProps: Omit<React.ComponentProps<typeof FilterBarChart>, "data">,
     // Per-row pixel height. Default (22) is Threats/Habitat's original sizing;
-    // Criteria passes 32 to match Number of Reassessments' bar thickness, since
+    // Criteria passes 32 to match Number of Assessments' bar thickness, since
     // that chart sits fixed at 170px for its always-5 buckets (170/5 = 34px
     // slot, minus FilterBarChart's internal 5px top/bottom margins = 32px).
     rowHeight = 22
@@ -4029,7 +4028,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           )}
 
           {/* Country + Threats are always visible, alongside Charts row 1
-              above — everything past that (Assessment Criteria/Number of Reassessments,
+              above — everything past that (Assessment Criteria/Number of Assessments,
               Realm/Movement/Trend, Habitat/Assessors-Reviewers, Growth Form)
               lives behind the "More Filters" toggle below. No
               independently-scrollable panel here anymore — nested
@@ -4062,7 +4061,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
 
           {!isNewAssessments && moreFiltersOpen && (
             <>
-                {/* Assessment Criteria alongside Number of Reassessments — a row, not a
+                {/* Assessment Criteria alongside Number of Assessments — a row, not a
                     stack (previously stacked in Habitat's right column; moved
                     out once Habitat started pairing with Assessors/Reviewers
                     instead). */}
@@ -4084,29 +4083,28 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                       parseCriteriaCodes' startsWith-based matching). */}
                   {!isNewAssessments && criteriaCard}
 
-                  {/* Number of Reassessments (#423 item 1) — how many times a
-                      species has been reassessed beyond its original
-                      assessment (assessment_count - 1), with a "1+" shortcut
-                      selecting every bucket except "0" in one click (flags
-                      species reassessed at least once, per the issue's
-                      explicit ask), same shape as the Outdated shortcut next
-                      to Years Since Assessed. */}
+                  {/* Number of Assessments (#423 item 1) — how many times a
+                      species has been assessed, with a "Reassessed" shortcut
+                      selecting every bucket >= 2 in one click (1+ reassessment
+                      = 2+ total assessments, per the issue's explicit ask),
+                      same shape as the Outdated shortcut next to Years Since
+                      Assessed. */}
                   {!isNewAssessments && (
                     <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
                       <div className="flex items-center justify-between mb-1">
-                        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Number of Reassessments</span>
+                        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Number of Assessments</span>
                         <button
                           type="button"
-                          onClick={handleOnePlusClick}
+                          onClick={handleReassessedClick}
                           className={`px-2 py-0.5 text-xs font-semibold rounded transition-colors ${
-                            isOnePlusSelected
+                            isReassessedSelected
                               ? "bg-red-600 text-white shadow-sm"
                               : "bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"
                           }`}
-                          aria-pressed={isOnePlusSelected}
-                          title="Filter to species reassessed 1 or more times"
+                          aria-pressed={isReassessedSelected}
+                          title="Filter to species assessed 2 or more times (reassessed at least once)"
                         >
-                          1+
+                          Reassessed
                         </button>
                       </div>
                       <div style={{ height: 170 }} className="flex items-center justify-center">

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -778,11 +778,11 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     setSelectedPopulationTrends(new Set());
     setSelectedMovementPatterns(new Set());
     setSelectedThreats(new Set());
-    setExpandedThreat(null);
+    setExpandedThreat(new Set());
     setSelectedCriteria(new Set());
     setExpandedCriteria(new Set());
     setSelectedHabitat(new Set());
-    setExpandedHabitat(null);
+    setExpandedHabitat(new Set());
     setHabitatBreadth(null);
     setSelectedHabitatImportance(new Set(ALL_HABITAT_IMPORTANCE));
     setSelectedHabitatSeasons(new Set(ALL_HABITAT_SEASONS));
@@ -912,19 +912,27 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
 
   const [showOnlyStarred, setShowOnlyStarred] = useState(false);
   const [moreFiltersOpen, setMoreFiltersOpen] = useState(false);
-  const [expandedThreat, setExpandedThreat] = useState<string | null>(null);
+  // Set, not a single string (like expandedCriteria below) — multi-selecting
+  // two top-level threats (cmd-click) should show pills below BOTH, not just
+  // whichever was clicked last.
+  const [expandedThreat, setExpandedThreat] = useState<Set<string>>(new Set());
 
-  // Keep the threats drill-down in sync with the selection. Whenever the expanded
+  // Keep the threats drill-down in sync with the selection. Whenever an expanded
   // top-level category is no longer represented in the selection — because the
   // threats were cleared (Clear all / chip ×), a child was deselected, or the view
-  // was reset — collapse the sub-category pane so no stale nested level lingers.
+  // was reset — collapse that category's pills so no stale level lingers.
+  // Independent per category, mirroring expandedCriteria's effect below.
   useEffect(() => {
-    if (!expandedThreat) return;
-    const stillSelected = Array.from(selectedThreats).some(
-      c => c === expandedThreat || c.startsWith(expandedThreat + ".")
-    );
-    if (!stillSelected) setExpandedThreat(null);
-  }, [selectedThreats, expandedThreat]);
+    setExpandedThreat(prev => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const ec of prev) {
+        const stillSelected = Array.from(selectedThreats).some(c => c === ec || c.startsWith(ec + "."));
+        if (!stillSelected) { next.delete(ec); changed = true; }
+      }
+      return changed ? next : prev;
+    });
+  }, [selectedThreats]);
 
   // Set, not a single string, so multiple branches can be drilled into and stay open
   // at once (e.g. B1b AND C2a both expanded simultaneously) — needed for proper
@@ -947,18 +955,22 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     });
   }, [selectedCriteria]);
 
-  // Habitat drill-down: a single expanded top-level category, like expandedThreat
-  // above (habitat only needs 2 levels — top category, then sub-habitat — so it
-  // doesn't need Criteria's multi-branch Set).
-  const [expandedHabitat, setExpandedHabitat] = useState<string | null>(null);
+  // Habitat drill-down — Set-based like expandedThreat above, for the same
+  // reason: multi-selecting two top-level habitats should show pills below
+  // both.
+  const [expandedHabitat, setExpandedHabitat] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    if (!expandedHabitat) return;
-    const stillSelected = Array.from(selectedHabitat).some(
-      c => c === expandedHabitat || c.startsWith(expandedHabitat + ".")
-    );
-    if (!stillSelected) setExpandedHabitat(null);
-  }, [selectedHabitat, expandedHabitat]);
+    setExpandedHabitat(prev => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const ec of prev) {
+        const stillSelected = Array.from(selectedHabitat).some(c => c === ec || c.startsWith(ec + "."));
+        if (!stillSelected) { next.delete(ec); changed = true; }
+      }
+      return changed ? next : prev;
+    });
+  }, [selectedHabitat]);
 
   // Habitat chart pagination — 18 top-level categories is more than
   // comfortably fits in the card's fixed chart height, so page through them
@@ -3075,16 +3087,26 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       .map(({ code, label }) => ({ code: label, rawCode: code, count: threatCounts[code] ?? 0, label: threatBarLabel(threatCounts[code] ?? 0) }))
       .filter(d => d.count > 0)
       .sort((a, b) => b.count - a.count);
-    // selectedItems needs to use labels too for dimming
+    // selectedItems needs to use labels too for dimming. A category counts as
+    // "selected" for muting purposes if it's directly selected OR any of its
+    // children are (so clicking a pill mutes every OTHER top-level bar, not
+    // just the ones that are themselves literally selected) — otherwise this
+    // set would always end up empty once only a child pill is picked, and no
+    // muting would ever happen.
     const selectedThreatLabels = new Set(
-      Array.from(selectedThreats).map(code => THREAT_CATEGORIES.find(c => c.code === code)?.label).filter(Boolean) as string[]
+      THREAT_CATEGORIES.filter(c =>
+        Array.from(selectedThreats).some(sel => sel === c.code || sel.startsWith(c.code + "."))
+      ).map(c => c.label)
     );
     const loading = speciesLoading && assessedSpecies.length === 0;
+    // Pills' left edge lines up with where the bars themselves start (past the
+    // y-axis label column), not the chart's left edge — yAxisWidth (155) +
+    // FilterBarChart's default leftMargin (5).
     const renderThreatPills = (rawCode: string) => {
       const drillCat = THREAT_CATEGORIES.find(c => c.code === rawCode);
       if (!drillCat) return null;
       return (
-        <div className="flex flex-wrap gap-1 pl-2 pb-1">
+        <div className="flex flex-wrap gap-1 pb-1" style={{ paddingLeft: 160 }}>
           {drillCat.children.map(child => {
             const count = threatCounts[child.code] ?? 0;
             if (count === 0) return null;
@@ -3123,7 +3145,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
         ) : threatBarData.length > 0 ? (
           renderInlineDrilldown(
             threatBarData,
-            (rawCode) => expandedThreat === rawCode,
+            (rawCode) => expandedThreat.has(rawCode),
             renderThreatPills,
             {
               dataKey: "code",
@@ -3138,7 +3160,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   if (prev.size === 1 && prev.has(code)) return new Set();
                   return new Set([code]);
                 });
-                setExpandedThreat(prev => prev === code ? null : code);
+                setExpandedThreat(prev => { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; });
               },
               barColor: "#8b5cf6",
               yAxisWidth: 155,
@@ -3170,14 +3192,16 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     const safeHabitatPage = Math.min(habitatPage, habitatTotalPages - 1);
     const pagedHabitatBarData = habitatBarData.slice(safeHabitatPage * HABITAT_PAGE_SIZE, (safeHabitatPage + 1) * HABITAT_PAGE_SIZE);
     const selectedHabitatLabels = new Set(
-      Array.from(selectedHabitat).map(code => HABITAT_CATEGORIES.find(c => c.code === code)?.label).filter(Boolean) as string[]
+      HABITAT_CATEGORIES.filter(c =>
+        Array.from(selectedHabitat).some(sel => sel === c.code || sel.startsWith(c.code + "."))
+      ).map(c => c.label)
     );
     const loading = speciesLoading && assessedSpecies.length === 0;
     const renderHabitatPills = (rawCode: string) => {
       const drillCat = HABITAT_CATEGORIES.find(c => c.code === rawCode);
       if (!drillCat) return null;
       return (
-        <div className="flex flex-wrap gap-1 pl-2 pb-1">
+        <div className="flex flex-wrap gap-1 pb-1" style={{ paddingLeft: 160 }}>
           {drillCat.children.map(child => {
             const count = habitatCounts[child.code] ?? 0;
             if (count === 0) return null;
@@ -3376,7 +3400,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           <>
             {renderInlineDrilldown(
               pagedHabitatBarData,
-              (rawCode) => expandedHabitat === rawCode,
+              (rawCode) => expandedHabitat.has(rawCode),
               renderHabitatPills,
               {
                 dataKey: "code",
@@ -3391,7 +3415,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                     if (prev.size === 1 && prev.has(code)) return new Set();
                     return new Set([code]);
                   });
-                  setExpandedHabitat(prev => prev === code ? null : code);
+                  setExpandedHabitat(prev => { const next = new Set(prev); if (next.has(code)) next.delete(code); else next.add(code); return next; });
                 },
                 barColor: "#0d9488",
                 yAxisWidth: 155,
@@ -3441,7 +3465,11 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // value), so drilling into one branch never collapses another branch you
   // already had open.
   const renderCriteriaRow = (nodes: CriteriaNode[], depth: number) => (
-    <div className="flex flex-wrap gap-1" style={{ paddingLeft: depth * 10 }}>
+    // Depth 1's pills align with where the bar chart's bars start
+    // (yAxisWidth 42 + leftMargin 5 = 47), same principle as Threats/Habitat's
+    // top-level pills; deeper levels keep the original 10px-per-level
+    // staircase on top of that base.
+    <div className="flex flex-wrap gap-1" style={{ paddingLeft: 47 + (depth - 1) * 10 }}>
       {nodes.map(node => {
         const isSelected = selectedCriteria.has(node.code);
         const count = criteriaCounts[node.code] ?? 0;
@@ -3497,12 +3525,20 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // recursive pill rows, unchanged — the issue's "opens pills not nested bars"
   // ask was already true for Criteria beyond the top level.
   const criteriaCard = (() => {
-    const criteriaLabelToCode = new Map(CRITERIA_CATEGORIES.map(c => [c.label, c.code]));
+    // code === rawCode here (CRITERIA_CATEGORIES' top-level code is already
+    // the bare letter) — bare letters on the axis match Number of
+    // Assessments' bare short labels so the two charts' bar geometry lines up
+    // when they sit side by side; the full description moves to the tooltip
+    // via labelFormatter below instead of living on the axis.
     const criteriaBarData: DrilldownBarDatum[] = CRITERIA_CATEGORIES
-      .map(({ code, label }) => ({ code: label, rawCode: code, count: criteriaCounts[code] ?? 0, label: (criteriaCounts[code] ?? 0).toLocaleString() }))
+      .map(({ code }) => ({ code, rawCode: code, count: criteriaCounts[code] ?? 0, label: (criteriaCounts[code] ?? 0).toLocaleString() }))
       .filter(d => d.count > 0 || selectedCriteria.has(d.rawCode));
-    const selectedCriteriaLabels = new Set(
-      Array.from(selectedCriteria).map(code => CRITERIA_CATEGORIES.find(c => c.code === code)?.label).filter(Boolean) as string[]
+    // A top-level letter counts as "selected" (and so isn't muted) if it OR
+    // any of its selected descendants (e.g. "B1b" under "B") is selected.
+    const selectedCriteriaCodes = new Set(
+      CRITERIA_CATEGORIES.filter(c =>
+        Array.from(selectedCriteria).some(sel => sel === c.code || sel.startsWith(c.code))
+      ).map(c => c.code)
     );
     const loading = speciesLoading && assessedSpecies.length === 0;
     const renderCriteriaPills = (rawCode: string) => {
@@ -3524,10 +3560,9 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             renderCriteriaPills,
             {
               dataKey: "code",
-              selectedItems: selectedCriteriaLabels,
+              selectedItems: selectedCriteriaCodes,
               onBarClick: (data: { payload?: { code?: string } }, event: React.MouseEvent) => {
-                const label = data.payload?.code;
-                const code = label ? criteriaLabelToCode.get(label) : undefined;
+                const code = data.payload?.code;
                 if (!code) return;
                 const isMulti = event.metaKey || event.ctrlKey;
                 if (isMulti) {
@@ -3541,9 +3576,9 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 }
               },
               barColor: "#6366f1",
-              yAxisWidth: 100,
-              rightMargin: 60,
-              yAxisTickMaxLength: 14,
+              yAxisWidth: 42,
+              rightMargin: 85,
+              labelFormatter: (code: string) => CRITERIA_CATEGORIES.find(c => c.code === code)?.label ?? code,
             }
           )
         ) : (
@@ -4333,9 +4368,9 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                 onClick={() => {
                   clearAllFiltersAndTaxa();
                   setShowOnlyStarred(false);
-                  setExpandedThreat(null);
+                  setExpandedThreat(new Set());
                   setExpandedCriteria(new Set());
-                  setExpandedHabitat(null);
+                  setExpandedHabitat(new Set());
                 }}
                 title="Reset all filters and the selected taxon"
                 className="px-2 md:px-3 py-1.5 rounded-lg text-xs md:text-sm font-medium transition-colors flex items-center gap-1 md:gap-1.5 bg-white text-zinc-700 border border-zinc-200 hover:bg-zinc-50 dark:bg-zinc-800 dark:text-zinc-300 dark:border-zinc-700 shrink-0"

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -1256,11 +1256,13 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     return false;
   }, [selectedObsRanges]);
 
-  // Bucket a species' assessment_count into a chart-bar label. 5+ collapses the
-  // long tail (a handful of species have 8-9 historical assessments) into one bar.
+  // Bucket a species' REASSESSMENT count (total assessments minus the first,
+  // original one) into a chart-bar label. 5+ collapses the long tail (a
+  // handful of species have 8-9 historical assessments, i.e. 7-8
+  // reassessments) into one bar.
   const assessmentCountBucket = useCallback((count: number | null | undefined): string => {
-    const n = count ?? 1;
-    return n >= 5 ? "5+" : String(n);
+    const reassessments = (count ?? 1) - 1;
+    return reassessments >= 5 ? "5+" : String(reassessments);
   }, []);
 
   // Helper to check if species matches the number-of-assessments filter (#423 item 1)
@@ -1789,19 +1791,20 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     }));
   }, [taxaFilteredSpecies, selectedCategories, selectedCountries, selectedYearRanges, selectedSystems, selectedPopulationTrends, selectedMovementPatterns, selectedThreats, selectedCriteria, matchesHabitatFilter, endemicsOnly, selectedGrowthForms, matchesSearch, matchesAssessorsFilter, matchesReviewersFilter, matchesYearRangeFilter, selectedAssessmentYears, matchesAssessmentYearFilter]);
 
-  // Number of Assessments chart (#423 item 1): apply all filters EXCEPT the
-  // assessment-count selection itself. NE species have no assessment history
+  // Number of Reassessments chart (#423 item 1): apply all filters EXCEPT the
+  // reassessment-count selection itself. NE species have no assessment history
   // (assessment_count is null) so they're excluded, same as other
   // assessment-only charts.
   const assessmentCountData = useMemo(() => {
     const buckets = [
+      { range: "0", shortRange: "0", count: 0 },
       { range: "1", shortRange: "1", count: 0 },
       { range: "2", shortRange: "2", count: 0 },
       { range: "3", shortRange: "3", count: 0 },
       { range: "4", shortRange: "4", count: 0 },
       { range: "5+", shortRange: "5+", count: 0 },
     ];
-    const byBucket: Record<string, number> = { "1": 0, "2": 1, "3": 2, "4": 3, "5+": 4 };
+    const byBucket: Record<string, number> = { "0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5+": 5 };
     taxaFilteredSpecies.forEach(s => {
       if (s.category === "NE") return;
       if (!matchesSearch(s)) return;
@@ -2731,7 +2734,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     });
   };
 
-  // Handle Number of Assessments bar click
+  // Handle Number of Reassessments bar click
   const handleAssessmentCountClick = (data: { payload?: { range?: string } }, event: React.MouseEvent) => {
     const range = data.payload?.range;
     if (!range) return;
@@ -2749,13 +2752,13 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     });
   };
 
-  // "Reassessed" shortcut (#423 item 1): one click selects every bucket >= 2,
+  // "1+" shortcut (#423 item 1): one click selects every bucket except "0",
   // flagging species that have been reassessed at least once. Toggling off
   // clears the selection entirely, mirroring the Outdated shortcut.
-  const REASSESSED_BUCKETS = ["2", "3", "4", "5+"];
-  const isReassessedSelected = REASSESSED_BUCKETS.every(b => selectedAssessmentCounts.has(b)) && selectedAssessmentCounts.size === REASSESSED_BUCKETS.length;
-  const handleReassessedClick = () => {
-    setSelectedAssessmentCounts(isReassessedSelected ? new Set() : new Set(REASSESSED_BUCKETS));
+  const ONE_PLUS_BUCKETS = ["1", "2", "3", "4", "5+"];
+  const isOnePlusSelected = ONE_PLUS_BUCKETS.every(b => selectedAssessmentCounts.has(b)) && selectedAssessmentCounts.size === ONE_PLUS_BUCKETS.length;
+  const handleOnePlusClick = () => {
+    setSelectedAssessmentCounts(isOnePlusSelected ? new Set() : new Set(ONE_PLUS_BUCKETS));
   };
 
   // Handle Year Described bucket bar click
@@ -3051,7 +3054,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     renderPills: (rawCode: string) => React.ReactNode,
     chartProps: Omit<React.ComponentProps<typeof FilterBarChart>, "data">,
     // Per-row pixel height. Default (22) is Threats/Habitat's original sizing;
-    // Criteria passes 38 to match Number of Assessments' bar thickness, since
+    // Criteria passes 38 to match Number of Reassessments' bar thickness, since
     // that chart sits fixed at 200px for its always-5 buckets (200/5 = 40px
     // slot, minus FilterBarChart's internal 5px top/bottom margins = 38px).
     rowHeight = 22
@@ -3561,7 +3564,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     return (
       <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
         <div className="flex items-center justify-between mb-1 min-h-[24px]">
-          <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Criteria</span>
+          <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Assessment Criteria</span>
         </div>
         {loading ? (
           <div style={{ height: 90 }} className="flex items-center justify-center"><Spinner className="h-4 w-4" /></div>
@@ -4027,7 +4030,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           )}
 
           {/* Country + Threats are always visible, alongside Charts row 1
-              above — everything past that (Criteria/Number of Assessments,
+              above — everything past that (Assessment Criteria/Number of Reassessments,
               Realm/Movement/Trend, Habitat/Assessors-Reviewers, Growth Form)
               lives behind the "More Filters" toggle below. No
               independently-scrollable panel here anymore — nested
@@ -4060,7 +4063,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
 
           {!isNewAssessments && moreFiltersOpen && (
             <>
-                {/* Criteria alongside Number of Assessments — a row, not a
+                {/* Assessment Criteria alongside Number of Reassessments — a row, not a
                     stack (previously stacked in Habitat's right column; moved
                     out once Habitat started pairing with Assessors/Reviewers
                     instead). */}
@@ -4082,31 +4085,32 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                       parseCriteriaCodes' startsWith-based matching). */}
                   {!isNewAssessments && criteriaCard}
 
-                  {/* Number of Assessments (#423 item 1) — how many times a
-                      species has been assessed, with a "Reassessed" shortcut
-                      selecting every bucket >= 2 in one click (flags species
-                      reassessed at least once, per the issue's explicit ask),
-                      same shape as the Outdated shortcut next to Years Since
-                      Assessed. */}
+                  {/* Number of Reassessments (#423 item 1) — how many times a
+                      species has been reassessed beyond its original
+                      assessment (assessment_count - 1), with a "1+" shortcut
+                      selecting every bucket except "0" in one click (flags
+                      species reassessed at least once, per the issue's
+                      explicit ask), same shape as the Outdated shortcut next
+                      to Years Since Assessed. */}
                   {!isNewAssessments && (
                     <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
                       <div className="flex items-center justify-between mb-1">
-                        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Number of Assessments</span>
+                        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Number of Reassessments</span>
                         <button
                           type="button"
-                          onClick={handleReassessedClick}
+                          onClick={handleOnePlusClick}
                           className={`px-2 py-0.5 text-xs font-semibold rounded transition-colors ${
-                            isReassessedSelected
+                            isOnePlusSelected
                               ? "bg-red-600 text-white shadow-sm"
                               : "bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"
                           }`}
-                          aria-pressed={isReassessedSelected}
-                          title="Filter to species assessed 2 or more times (reassessed at least once)"
+                          aria-pressed={isOnePlusSelected}
+                          title="Filter to species reassessed 1 or more times"
                         >
-                          Reassessed
+                          1+
                         </button>
                       </div>
-                      <div style={{ height: 200 }} className="flex items-center justify-center">
+                      <div style={{ height: 240 }} className="flex items-center justify-center">
                         {speciesLoading && assessedSpecies.length === 0 ? (
                           <Spinner />
                         ) : isSingleSpecies && singleSpecies ? (

--- a/app/src/components/redlist/ReviewerChart.tsx
+++ b/app/src/components/redlist/ReviewerChart.tsx
@@ -81,10 +81,10 @@ export default function AssessorChart({
 
   return (
     <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
-      <div className="flex items-center justify-between mb-1">
+      <div className="flex items-center gap-2 mb-1.5">
         {showToggle ? (
           /* Toggle between Assessors and Reviewers */
-          <div className="inline-flex rounded-md bg-zinc-100 dark:bg-zinc-800 p-0.5">
+          <div className="inline-flex rounded-md bg-zinc-100 dark:bg-zinc-800 p-0.5 shrink-0">
             <button
               onClick={() => handleViewModeChange("assessors")}
               className={`px-2 py-0.5 text-xs font-semibold rounded transition-colors ${
@@ -107,42 +107,41 @@ export default function AssessorChart({
             </button>
           </div>
         ) : (
-          <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">{title}</span>
+          <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 shrink-0">{title}</span>
         )}
-        <span className="text-[10px] text-zinc-400 hidden xl:inline">(cmd/ctrl+click to multiselect)</span>
-      </div>
 
-      {/* Search input */}
-      <div className="relative mb-1.5">
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => handleSearchChange(e.target.value)}
-          placeholder={`Search ${activeLabel}...`}
-          className="w-full px-2.5 py-1 pl-7 pr-14 rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-1 focus:ring-red-500 text-xs"
-        />
-        <svg
-          className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-zinc-400 pointer-events-none"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-        </svg>
-        {search && (
-          <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-1 text-[10px] text-zinc-400">
-            <span>{searchResults.length} result{searchResults.length !== 1 ? "s" : ""}</span>
-            <button
-              onClick={() => handleSearchChange("")}
-              className="p-0.5 rounded hover:bg-zinc-200 dark:hover:bg-zinc-700"
-              title="Clear search"
-            >
-              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-        )}
+        {/* Search input, in the header row alongside the toggle */}
+        <div className="relative flex-1 min-w-0">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            placeholder={`Search ${activeLabel}...`}
+            className="w-full px-2.5 py-1 pl-7 pr-14 rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 placeholder-zinc-400 focus:outline-none focus:ring-1 focus:ring-red-500 text-xs"
+          />
+          <svg
+            className="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-zinc-400 pointer-events-none"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          {search && (
+            <div className="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-1 text-[10px] text-zinc-400">
+              <span>{searchResults.length} result{searchResults.length !== 1 ? "s" : ""}</span>
+              <button
+                onClick={() => handleSearchChange("")}
+                className="p-0.5 rounded hover:bg-zinc-200 dark:hover:bg-zinc-700"
+                title="Clear search"
+              >
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          )}
+        </div>
       </div>
 
       <div style={{ height: 240 }} className="flex items-center justify-center">


### PR DESCRIPTION
## Summary

Closes #436. Unifies the interaction pattern across all three hierarchical filters (Criteria, Threats, Habitat): **top level is a bar chart, drilling into a category shows pills, not another bar chart.**

Previously Criteria was pills at every level, while Threats and Habitat were a bar chart at the top level that drilled into a *second, nested* bar chart for sub-categories. Neither matched the target pattern — Criteria needed a bar chart on top, Threats/Habitat needed pills on drill-down.

## What this PR does

**Criteria** — extracted a new `criteriaCard` (mirroring `threatsCard`/`habitatCard`'s shape) with the top-level A-E row rendered as a `FilterBarChart` instead of a pill row. A bar click still both selects the code and toggles its membership in `expandedCriteria`, exactly as before. Deliberately **not** sorted by count (unlike Threats/Habitat) — A-E is a standardized, widely recognized IUCN ordering, and reshuffling it by species count would work against that familiarity.

Deeper levels (number → sub-clause → roman numeral) are untouched — `renderCriteriaLevel`'s recursive, Set-based multi-branch pill rendering already matched the "opens pills" ask beyond the top level, so nothing needed to change there. Multi-branch expansion (e.g. B and C simultaneously) still works.

**Threats and Habitat** — replaced the second, nested `<FilterBarChart>` that rendered sub-category counts with a flat pill row (same style as Criteria's existing pills), reusing the same `drillCat`/`drillSubData` derivation and single-expand (`expandedThreat`/`expandedHabitat`) state — only the sub-level's *rendering* changed, not the drill mechanics. (The close button described below was itself superseded by the follow-up round — see below.)

## Bug caught during review

An initial pass reused a too-narrow `yAxisWidth` (22px, sized for a single letter) for Criteria's chart, but the axis data key holds the full descriptive label ("A — Population reduction") for consistency with Threats/Habitat — labels rendered garbled/overlapping. Fixed by widening to 100px with `yAxisTickMaxLength={14}` truncation, matching the same pattern Threats/Habitat already use.

## Follow-up round: pills move inline, merged Assessors/Reviewers, More Filters reorder

Based on review feedback after the first pass:

- **Pills now render directly below the clicked bar**, not in a separate scrollable section below the whole chart. Added a shared `renderInlineDrilldown()` helper: splits the bar data into segments around each expanded item — recharts can't interleave arbitrary content between bars in one chart instance, so this renders one `FilterBarChart` per segment with pills sandwiched between. Criteria's multi-branch `Set`-based expansion can produce more than 2 segments (e.g. B and C both expanded → 3 segments); Threats/Habitat's single-value expand state produces at most 2. The card now grows to fit instead of scrolling — no more fixed-height area. Also shrank the pills (smaller text/padding) and dropped the now-redundant drilled-category header + close (×) button, since the pills' position already shows which bar they belong to and re-clicking that bar collapses them.
- **Verified multi-select still composes correctly** after the rewrite: clicking a top-level bar then cmd-clicking two of its pills results in all three codes in the URL together (e.g. `habitat=1,1.1,1.2`), not the pills replacing each other or the parent selection.
- **Assessors/Reviewers merged into one toggleable chart**, reusing `ReviewerChart`'s existing (previously disabled) `showToggle` prop instead of two permanently side-by-side charts — halves the vertical space at the cost of one click to see the other list.
- **More Filters reordered**: Criteria and Number of Assessments moved out of Habitat's right-column stack into their own row; Realm/Movement/Trend became its own row (3 columns); Habitat now pairs with the merged Assessors/Reviewers chart; Growth Form moved to the last row. (The row order was swapped again in a later round — Criteria/Number of Assessments now comes first — see below.)

## Screenshots

Current layout (shown on Plants, since Growth Form only renders for plants/fungi) — Growth Form, Criteria + Number of Assessments row, Realm/Movement/Trend row, Habitat + merged Assessors/Reviewers row (the row order went through a few more swaps in later rounds — see below):

![layout](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-437-bar-chart-drilldown/04-layout-v9.png)

(See the bar-length-fix screenshots further down for the current rendering of a mid-list bar click — pills land directly below it, remaining bars continue below the pills, no scrollbar.)

## Follow-up round: multi-expand for Threats/Habitat, pill alignment, mute-on-select, Criteria/Number-of-Assessments geometry match

Based on further review feedback:

- **Threats and Habitat now support multi-expand**, matching Criteria's existing behavior. `expandedThreat`/`expandedHabitat` were single-value (`string | null`), so cmd-clicking two top-level bars only showed pills below whichever was clicked last. Converted both to `Set<string>` with the same unconditional toggle-on-click and per-category reconciliation effect Criteria already used — multi-selecting two threats (or habitats) now opens pills below both simultaneously.
- **Pills now left-align with where the bar itself starts**, not the chart's left edge — previously a small fixed `pl-2`/`paddingLeft: depth*10` left them hugging the card's edge, well to the left of the bars they belong to. Fixed for Threats, Habitat, and Criteria's nested pill levels (`renderCriteriaRow`) to align with `yAxisWidth + leftMargin`.
- **Selecting a pill (child code) now correctly mutes the other top-level bars.** The `selectedItems` set passed to each top-level chart was only matching *exact* top-level codes, so if just a child was selected (e.g. threat "5.1" but not "5"), the set ended up empty and no dimming ever triggered. Fixed by prefix-matching: a top-level category now counts as selected — and its siblings get dimmed — if it or any of its descendants is selected. Applies to Threats, Habitat, and Criteria.
- **Criteria's bars now match Number of Assessments' geometry exactly**, since the two sit side by side in the same row. Criteria previously showed the full descriptive label ("A — Population reduction...") with `yAxisWidth={100}`; now shows the bare letter (already the `code` field) with the same `yAxisWidth={42}`/`rightMargin={85}` Number of Assessments uses, so both charts' bars start and scale identically. The full description is still available via a hover tooltip.

Measured in-browser: Criteria's and Number of Assessments' bars both start at exactly 47px from their chart's left edge (`yAxisWidth 42 + leftMargin 5`), confirming the geometry match; pill left-edges also measured to land at the same x-coordinate as their parent bar's left edge for both Threats and Habitat.

## Bug caught after the above: bar lengths stretching in the segment below the pills

`renderInlineDrilldown` splits a chart's data into one `<FilterBarChart>` per segment around each expanded item (needed since recharts can't interleave arbitrary content between bars in one chart instance). Each segment is an independent chart instance, and without a shared `xAxisMax` its X axis auto-scaled to *that segment's own* local max count — so the segment below the pills (usually holding smaller counts than whatever came before it) stretched its bars to fill the width instead of staying proportional to how the un-split chart used to render. Fixed by computing one max count across the full dataset and passing it to every segment via `xAxisMax`, so bar length stays comparable across the split, same as before the split existed.

## Bug caught after the above: stray focus-outline rectangle on click

Clicking a bar (e.g. "Invasive species") left a rectangle highlighted around the chart segment below the pills until clicking elsewhere. Cause: recharts' accessibility layer sets `tabIndex={0}` on the chart's root SVG so keyboard users can reach the tooltip, but that also makes an ordinary mouse click focus it, and the browser draws its default focus-ring outline around the SVG until focus moves away. Fixed with a global CSS rule scoped to `svg.recharts-surface` (`src/app/globals.css`): suppressed on `:focus` (mouse clicks), kept on `:focus-visible` so keyboard-driven focus still gets a visible ring — same pattern this file already used for the dual-range slider's focus ring.

## Follow-up: match Criteria's bar row height to Number of Assessments'

Criteria's bars used the same 22px-per-row sizing as Threats/Habitat's `renderInlineDrilldown` segments, noticeably thinner than Number of Assessments' bars despite the two charts sitting side by side in the same row. Number of Assessments is fixed at 200px for its always-5 buckets (200/5 = 40px slot, minus `FilterBarChart`'s 5px top/bottom margins = 38px per row). Added an optional `rowHeight` parameter to `renderInlineDrilldown` (default 22, unchanged for Threats/Habitat) and passed 38 for Criteria specifically. Measured in-browser: both charts' first bar now render at 29-30px tall (1px apart due to rounding, visually identical).

Screenshots (also reflect the bar-length and focus-outline fixes above) — Threats with a mid-list bar ("System modifications") expanded: pills land directly below it, aligned with the bar, muting the other top-level bars, the segment below the pills scales consistently (not stretched), and no stray focus rectangle remains. Criteria's bars are now visibly as thick as Number of Assessments':

![threats fixes](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-437-bar-chart-drilldown/01-threats-v9.png)

Same for Habitat (Artificial/Terrestrial expanded):

![habitat fixes](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-437-bar-chart-drilldown/02-habitat-v9.png)

## Follow-up: Criteria/Number of Assessments row moved above Realm/Movement/Trend

Swapped the order of the two top rows in More Filters — Criteria + Number of Assessments now comes first, Realm/Movement/Trend second (both a plain content swap of the two `<div className="grid ...">` blocks, no logic changes). See the layout screenshot above for the current order.

## Follow-up: Number of Assessments → Number of Reassessments, Criteria → Assessment Criteria

- **"Number of Assessments" renamed to "Number of Reassessments"**, and its bucket scale changed from `1,2,3,4,5+` (total assessments) to `0,1,2,3,4,5+` (assessments *beyond* the original one — `reassessments = assessment_count - 1`). Bucket "0" now reads as "never reassessed" (assessed exactly once); "5+" now means 6 or more total assessments. Chart container grown from 200px to 240px to keep per-row bar thickness consistent with the added bucket (still matches Assessment Criteria's row height from the earlier fix). (The top bucket was collapsed from "5+" to "4+" in a later round — see below.)
- **"Reassessed" shortcut renamed to "1+"**, selecting every bucket except "0" — same underlying species set as before (assessment_count ≥ 2), just relabeled to match the new 0-indexed scale so the button text and axis stay consistent.
- **"Criteria" card renamed to "Assessment Criteria"**.

## Follow-up: collapse "5+" into "4+", harden the focus-outline fix, shorten both rows

- **Number of Reassessments' top bucket collapsed from "5+" to "4+"** (now `0,1,2,3,4+`, five buckets instead of six) — one fewer, less granular tail bucket. The "1+" shortcut now selects `1,2,3,4+`.
- **The earlier focus-outline fix wasn't fully suppressing the rectangle** — the `:focus`/`:focus-visible` split (suppress on plain click, keep for keyboard nav) apparently still let some clicks show the ring, likely a browser-dependent quirk in how a click on an SVG with a manually-set `tabIndex` gets classified. Replaced with an unconditional, `!important` rule on `svg.recharts-surface` and all its descendants, and added `-webkit-tap-highlight-color: transparent` to also cover Safari's separate translucent tap-highlight box (a different mechanism outline:none doesn't touch).
- **Assessment Criteria and Number of Reassessments rows shortened**: Number of Reassessments' container 240px → 170px, Criteria's per-row height 38px → 32px (both dropped further once the bucket count also went from 6 to 5). The two charts' bar thickness still match each other (measured ~34px/~32px per row).

Verified in browser: axis now reads `0,1,2,3,4+`; clicking "1+" selects buckets `1,2,3,4+` and mutes bucket "0"; a real mousedown+move+mouseup click (not a clean synthetic click) on Threats and Habitat bars leaves `document.activeElement`'s computed `outline` as `none`; both charts' `svg` height measured at ~168-170px (down from ~198-200px). Screenshots above (layout, threats, habitat) reflect the new scale and heights.

## Follow-up: revert "Number of Reassessments" back to "Number of Assessments"

The reassessment-count relabeling broke the selected-filter chip: it renders `"{count} assessments"`, so a selected bucket "0" showed as "0 assessments" — misleading, since every assessed species has at least one assessment. Reverted the bucket function and chart back to raw `assessment_count` (`1,2,3,4,5+`) and the chart title back to "Number of Assessments". The shortcut button reverted to "Reassessed" (selects buckets ≥ 2, i.e. 1+ reassessment = 2+ total assessments) — same underlying species set as the "1+" button it replaces, just labeled to avoid the ambiguity a bare "1+" would have against a chart showing raw assessment counts again. "Assessment Criteria" naming is unaffected.

Verified in browser: card title reads "Number of Assessments" again; clicking "Reassessed" selects buckets `2,3,4,5+` (URL: `assessmentCounts=2,3,4,5+`); the resulting filter chips read "2 assessments", "3 assessments", etc. — no more "0 assessments". Screenshots above (layout, threats, habitat) reflect the reverted naming and scale.

## Follow-up: Assessors/Reviewers search moves into the header row, drop the multiselect hint

`ReviewerChart`'s search input previously sat on its own row below the Assessors/Reviewers toggle, with a "(cmd/ctrl+click to multiselect)" hint on the toggle's row. Merged them: the search input now sits in the header row itself (`flex-1` next to the `shrink-0` toggle), saving a row of vertical space, and dropped the hint text entirely. Search/clear/result-count behavior is unchanged, just repositioned.

## Follow-up: Growth Form moved to the top of More Filters

Reordered More Filters again: Growth Form now comes first, followed by Assessment Criteria/Number of Assessments, Realm/Movement/Trend, and Habitat/Assessors-Reviewers. Plain content move (swapped which block sits first inside the `moreFiltersOpen` fragment), no logic changes. Layout screenshot above now shows Plants (rather than Mammals) specifically so Growth Form — which only renders for plants/fungi — is visible in its new top position.

## Bug caught after the above: Habitat's selected-pill color didn't match its chart's bar color

Habitat's bar chart uses `barColor="#0d9488"` (Tailwind `teal-600`), but its selected child pills used `bg-teal-500` — a visibly lighter shade of the same hue. Threats (`bg-violet-500` pill / `#8b5cf6` bar — both `violet-500`) and Criteria (`bg-indigo-500` pill / `#6366f1` bar — both `indigo-500`) already matched exactly; only Habitat's pill was off by one shade. Fixed by changing the pill to `bg-teal-600` to match.

![habitat pill color fix](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-437-bar-chart-drilldown/06-habitat-pill-color-fix.png)

Verified in browser: computed `background-color` of a selected Habitat pill and `fill` of its parent bar both resolve to `rgb(13, 148, 136)` (`#0d9488`).

## Test plan

- [x] Typecheck passes
- [x] Lint passes (0 errors, 0 warnings)
- [x] Full test suite passes (744 tests)
- [x] Verified in browser: Criteria renders as a bar chart with correctly readable axis labels
- [x] Verified in browser: clicking a bar selects it, cross-filters the page, and expands pills directly below that bar (not a separate section)
- [x] Verified in browser: multi-branch Criteria expansion (e.g. B and C both open at once) still works, each with its own pills inline
- [x] Verified in browser: cmd/ctrl-click multi-select composes correctly across a bar click and multiple pill clicks
- [x] Verified in browser: Assessors/Reviewers toggle switches between the two charts correctly
- [x] Verified in browser: Growth Form still appears (plants-only) in its new last-row position
- [x] Verified in browser: full row order (Criteria/Number of Assessments, Realm/Movement/Trend, Habitat/Assessors-Reviewers, Growth) renders correctly
- [x] Verified in browser: cmd-clicking two top-level Threats bars (and separately, two Habitat bars) opens pills below both at once, with the URL reflecting both codes (e.g. `threats=5,2`, `habitat=1,14`)
- [x] Verified in browser (measured via `getBoundingClientRect`): pill rows' left edge exactly matches their parent bar's left edge, for both Threats and Habitat
- [x] Verified in browser: selecting a pill visibly mutes sibling top-level bars in Threats and Habitat
- [x] Verified in browser (measured via `getBoundingClientRect`): Criteria's and Number of Assessments' bars start at the identical 47px offset from their chart's left edge
- [x] Verified in browser: bar widths measured across a segment split (mid-list bar expanded) are monotonically consistent with their counts, not stretched to fill the second segment's own width
- [x] Verified in browser: clicking a bar no longer leaves a focus-outline rectangle around the chart (checked `document.activeElement`'s computed `outline` is `none` after click)
- [x] Verified in browser (measured via `getBoundingClientRect`): Criteria's and Number of Assessments' first bar render at matching height (29px vs 30px, 1px rounding)
- [x] Verified in browser: "1+" shortcut selects buckets `1,2,3,4+` and mutes bucket "0"; card titles read "Assessment Criteria" and "Number of Reassessments"; axis reads `0,1,2,3,4+`
- [x] Verified in browser: a real (non-synthetic) mousedown+move+mouseup click on Threats and Habitat bars leaves no focus-outline rectangle (`document.activeElement`'s computed `outline` is `none`)
- [x] Verified in browser (measured via `getBoundingClientRect`): Assessment Criteria and Number of Reassessments charts are both ~168-170px tall, down from ~198-200px, with matching bar thickness
- [x] Verified in browser: card title reads "Number of Assessments" (reverted); "Reassessed" shortcut selects buckets `2,3,4,5+`; filter chips read "2 assessments" etc., not "0 assessments"
- [x] Verified in browser: Assessors/Reviewers search input renders in the header row next to the toggle, not on its own row; the "(cmd/ctrl+click to multiselect)" hint text is gone; search filtering/clear/result-count still work in the new layout
- [x] Verified in browser (on Plants): Growth Form renders first in More Filters, ahead of Assessment Criteria/Number of Assessments, Realm/Movement/Trend, and Habitat/Assessors-Reviewers
- [x] Verified in browser: selected Habitat pill's computed background-color matches its parent bar's fill color exactly (`rgb(13, 148, 136)` both)
- [x] No console errors











