### PR TITLE
Fix sign-in on red.cst.cam.ac.uk / en.ki: keep OAuth on the domain the browser is on

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -50,13 +50,14 @@ const nextConfig: NextConfig = {
   // Server Actions (e.g. the GitHub sign-in form in /login) reject any request
   // whose Origin header doesn't match the request's own host, as CSRF
   // protection — by default only the exact same origin is trusted. This app is
-  // served on multiple custom domains (see src/config/brand.ts), and at least
-  // one (red.cst.cam.ac.uk, likely proxied through Cambridge's own campus DNS/
-  // reverse-proxy layer in front of Vercel) was seen 500ing on sign-in because
-  // the origin Next.js saw didn't match what it expected — list every domain
-  // this app answers on explicitly, plus a wildcard for Vercel's own preview
-  // deployments (both URL shapes: the stable git-branch alias and the
-  // per-deployment hash that changes on every push).
+  // served on multiple custom domains (see src/config/brand.ts), and two of them
+  // (red.cst.cam.ac.uk and en.ki) reach Vercel through a Caddy reverse proxy on
+  // a Cambridge VM that rewrites Host to red-list-dashboard.vercel.app, so the
+  // Origin the browser sends never matches the Host Next.js sees and sign-in
+  // 500s without an explicit entry — list every domain this app answers on,
+  // plus a wildcard for Vercel's own preview deployments (both URL shapes: the
+  // stable git-branch alias and the per-deployment hash that changes on every
+  // push). Keep in step with src/config/public-origin.ts.
   experimental: {
     serverActions: {
       allowedOrigins: [
@@ -64,6 +65,7 @@ const nextConfig: NextConfig = {
         "dashoflife.org",
         "red-list-dashboard.vercel.app",
         "red.cst.cam.ac.uk",
+        "en.ki",
         "*-shaneweiszs-projects.vercel.app",
       ],
     },

--- a/app/src/app/auth/callback/route.ts
+++ b/app/src/app/auth/callback/route.ts
@@ -1,18 +1,36 @@
 import { NextResponse } from "next/server";
+import { safeRedirectPath } from "@/config/public-origin";
 import { createClient } from "@/lib/supabase/server";
 
+/**
+ * Redirect with a *relative* Location, which the browser resolves against the
+ * URL it is already on.
+ *
+ * Deliberately not `NextResponse.redirect(absoluteUrl)`: the origin of
+ * `request.url` is built from the Host header, and behind the Caddy proxy in
+ * front of red.cst.cam.ac.uk / en.ki that header says
+ * red-list-dashboard.vercel.app. An absolute redirect therefore threw users off
+ * their own domain half-way through sign-in (#416). A relative one keeps them
+ * wherever they started, on every domain, with no host detection at all.
+ */
+function redirectToPath(path: string) {
+  return new NextResponse(null, { status: 302, headers: { Location: path } });
+}
+
 export async function GET(request: Request) {
-  const { searchParams, origin } = new URL(request.url);
+  const { searchParams } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/";
+  // `next` is attacker-controllable and a relative Location makes that matter —
+  // see safeRedirectPath.
+  const next = safeRedirectPath(searchParams.get("next"));
 
   if (code) {
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      return redirectToPath(next);
     }
   }
 
-  return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`);
+  return redirectToPath("/login?error=auth_callback_failed");
 }

--- a/app/src/app/login/SignInForm.tsx
+++ b/app/src/app/login/SignInForm.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { signInWithGitHub } from "@/lib/auth/actions";
+
+// window.location.origin never changes for the life of the page, so there is
+// nothing to subscribe to — this is just the React-sanctioned way to read a
+// browser-only value without a hydration mismatch. It renders as "" on the
+// server and during hydration, then as the real origin.
+const NEVER_CHANGES = () => () => {};
+const readOrigin = () => window.location.origin;
+const noOriginOnServer = () => "";
+
+/**
+ * Sends the browser's own origin along with the sign-in request.
+ *
+ * The server can't derive it reliably: red.cst.cam.ac.uk and en.ki are proxied
+ * to Vercel through a Caddy instance that rewrites the Host header, so the
+ * request arrives claiming to be red-list-dashboard.vercel.app and the OAuth
+ * callback used to be sent there — to a domain without the PKCE cookie, which
+ * failed the exchange (#416). Only the browser knows the true origin.
+ *
+ * Filled in after hydration (window doesn't exist during SSR). If JavaScript
+ * never runs, the field stays empty and the server falls back to the request
+ * headers, which is what every Vercel-served domain used before this.
+ */
+export function SignInForm() {
+  const origin = useSyncExternalStore(NEVER_CHANGES, readOrigin, noOriginOnServer);
+
+  return (
+    <form action={signInWithGitHub}>
+      <input type="hidden" name="origin" value={origin} />
+      <button
+        type="submit"
+        className="w-full flex items-center justify-center gap-3 px-4 py-2.5 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-700 dark:text-zinc-200 font-medium hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors"
+      >
+        <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23a11.28 11.28 0 013-.405c1.02 0 2.04.135 3 .405 2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+        </svg>
+        Sign in with GitHub
+      </button>
+    </form>
+  );
+}

--- a/app/src/app/login/page.tsx
+++ b/app/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
-import { signInWithGitHub } from "@/lib/auth/actions";
+import { SignInForm } from "./SignInForm";
 
 const ERROR_MESSAGES: Record<string, string> = {
   oauth_init_failed: "Couldn't start the GitHub sign-in flow. Please try again.",
@@ -35,17 +35,7 @@ export default async function LoginPage({
             {ERROR_MESSAGES[error] ?? "Something went wrong. Please try again."}
           </p>
         )}
-        <form action={signInWithGitHub}>
-          <button
-            type="submit"
-            className="w-full flex items-center justify-center gap-3 px-4 py-2.5 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-700 dark:text-zinc-200 font-medium hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors"
-          >
-            <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23a11.28 11.28 0 013-.405c1.02 0 2.04.135 3 .405 2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
-            </svg>
-            Sign in with GitHub
-          </button>
-        </form>
+        <SignInForm />
       </div>
     </div>
   );

--- a/app/src/config/__tests__/public-origin.test.ts
+++ b/app/src/config/__tests__/public-origin.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { resolvePublicOrigin, safeRedirectPath } from "../public-origin";
+
+// What the Caddy-proxied domains look like once Vercel sees them: the real
+// domain is gone from the headers entirely.
+const PROXIED_HEADERS = {
+  host: "red-list-dashboard.vercel.app",
+  protocol: "https",
+};
+
+describe("resolvePublicOrigin", () => {
+  it("uses the browser origin for a proxied domain the headers can't reveal", () => {
+    expect(resolvePublicOrigin("https://red.cst.cam.ac.uk", PROXIED_HEADERS)).toBe(
+      "https://red.cst.cam.ac.uk"
+    );
+    expect(resolvePublicOrigin("https://en.ki", PROXIED_HEADERS)).toBe("https://en.ki");
+  });
+
+  it("accepts the other production domains, with or without www", () => {
+    expect(resolvePublicOrigin("https://dashforlife.org", PROXIED_HEADERS)).toBe(
+      "https://dashforlife.org"
+    );
+    expect(resolvePublicOrigin("https://www.dashoflife.org", PROXIED_HEADERS)).toBe(
+      "https://www.dashoflife.org"
+    );
+  });
+
+  it("accepts Vercel preview deployments and localhost", () => {
+    expect(
+      resolvePublicOrigin(
+        "https://redlist-dashboard-git-some-branch-shaneweiszs-projects.vercel.app",
+        PROXIED_HEADERS
+      )
+    ).toBe("https://redlist-dashboard-git-some-branch-shaneweiszs-projects.vercel.app");
+    expect(
+      resolvePublicOrigin("http://localhost:3000", { host: "localhost:3000", protocol: "http" })
+    ).toBe("http://localhost:3000");
+  });
+
+  it("ignores an unknown origin rather than redirecting sign-in off-site", () => {
+    expect(resolvePublicOrigin("https://evil.com", PROXIED_HEADERS)).toBe(
+      "https://red-list-dashboard.vercel.app"
+    );
+    // A lookalike that merely contains a known host as a substring.
+    expect(resolvePublicOrigin("https://red.cst.cam.ac.uk.evil.com", PROXIED_HEADERS)).toBe(
+      "https://red-list-dashboard.vercel.app"
+    );
+    // ...and one that merely ends with the preview suffix's domain.
+    expect(resolvePublicOrigin("https://evil-shaneweiszs-projects.vercel.app.evil.com", PROXIED_HEADERS)).toBe(
+      "https://red-list-dashboard.vercel.app"
+    );
+  });
+
+  it("ignores non-http(s) schemes", () => {
+    expect(resolvePublicOrigin("javascript://red.cst.cam.ac.uk", PROXIED_HEADERS)).toBe(
+      "https://red-list-dashboard.vercel.app"
+    );
+  });
+
+  it("falls back to the headers when the form field is missing or unusable", () => {
+    // No JavaScript ran, so the hidden field posted empty.
+    expect(resolvePublicOrigin("", PROXIED_HEADERS)).toBe("https://red-list-dashboard.vercel.app");
+    expect(resolvePublicOrigin(null, PROXIED_HEADERS)).toBe(
+      "https://red-list-dashboard.vercel.app"
+    );
+    // FormData.get returns a File when the field name collides with an upload.
+    expect(resolvePublicOrigin(new Blob(), PROXIED_HEADERS)).toBe(
+      "https://red-list-dashboard.vercel.app"
+    );
+    expect(resolvePublicOrigin("not a url", PROXIED_HEADERS)).toBe(
+      "https://red-list-dashboard.vercel.app"
+    );
+  });
+
+  it("keeps working for domains Vercel serves directly", () => {
+    expect(
+      resolvePublicOrigin(undefined, { host: "dashforlife.org", protocol: "https" })
+    ).toBe("https://dashforlife.org");
+  });
+});
+
+describe("safeRedirectPath", () => {
+  it("passes through a normal in-app path, query and fragment included", () => {
+    expect(safeRedirectPath("/browse?taxon=Aves#top")).toBe("/browse?taxon=Aves#top");
+  });
+
+  it("rejects protocol-relative and absolute URLs that would leave the site", () => {
+    expect(safeRedirectPath("//evil.com")).toBe("/");
+    // Browsers normalise backslashes to slashes, so this is "//evil.com" too.
+    expect(safeRedirectPath("/\\evil.com")).toBe("/");
+    expect(safeRedirectPath("https://evil.com")).toBe("/");
+  });
+
+  it("defaults to the home page when absent or empty", () => {
+    expect(safeRedirectPath(null)).toBe("/");
+    expect(safeRedirectPath(undefined)).toBe("/");
+    expect(safeRedirectPath("")).toBe("/");
+  });
+});

--- a/app/src/config/public-origin.ts
+++ b/app/src/config/public-origin.ts
@@ -1,0 +1,78 @@
+// Every public host this app answers on. Keep in step with the brand map in
+// ./brand.ts and the Server Actions `allowedOrigins` list in next.config.ts.
+//
+// This exists because the server cannot always tell which of these it is being
+// asked for. red.cst.cam.ac.uk and en.ki are served through a Caddy reverse
+// proxy on a Cambridge VM that rewrites the Host header to
+// red-list-dashboard.vercel.app before forwarding to Vercel, so by the time a
+// request reaches Next.js every trace of the real domain is gone. The browser
+// always knows, though — so the sign-in form sends its own origin and we check
+// it against this list rather than trusting it outright (an unvalidated
+// caller-supplied redirect origin is an open redirect, and this one ends up in
+// an OAuth redirectTo).
+const PUBLIC_HOSTS = new Set([
+  "dashforlife.org",
+  "dashoflife.org",
+  "red-list-dashboard.vercel.app",
+  "red.cst.cam.ac.uk",
+  "en.ki",
+]);
+
+// Vercel preview deployments: both the stable git-branch alias and the
+// per-deployment hash, which changes on every push.
+const PREVIEW_HOST_SUFFIX = "-shaneweiszs-projects.vercel.app";
+
+const DEV_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+function isKnownHostname(hostname: string): boolean {
+  const bare = hostname.replace(/^www\./, "");
+  return (
+    PUBLIC_HOSTS.has(bare) ||
+    bare.endsWith(PREVIEW_HOST_SUFFIX) ||
+    DEV_HOSTNAMES.has(bare)
+  );
+}
+
+/**
+ * The origin to send users back to after an external redirect (OAuth).
+ *
+ * Prefers `clientOrigin` — the browser-reported `window.location.origin`, the
+ * only source that survives a Host-rewriting proxy — but only when it names a
+ * host we recognise. Anything else falls back to the request headers, which is
+ * correct for every domain Vercel serves directly.
+ */
+export function resolvePublicOrigin(
+  clientOrigin: unknown,
+  fallback: { host: string | null; protocol: string }
+): string {
+  if (typeof clientOrigin === "string" && clientOrigin !== "") {
+    try {
+      const url = new URL(clientOrigin);
+      if (
+        (url.protocol === "https:" || url.protocol === "http:") &&
+        isKnownHostname(url.hostname)
+      ) {
+        return url.origin;
+      }
+    } catch {
+      // Not a parseable URL — fall through to the header-derived origin.
+    }
+  }
+
+  return `${fallback.protocol}://${fallback.host}`;
+}
+
+/**
+ * Narrow an untrusted `?next=` value to a path that can only ever redirect
+ * within this site.
+ *
+ * This matters because the auth callback redirects *relatively* (see
+ * app/auth/callback/route.ts): "//evil.com" and "/\evil.com" — which browsers
+ * normalise to the same thing — are protocol-relative URLs, so as a bare
+ * Location they leave the site entirely. Only a single leading slash is
+ * same-origin.
+ */
+export function safeRedirectPath(next: string | null | undefined): string {
+  if (!next || next[0] !== "/" || next[1] === "/" || next[1] === "\\") return "/";
+  return next;
+}

--- a/app/src/lib/auth/actions.ts
+++ b/app/src/lib/auth/actions.ts
@@ -2,21 +2,27 @@
 
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { resolvePublicOrigin } from "@/config/public-origin";
 import { createClient } from "@/lib/supabase/server";
 
-export async function signInWithGitHub() {
+export async function signInWithGitHub(formData: FormData) {
   const supabase = await createClient();
 
-  // Derive the current domain from the Host header (what Vercel's own routing
-  // is built on, present on every request) rather than the browser-sent
-  // Origin header — Origin proved unreliable across this app's several
-  // custom domains (different DNS/proxy paths), occasionally producing a
-  // redirectTo Supabase didn't recognize and silently falling back to the
-  // Site URL instead of completing sign-in.
+  // Where GitHub should send the user back to. This has to be the domain the
+  // browser is actually on: the PKCE code verifier is stored in a cookie set on
+  // that domain, and if the callback lands anywhere else the cookie isn't sent
+  // and the code exchange fails (#416).
+  //
+  // The Host header alone can't tell us — red.cst.cam.ac.uk and en.ki reach
+  // Vercel through a proxy that rewrites Host to red-list-dashboard.vercel.app,
+  // so sign-in from those domains used to bounce the user to the vercel.app
+  // origin and fail there. The form posts the browser's own origin instead;
+  // resolvePublicOrigin validates it and falls back to the headers.
   const headersList = await headers();
-  const host = headersList.get("x-forwarded-host") ?? headersList.get("host");
-  const protocol = headersList.get("x-forwarded-proto") ?? "https";
-  const origin = `${protocol}://${host}`;
+  const origin = resolvePublicOrigin(formData.get("origin"), {
+    host: headersList.get("x-forwarded-host") ?? headersList.get("host"),
+    protocol: headersList.get("x-forwarded-proto") ?? "https",
+  });
 
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: "github",


### PR DESCRIPTION
Fixes #416.

## The bug

Signing in on https://red.cst.cam.ac.uk fails with *"Sign-in didn't complete. Please try again."* and dumps the user on `https://red-list-dashboard.vercel.app/login?error=auth_callback_failed`.

`red.cst.cam.ac.uk` and `en.ki` don't reach Vercel directly. They're served by a Caddy reverse proxy on the Cambridge VM, which rewrites the Host header before forwarding:

```
red.cst.cam.ac.uk, en.ki {
    reverse_proxy https://red-list-dashboard.vercel.app {
        header_up Host red-list-dashboard.vercel.app
    }
}
```

So by the time a request reaches Next.js, every trace of the real domain is gone. That breaks sign-in in two places:

1. `signInWithGitHub` built `redirectTo` from the Host header, so GitHub was told to send the user back to `red-list-dashboard.vercel.app/auth/callback`.
2. The PKCE **code verifier cookie** was set on `red.cst.cam.ac.uk` — the domain the browser was actually on. It isn't sent to a `vercel.app` callback, so `exchangeCodeForSession` fails.
3. The callback's own error redirect was also built from the Host header, which is why the user visibly ended up on the `vercel.app` URL rather than back on `red.cst`.

Live on production today, showing step 3 in isolation:

```console
$ curl -sI "https://red.cst.cam.ac.uk/auth/callback?code=bogus" | grep -i location
location: https://red-list-dashboard.vercel.app/login?error=auth_callback_failed

$ curl -sI "https://en.ki/auth/callback?code=bogus" | grep -i location
location: https://red-list-dashboard.vercel.app/login?error=auth_callback_failed
```

(#412's switch from the `Origin` header to `Host` was right for the domains Vercel serves directly — it just can't survive a proxy that rewrites Host.)

## The fix

Two independent changes, either of which alone would have prevented the visible symptom:

**The browser tells the server which origin it's on.** The sign-in form posts `window.location.origin` in a hidden field — the only source that survives a Host-rewriting proxy. `resolvePublicOrigin` validates it against the known public hosts before use, because an unvalidated caller-supplied redirect origin that ends up in an OAuth `redirectTo` is an open redirect. If JavaScript never runs, the field posts empty and the server falls back to the request headers exactly as before.

**The auth callback redirects relatively.** `NextResponse.redirect(absoluteUrl)` built its origin from the Host header; a bare `Location: /login?error=…` is resolved by the browser against the URL it's already on, so it cannot throw users off their own domain regardless of what any proxy did. That makes `?next=` a redirect target worth sanitising (`//evil.com` and `/\evil.com` are protocol-relative URLs that leave the site), which `safeRedirectPath` now does.

Also adds `en.ki` to the Server Actions `allowedOrigins` list — it's served by the same Caddy block and would otherwise 500 on submit, the same way `red.cst.cam.ac.uk` did before #411.

## Two things outside this repo still need doing

This PR makes the app behave correctly behind the proxy, but sign-in on `red.cst.cam.ac.uk` won't work end-to-end until:

1. **Supabase → Auth → URL Configuration → Redirect URLs** gains `https://red.cst.cam.ac.uk/**` (and `https://en.ki/**`). With the fix, `redirectTo` becomes `https://red.cst.cam.ac.uk/auth/callback`; Supabase silently falls back to the Site URL for anything not on that allowlist.
2. Ideally, the **DNS cutover** that makes `red.cst.cam.ac.uk` a first-class Vercel domain (TXT verify record on `_vercel.cam.ac.uk` + CNAME to Vercel), retiring the Caddy hop entirely. Currently `red.cst.cam.ac.uk` still CNAMEs to `svr-avsm2-red.cl.cam.ac.uk` and the domain isn't attached to the Vercel project. This PR is not a substitute for that — it just means sign-in works either way.

## Test plan

Reproduced the production setup locally with a proxy that mimics the Caddy block exactly: the browser talks to `127.0.0.1:3019`, while the app behind it only ever sees `Host: localhost:3018`.

**The `redirect_to` handed to Supabase**, posting the sign-in form through that proxy:

```console
# hidden origin field empty (no JS, i.e. the old header-only behaviour):
location: …/authorize?provider=github&redirect_to=http%3A%2F%2Flocalhost%3A3018%2Fauth%2Fcallback
                                                            ^^^^^^^^^^^^^^ upstream host — the bug

# hidden origin field populated (the fix):
location: …/authorize?provider=github&redirect_to=http%3A%2F%2F127.0.0.1%3A3019%2Fauth%2Fcallback
                                                            ^^^^^^^^^^^^^^ browser's own domain
```

**The callback now redirects relatively**, through the same proxy:

```console
$ curl -sI "http://127.0.0.1:3019/auth/callback?code=bogus" | grep -i location
location: /login?error=auth_callback_failed        # was: http://localhost:3018/login?error=…

$ curl -sI "http://127.0.0.1:3019/auth/callback?next=//evil.com" | grep -i location
location: /login?error=auth_callback_failed        # open-redirect attempt rejected
```

**Browser drive-through** (Playwright, Chromium) on both the direct and proxied origins: login page renders identically, the hidden field holds the correct origin after hydration (`http://localhost:3018` and `http://127.0.0.1:3019` respectively), the button submits, and there are no console or page errors in any run.

| Login page (unchanged) | Error state still renders |
| --- | --- |
| <img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-438-signin-behind-proxy/01-login-page-unchanged.png" width="440"> | <img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-438-signin-behind-proxy/02-login-error-state.png" width="440"> |

Also: 748 unit tests pass (10 new ones covering `resolvePublicOrigin` and `safeRedirectPath`, including lookalike hosts such as `red.cst.cam.ac.uk.evil.com`, non-http schemes, and the empty/absent-field fallback), `tsc --noEmit` clean, eslint clean.

**Not exercised:** the GitHub leg of the OAuth round trip — completing it needs real GitHub credentials in the automated browser. What was verified is the step that was failing: that the callback URL handed to Supabase is now the domain holding the PKCE cookie. Worth a manual sign-in on the preview deployment once the Supabase redirect-URL entry above is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
