### PR TITLE
Add Google and Microsoft sign-in alongside GitHub

### DIFF
--- a/app/src/app/login/SignInForm.tsx
+++ b/app/src/app/login/SignInForm.tsx
@@ -1,7 +1,47 @@
 "use client";
 
 import { useSyncExternalStore } from "react";
-import { signInWithGitHub } from "@/lib/auth/actions";
+import { OAUTH_PROVIDERS } from "@/config/oauth-providers";
+import { signInWithOAuth } from "@/lib/auth/actions";
+
+// Each provider's own mark, drawn in its brand colours (GitHub's is
+// monochrome by design, so it follows the button's text colour and works in
+// both themes).
+const PROVIDER_ICONS: Record<string, React.ReactNode> = {
+  github: (
+    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23a11.28 11.28 0 013-.405c1.02 0 2.04.135 3 .405 2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+    </svg>
+  ),
+  google: (
+    <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.84 14.1c-.22-.66-.35-1.36-.35-2.1s.13-1.44.35-2.1V7.07H2.18A10.99 10.99 0 001 12c0 1.78.43 3.46 1.18 4.93l3.66-2.84z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      />
+    </svg>
+  ),
+  azure: (
+    <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
+      <path fill="#F25022" d="M2 2h9.5v9.5H2z" />
+      <path fill="#7FBA00" d="M12.5 2H22v9.5h-9.5z" />
+      <path fill="#00A4EF" d="M2 12.5h9.5V22H2z" />
+      <path fill="#FFB900" d="M12.5 12.5H22V22h-9.5z" />
+    </svg>
+  ),
+};
 
 // window.location.origin never changes for the life of the page, so there is
 // nothing to subscribe to — this is just the React-sanctioned way to read a
@@ -28,17 +68,24 @@ export function SignInForm() {
   const origin = useSyncExternalStore(NEVER_CHANGES, readOrigin, noOriginOnServer);
 
   return (
-    <form action={signInWithGitHub}>
+    // One form, one origin field, one button per provider: the pressed button's
+    // name/value is what tells the action which provider to start.
+    <form action={signInWithOAuth} className="flex flex-col gap-3">
       <input type="hidden" name="origin" value={origin} />
-      <button
-        type="submit"
-        className="w-full flex items-center justify-center gap-3 px-4 py-2.5 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-700 dark:text-zinc-200 font-medium hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors"
-      >
-        <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23a11.28 11.28 0 013-.405c1.02 0 2.04.135 3 .405 2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
-        </svg>
-        Sign in with GitHub
-      </button>
+      {OAUTH_PROVIDERS.map(({ id, label }) => (
+        <button
+          key={id}
+          type="submit"
+          name="provider"
+          value={id}
+          className="relative w-full flex items-center justify-center px-12 py-2.5 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-700 dark:text-zinc-200 font-medium hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors"
+        >
+          {/* Absolute so the three icons line up with each other, while the
+              labels stay centred as they were with the single button. */}
+          <span className="absolute left-4 flex items-center">{PROVIDER_ICONS[id]}</span>
+          Sign in with {label}
+        </button>
+      ))}
     </form>
   );
 }

--- a/app/src/app/login/page.tsx
+++ b/app/src/app/login/page.tsx
@@ -3,7 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { SignInForm } from "./SignInForm";
 
 const ERROR_MESSAGES: Record<string, string> = {
-  oauth_init_failed: "Couldn't start the GitHub sign-in flow. Please try again.",
+  oauth_init_failed: "Couldn't start the sign-in flow. Please try again.",
   auth_callback_failed: "Sign-in didn't complete. Please try again.",
 };
 
@@ -28,7 +28,7 @@ export default async function LoginPage({
       <div className="w-full max-w-sm text-center">
         <h1 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100 mb-2">Sign in</h1>
         <p className="text-sm text-zinc-500 dark:text-zinc-400 mb-6">
-          Sign in with your GitHub account to continue.
+          Choose an account to continue.
         </p>
         {error && (
           <p className="text-sm text-red-600 dark:text-red-400 mb-4">

--- a/app/src/app/privacy/page.tsx
+++ b/app/src/app/privacy/page.tsx
@@ -61,9 +61,9 @@ export default function PrivacyPage() {
           the dashboard shows by default is public, and you do not need an
           account to use it. If you do sign in with Google, Microsoft or GitHub,
           we store the email address, name and profile picture that provider
-          gives us, so the site can show who you are signed in as and, for a
-          small number of accounts, unlock additional map layers. We never
-          receive your password. Accounts are handled by{" "}
+          gives us, so the site can show who you are signed in as and manage
+          access to some features. We never receive your password. Accounts are
+          handled by{" "}
           <a
             href="https://supabase.com"
             target="_blank"

--- a/app/src/app/privacy/page.tsx
+++ b/app/src/app/privacy/page.tsx
@@ -71,8 +71,9 @@ export default function PrivacyPage() {
             className="underline hover:text-zinc-800 dark:hover:text-zinc-200"
           >
             Supabase
-          </a>
-          , and signing in stores a cookie on your device to keep you signed in.
+          </a>{" "}
+          (hosted in the EU), and signing in stores a cookie on your device to
+          keep you signed in.
           That cookie is strictly necessary for signing in to work, so it does
           not require a consent banner. To have your account and everything
           stored with it deleted, email{" "}

--- a/app/src/app/privacy/page.tsx
+++ b/app/src/app/privacy/page.tsx
@@ -26,7 +26,8 @@ export default function PrivacyPage() {
           This dashboard is part of a PhD research project at the University of
           Cambridge, which is the data controller. We collect a small amount of{" "}
           <strong>anonymous usage analytics</strong> to understand how the
-          dashboard is used and to improve it.
+          dashboard is used and to improve it, and — only if you choose to sign
+          in — the account details described below.
         </p>
 
         <p>
@@ -40,9 +41,10 @@ export default function PrivacyPage() {
           >
             PostHog
           </a>{" "}
-          (hosted in the EU). This data is not linked to your identity. We do{" "}
-          <strong>not</strong> use analytics cookies or store any identifier on
-          your device, so no cookie banner is needed. We also use{" "}
+          (hosted in the EU). This data is not linked to your identity, even if
+          you are signed in. We do <strong>not</strong> use analytics cookies or
+          store any analytics identifier on your device, so no cookie banner is
+          needed. We also use{" "}
           <a
             href="https://sentry.io"
             target="_blank"
@@ -55,9 +57,39 @@ export default function PrivacyPage() {
         </p>
 
         <p>
+          <strong>If you sign in.</strong> Signing in is optional — everything
+          the dashboard shows by default is public, and you do not need an
+          account to use it. If you do sign in with Google, Microsoft or GitHub,
+          we store the email address, name and profile picture that provider
+          gives us, so the site can show who you are signed in as and, for a
+          small number of accounts, unlock additional map layers. We never
+          receive your password. Accounts are handled by{" "}
+          <a
+            href="https://supabase.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-zinc-800 dark:hover:text-zinc-200"
+          >
+            Supabase
+          </a>
+          , and signing in stores a cookie on your device to keep you signed in.
+          That cookie is strictly necessary for signing in to work, so it does
+          not require a consent banner. To have your account and everything
+          stored with it deleted, email{" "}
+          <a
+            href="mailto:sw984@cam.ac.uk"
+            className="underline hover:text-zinc-800 dark:hover:text-zinc-200"
+          >
+            sw984@cam.ac.uk
+          </a>
+          .
+        </p>
+
+        <p>
           <strong>Why.</strong> We process this data under our legitimate
-          interest in maintaining and improving a public research tool. We do
-          not sell it or use it for advertising.
+          interest in maintaining and improving a public research tool, and — for
+          account details — in offering sign-in at all. We do not sell it or use
+          it for advertising.
         </p>
 
         <p>

--- a/app/src/config/__tests__/oauth-providers.test.ts
+++ b/app/src/config/__tests__/oauth-providers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { OAUTH_PROVIDERS, resolveOAuthProvider } from "../oauth-providers";
+
+describe("resolveOAuthProvider", () => {
+  it("accepts each provider the sign-in page offers", () => {
+    for (const provider of OAUTH_PROVIDERS) {
+      expect(resolveOAuthProvider(provider.id)).toBe(provider);
+    }
+  });
+
+  it("rejects anything not on the list rather than passing it to Supabase", () => {
+    // "microsoft" is the plausible near-miss: Supabase's slug for it is "azure",
+    // so this is what a hand-written form post would most likely send.
+    expect(resolveOAuthProvider("microsoft")).toBeNull();
+    expect(resolveOAuthProvider("apple")).toBeNull();
+    expect(resolveOAuthProvider("")).toBeNull();
+    expect(resolveOAuthProvider(null)).toBeNull();
+    expect(resolveOAuthProvider(undefined)).toBeNull();
+    // A File is what `formData.get()` returns for a file input, and the form
+    // field is caller-controlled, so it need not be a string at all.
+    expect(resolveOAuthProvider(new File([], "provider"))).toBeNull();
+  });
+
+  it("asks Microsoft for the email scope, since it withholds email otherwise", () => {
+    expect(resolveOAuthProvider("azure")?.scopes).toBe("email");
+  });
+});

--- a/app/src/config/oauth-providers.ts
+++ b/app/src/config/oauth-providers.ts
@@ -1,0 +1,39 @@
+// The OAuth providers the sign-in page offers, shared by the button list
+// (app/login/SignInForm.tsx) and the server action behind it
+// (lib/auth/actions.ts) so the two can't drift apart.
+
+type OAuthProvider = {
+  // Supabase's own provider slug, which has to match what's enabled under
+  // Authentication → Providers in the Supabase dashboard. Microsoft's is
+  // "azure" — named after Azure AD, the former name of Microsoft Entra ID —
+  // not "microsoft".
+  id: "github" | "google" | "azure";
+  label: string;
+  // Extra OAuth scopes to request, beyond whatever the provider returns by
+  // default. Omitted for providers that need none.
+  scopes?: string;
+};
+
+export const OAUTH_PROVIDERS: readonly OAuthProvider[] = [
+  { id: "github", label: "GitHub" },
+  { id: "google", label: "Google" },
+  // Azure only returns an email claim if the email scope is asked for
+  // explicitly, and the rest of the app leans on email throughout — it labels
+  // the account menu, it's the fallback avatar initial, and it's how an
+  // account is looked up to grant the admin role in user_roles. A Microsoft
+  // user without one would sign in to a half-broken session.
+  { id: "azure", label: "Microsoft", scopes: "email" },
+];
+
+/**
+ * Narrow the untrusted `provider` field posted by the sign-in form to one of
+ * the providers above, or null.
+ *
+ * The value is caller-controlled form data that goes straight into a Supabase
+ * call which redirects the browser off-site, so it gets the same treatment as
+ * the origin posted alongside it (see resolvePublicOrigin): checked against a
+ * fixed list rather than trusted.
+ */
+export function resolveOAuthProvider(value: unknown): OAuthProvider | null {
+  return OAUTH_PROVIDERS.find((provider) => provider.id === value) ?? null;
+}

--- a/app/src/config/oauth-providers.ts
+++ b/app/src/config/oauth-providers.ts
@@ -14,8 +14,14 @@ type OAuthProvider = {
   scopes?: string;
 };
 
+// This is the order the buttons appear in, and the first one reads as the
+// recommended one — so it leads with whichever works for the most people.
+// Google has no gate at all. Microsoft is blocked at organisations that disable
+// third-party user consent (Cambridge's tenant does, answering "Approval
+// required"), which is common at universities and NGOs. GitHub is a developer
+// account most of this audience won't have, and the few people already signed
+// in that way know where to look.
 export const OAUTH_PROVIDERS: readonly OAuthProvider[] = [
-  { id: "github", label: "GitHub" },
   { id: "google", label: "Google" },
   // Azure only returns an email claim if the email scope is asked for
   // explicitly, and the rest of the app leans on email throughout — it labels
@@ -23,6 +29,7 @@ export const OAUTH_PROVIDERS: readonly OAuthProvider[] = [
   // account is looked up to grant the admin role in user_roles. A Microsoft
   // user without one would sign in to a half-broken session.
   { id: "azure", label: "Microsoft", scopes: "email" },
+  { id: "github", label: "GitHub" },
 ];
 
 /**

--- a/app/src/lib/auth/actions.ts
+++ b/app/src/lib/auth/actions.ts
@@ -2,16 +2,23 @@
 
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { resolveOAuthProvider } from "@/config/oauth-providers";
 import { resolvePublicOrigin } from "@/config/public-origin";
 import { createClient } from "@/lib/supabase/server";
 
-export async function signInWithGitHub(formData: FormData) {
+export async function signInWithOAuth(formData: FormData) {
+  // Which button was pressed. Untrusted input — see resolveOAuthProvider.
+  const provider = resolveOAuthProvider(formData.get("provider"));
+  if (!provider) {
+    redirect("/login?error=oauth_init_failed");
+  }
+
   const supabase = await createClient();
 
-  // Where GitHub should send the user back to. This has to be the domain the
-  // browser is actually on: the PKCE code verifier is stored in a cookie set on
-  // that domain, and if the callback lands anywhere else the cookie isn't sent
-  // and the code exchange fails (#416).
+  // Where the provider should send the user back to. This has to be the domain
+  // the browser is actually on: the PKCE code verifier is stored in a cookie set
+  // on that domain, and if the callback lands anywhere else the cookie isn't
+  // sent and the code exchange fails (#416).
   //
   // The Host header alone can't tell us — red.cst.cam.ac.uk and en.ki reach
   // Vercel through a proxy that rewrites Host to red-list-dashboard.vercel.app,
@@ -25,9 +32,10 @@ export async function signInWithGitHub(formData: FormData) {
   });
 
   const { data, error } = await supabase.auth.signInWithOAuth({
-    provider: "github",
+    provider: provider.id,
     options: {
       redirectTo: `${origin}/auth/callback`,
+      ...(provider.scopes ? { scopes: provider.scopes } : {}),
     },
   });
 


### PR DESCRIPTION
## Summary

Adds **Google** and **Microsoft** to the sign-in page, alongside the existing GitHub button.

The page previously offered one provider, with `"github"` hardcoded in the server action and a single hand-written button. Both are now generalised: the action takes the provider from the pressed button, and the button list is generated from one shared list.

| | |
|---|---|
| <img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-440-google-microsoft-oauth/04-login-light-v2.png" width="450"> | <img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-440-google-microsoft-oauth/05-login-dark-v2.png" width="450"> |

Buttons are ordered **Google, Microsoft, GitHub** — the first reads as the recommended one, so it leads with the provider that works for the most people. Google has no consent gate; Microsoft is blocked at organisations that disable third-party user consent (see §2); GitHub is a developer account most of this audience won't have.

**`app/src/config/oauth-providers.ts`** (new) is the single place the button list and the server action agree on, and it carries the two provider quirks worth knowing about:

- **Microsoft's Supabase slug is `azure`**, not `microsoft` — named after Azure AD, Microsoft Entra ID's former name.
- **Azure returns an email claim only if the `email` scope is requested explicitly**, and email is load-bearing here: it labels the account menu, it's the fallback avatar initial (`AuthStatus.tsx`), and it's how an account is looked up to grant `admin` in `user_roles`. A Microsoft user without one would sign in to a half-broken session.

The `provider` field is caller-controlled form data that ends up in a call which redirects the browser off-site, so it's checked against that list rather than trusted — the same treatment `resolvePublicOrigin` already gives the origin posted alongside it. An unrecognised value lands back on `/login` with the generic error instead of reaching Supabase.

**Deliberately unchanged:** `app/auth/callback/route.ts` (`exchangeCodeForSession` is provider-agnostic) and the #438 origin handling (`redirectTo` is still the browser's own origin). So the Caddy-proxied domains — red.cst.cam.ac.uk, en.ki — behave identically on all three providers, with no new entries needed in Supabase's Redirect URLs allowlist.

---

# Setup instructions

Provider config is Supabase **project settings**, not schema — so there's nothing for `app/supabase/migrations/` to carry and CI can't apply it. These steps are manual and need account access.

The one value both providers need:

```
https://styqwjdaexkojhunvkqa.supabase.co/auth/v1/callback
```

**This is Supabase's callback, not the app's.** Google and Microsoft only ever redirect back to Supabase; Supabase then redirects on to the app's `/auth/callback`, which is governed by Supabase's own **Redirect URLs** allowlist — already populated for every domain from the GitHub setup, so there is nothing to add there.

Both providers can be set up independently — if one gets stuck, the other still works, and any provider not yet enabled just shows "Couldn't start the sign-in flow" on its button.

## 1. Google — ✅ done

Enabled and **brand-verified**, so the consent screen shows the app name rather than the Supabase project domain:

<img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-440-google-microsoft-oauth/03-google-consent-branded.png" width="480">

**Audience: External**, published. External rather than Internal because Internal restricts sign-in to members of the Google Workspace org that owns the Cloud project, which is the opposite of the goal here (IUCN and academic users signing in with whatever Google account they have). Published rather than left in `Testing`, because Testing admits only explicitly-listed test users and expires their sessions after 7 days.

**On branding — worth recording, because it wasn't obvious.** Setting *App name* alone does nothing: until brand verification completes, Google shows the OAuth client's domain, which here was the raw `styqwjdaexkojhunvkqa.supabase.co`. That looked like a dead end, because brand verification requires you to own every entry in *Authorized domains*, and the Supabase callback domain is auto-added there when you save the redirect URI. In practice verification went through anyway with that entry present, once `dashforlife.org` was verified in Search Console and the privacy policy and terms pages existed. So **no Supabase Custom Domains add-on was needed** — which is the workaround usually recommended for this, and it would have meant a paid plan, DNS changes and a new callback URL for nothing.

**Google Cloud Console** — make sure the right project is selected in the top bar first.

1. Go to **[Clients](https://console.cloud.google.com/auth/clients)** (Google Auth Platform → Clients) → **Create client**.
2. **Application type:** `Web application`. Name it something recognisable, e.g. `Red List Dashboard`.
3. **Authorized JavaScript origins** — the *first* of the two URI boxes on the page, and **not** where the callback URL goes. It accepts a bare origin only; pasting the callback there fails with `Invalid Origin: URIs must not contain a path or end with "/"`. This flow doesn't use it (when the browser reaches Google it's on `supabase.co`, not one of our domains), so leave it empty — or, if the form insists, `https://styqwjdaexkojhunvkqa.supabase.co` with no path. Putting dashforlife.org here achieves nothing.
4. **Authorized redirect URIs** → **+ Add URI** → paste the callback URL above. *This* is the field that matters, and it's the one that takes a full path.
5. **Create**, then copy the **Client ID** and **Client secret** (the secret is shown once — grab it now).

Then check the consent screen, under **Google Auth Platform**:

6. **[Data Access](https://console.cloud.google.com/auth/scopes)** → confirm `.../auth/userinfo.email` and `.../auth/userinfo.profile` are present (they're default) and **add `openid` manually** if it isn't listed.
7. **[Audience](https://console.cloud.google.com/auth/audience)** → if **Publishing status** is `Testing`, only accounts explicitly listed under **Test users** can sign in, and their sessions expire after 7 days. Click **Publish app** to move it to `In production`. These three scopes are all non-sensitive, so publishing does **not** trigger Google's verification review — the app may show an "unverified" interstitial until branding verification completes, but sign-in works.
8. **[Branding](https://console.cloud.google.com/auth/branding)** → app name and logo, if you want the consent screen to look right. Optional, and verification here can take a few business days.

**Supabase dashboard** → [Authentication → Providers → Google](https://supabase.com/dashboard/project/styqwjdaexkojhunvkqa/auth/providers?provider=Google):

9. Toggle **Enable Sign in with Google**, paste **Client ID** and **Client Secret**, **Save**.

## 2. Microsoft — ✅ done

⚠️ **Caveat found while testing: tenants that disable third-party user consent will block this button.** Signing in with a Cambridge address returns *"Approval required — Dash for Life, unverified. This app requires your admin's approval to: view users' basic profile / maintain access to data you have given it access to."* Those two permissions are already the floor (`User.Read` and `offline_access`), so there's nothing to trim to get under the bar — it's tenant policy, not app config, and nothing in this repo can change it.

That matters for the stated audience: locked-down consent is common in universities and NGOs, so if IUCN's tenant is configured this way, Microsoft is the *least* usable button for exactly the people it was added for, and Google — which has no equivalent gate — is the more reliable institutional option. A personal Microsoft account signs in cleanly, confirming the registration itself is correct. Publisher verification (via a Microsoft Partner Network account) can satisfy some tenants' "allow user consent for verified publishers" policies, but that's a separate project, not a step.

As registered:

| | |
|---|---|
| **Name** | `Dash for Life` — matches the Google consent screen, so users see the same name whichever button they click |
| **Supported account types** | Any Entra ID tenant **+ personal Microsoft accounts** |
| **Redirect URI** | `Web` → `https://styqwjdaexkojhunvkqa.supabase.co/auth/v1/callback` |
| **Client secret** | Created 2026-07-29, 24-month expiry → **expires 2028-07-29** |
| **Azure Tenant URL** (in Supabase) | blank — it's only for single-tenant apps |

Personal Microsoft accounts are included deliberately: excluding them means an outlook.com user clicking the button gets a bare Microsoft error rather than a sign-in, and including them costs nothing.

**⚠️ The client secret expires 2028-07-29**, and the failure is silent and total — every Microsoft sign-in starts failing with no warning. Rotation is zero-downtime, though: create the new secret, paste the Value into Supabase, save, then delete the old one. Two secrets can be live at once.

`optionalClaims` as applied in the app registration's Manifest — Azure withholds the email claim without this, and `xms_edov` is what marks the email verified, which is what decides whether Supabase links a Microsoft identity to an existing account:

```json
"optionalClaims": {
    "idToken": [
        { "name": "email", "essential": false },
        { "name": "xms_edov", "essential": false }
    ],
    "accessToken": [
        { "name": "email", "essential": false },
        { "name": "xms_edov", "essential": false }
    ],
    "saml2Token": []
},
```

**Still outstanding:** paste the client ID and secret Value into Supabase → Authentication → Providers → Azure. Until then `/auth/v1/authorize?provider=azure` returns `"Unsupported provider: provider is not enabled"` and the button shows the generic error.

One footnote from setting this up: a personal Microsoft account has no Entra tenant, so portal.azure.com fails with `AADSTS16000` until you create one (the free Azure signup provisions a "Default Directory"). Cambridge's tenant refused the registration on permissions. The tenant hosting the registration doesn't constrain who can sign in — that's entirely the *Supported account types* setting — so a personal tenant is fine here.

### Original steps, for reference

**Azure portal** → [portal.azure.com](https://portal.azure.com) → **Microsoft Entra ID**.

1. Sidebar → **App registrations** → **New registration**.
2. **Name:** e.g. `Red List Dashboard`.
3. **Supported account types** — this is the decision that determines who can sign in. For an IUCN/academic audience you almost certainly want **"Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant) and personal Microsoft accounts"**, which covers work/school accounts at any institution *and* personal outlook.com/hotmail.com addresses. Picking "My organization only" would restrict sign-in to a single tenant.
4. **Redirect URI** → platform **`Web`** → paste the callback URL above.
5. **Register**. Copy **Application (client) ID** from the overview page.
6. Overview → **Add a certificate or secret** → **Client secrets** tab → **New client secret** → pick an expiry → **Add**. Copy the **Value** column, **not** the Secret ID. ⚠️ It's only fully visible right after creation, and **it expires** — whatever expiry you pick is the date Microsoft sign-in silently breaks, so it's worth noting somewhere.
7. Sidebar → **Manifest** → find `optionalClaims` and add `email` and `xms_edov` to both the `idToken` and `accessToken` arrays → **Save**. `xms_edov` is what tells Supabase whether the email is verified; without it Microsoft accounts can arrive with an unverified email, which affects whether Supabase links them to an existing account (see the identity-linking note below).

**Supabase dashboard** → [Authentication → Providers → Azure](https://supabase.com/dashboard/project/styqwjdaexkojhunvkqa/auth/providers?provider=Azure):

8. Toggle **Enable Sign in with Azure**, paste **Application (client) ID** and the secret **Value**, **Save**.
9. **Azure Tenant URL** — leave it **blank** for the multitenant + personal accounts option in step 3. It's only for single-tenant apps ("My organization only"), where it takes the form `https://login.microsoftonline.com/<tenant-id>`. *(An earlier revision of this description said to put `common` here — that was wrong; blank is the multitenant setting.)*

## 3. Check it

Enabling a provider takes effect immediately and at the **project** level, which this app shares between production and preview deployments. Production won't show the new buttons until this PR merges, but **this PR's Vercel preview will start working the moment you hit Save** — so that's the place to test:

- Preview URL → `/login` → **Sign in with Google** → should land back on the dashboard signed in, with your Google avatar in the header.
- Same for **Sign in with Microsoft**. Confirm your email address appears in the header dropdown — that's the check that the `email` scope and optional claims did their job.
- If a button returns "Couldn't start the sign-in flow", that provider isn't enabled yet. If you get `{"error_code":"validation_failed","msg":"Unsupported provider: provider is not enabled"}` on a Supabase URL, same cause — the Save in step 9 / step 8 didn't take.

## Privacy policy

`/privacy` described anonymous analytics only — no mention of accounts, email addresses or Supabase — while asserting "this data is not linked to your identity". That was already incomplete when GitHub sign-in shipped in #406; this PR widens who it applies to, so it's fixed here rather than left trailing. Cambridge is the named data controller, and this page is also what Google reviewed for brand verification.

Adds a paragraph covering what each provider gives us (email, name, profile picture), why it's stored, that Supabase handles accounts, that the session cookie is strictly necessary and so needs no consent banner, and how to get an account deleted. Also scopes the "no identifier on your device" sentence to *analytics*, which is what it always meant but which reads wrongly now that signing in sets a cookie.

<img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-440-google-microsoft-oauth/08-privacy-policy-v3.png" width="480">

Supabase is named as hosted in the EU (the project is in `eu-west-1`, Ireland), matching how PostHog is already described. The legal basis is stated as legitimate interest, consistent with the existing framing — worth a second look given Cambridge is the named controller.

## Notes

- **Identity linking — verified, works.** Supabase auto-links a new provider identity to an existing user when the email is verified and matches, and it did: the owner account now shows `app_metadata.providers = ["github","google","azure"]` on a *single* `auth.users` row, which is the row holding the `admin` grant. So range-map access survives whichever of the three buttons is used. The failure mode to know about is a provider returning a *different* address — that creates a second row with no roles, and the fix is one more `user_roles` insert for the new `user_id`.
- **Consent-screen names are consistent.** All three now show "Dash for Life" — the GitHub OAuth app was renamed to match Google and Microsoft.
- **Signup is open.** Anyone with a GitHub account could already create one (`user_roles` gates only the range map), and one unrelated account has signed up this way already. This widens that from "has GitHub" to "has an email address" — likely the intent for the IUCN audience, but a real change in exposure. The safeguard is that being signed in confers nothing: every privilege goes through `user_roles`. Worth preserving that invariant — the risk isn't today, it's a future feature written as `if (user)` rather than `if (isAdmin(...))`, which would silently be open to everyone.

## Test plan

Full browser drive-through with Playwright against the dev server, tracing each button's actual navigation chain:

- ✅ **GitHub** — unchanged end-to-end: `/auth/v1/authorize?provider=github` → `github.com/login/oauth/authorize` → GitHub's "Sign in to GitHub / to continue to Red List Dashboard" page. No regression from the refactor.
- ✅ **Google** — reaches `/auth/v1/authorize?provider=google&redirect_to=…/auth/callback&code_challenge=…`, blocked only by `{"error_code":"validation_failed","msg":"Unsupported provider: provider is not enabled"}` — i.e. everything up to the un-done dashboard step is correct.
- ✅ **Microsoft** — same, as `provider=azure&scopes=email`, confirming the email scope is actually sent.
- ✅ **Unknown provider** — a hand-written form post with `provider=evil-provider` (buttons' `name` stripped so it's the only value) never reaches Supabase; it lands on `/login?error=oauth_init_failed` showing "Couldn't start the sign-in flow."
- ✅ **`origin` hidden field** still carries the browser's own origin (the #438 mechanism).
- ✅ Light and dark themes screenshotted above; icons aligned, brand colours legible on both. Zero console errors.
- ✅ `tsc --noEmit` clean, `eslint` clean across the app, `vitest run` 751 passed / 6 skipped — including 3 new tests for the provider allowlist.

Re-verified after Google was enabled (§1):

- ✅ **Google is live** — `/auth/v1/authorize?provider=google` now 302s to `accounts.google.com` with the real client ID, instead of the earlier "provider is not enabled".
- ✅ **Consent screen is branded** — driving the button through to Google's signed-out page shows "Sign in / to continue to **Dash for Life**", with the Privacy Policy and Terms links. Screenshot in §1. No `supabase.co` string anywhere on it.
- ✅ **Microsoft is live** — `/auth/v1/authorize?provider=azure` 302s to `login.microsoftonline.com/common/` (the `/common/` endpoint confirming multitenant + personal accounts) with `scope=openid email`, so the `email` scope from `oauth-providers.ts` is on the wire.
- ✅ **Real sign-ins completed** by Shane on Google and on Microsoft (personal account), both landing back signed in.
- ✅ **All three linked to one account** — confirmed against the Supabase admin API: `app_metadata.providers = ["github","google","azure"]` on the single `auth.users` row that holds the `admin` role. Range map access is unaffected by which button is used.
- ⚠️ **Microsoft blocked for Cambridge accounts** by tenant consent policy — see §2. Not a code issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
