### PR TITLE
Fix GBIF occurrence links returning 0 records

### DIFF
--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2790,7 +2790,23 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   }, []);
 
   const currentYear = new Date().getFullYear();
-  const GBIF_FILTERS = "has_coordinate=true&has_geospatial_issue=false&basis_of_record=HUMAN_OBSERVATION&basis_of_record=MACHINE_OBSERVATION&basis_of_record=OCCURRENCE&basis_of_record=MATERIAL_SAMPLE&basis_of_record=OBSERVATION";
+  // GBIF relaunched gbif.org on 18 June 2026 with Catalogue of Life Extended
+  // Release as its default taxonomy. The gbif_species_key values stored here are
+  // keys from the GBIF Backbone, which resolve to nothing under CoL — and GBIF
+  // answers that with an empty result set rather than an error, so these links
+  // silently landed on a search reading "0 records". Naming the backbone
+  // checklist explicitly is GBIF's documented fix:
+  //   https://data-blog.gbif.org/post/catalogue-of-life-taxonomic-backbone/
+  //   "An old occurrence search link without the checklistKey parameter will
+  //    return nothing"
+  // The filter params are camelCase because that is what the new site documents;
+  // the old snake_case spellings now survive only via GBIF's redirect layer.
+  //
+  // The backbone is frozen (last updated 2023), so the durable fix is to store
+  // CoL keys in the pipeline instead — a much larger migration, tracked in #441.
+  // Until then this keeps every link working.
+  const GBIF_BACKBONE_CHECKLIST_KEY = "d7dddbf4-2cf0-4f39-9b2a-bb099caae36c";
+  const GBIF_FILTERS = `checklistKey=${GBIF_BACKBONE_CHECKLIST_KEY}&hasCoordinate=true&hasGeospatialIssue=false&basisOfRecord=HUMAN_OBSERVATION&basisOfRecord=MACHINE_OBSERVATION&basisOfRecord=OCCURRENCE&basisOfRecord=MATERIAL_SAMPLE&basisOfRecord=OBSERVATION`;
   const isNE = (s: Species) => s.category === "NE";
 
   // GBIF occurrence counts aren't filterable per-country/category/etc. — only show
@@ -4976,7 +4992,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                     <td className="px-4 py-3 text-right text-zinc-600 dark:text-zinc-400 text-sm tabular-nums whitespace-nowrap">
                       {details?.gbifOccurrences != null && details?.gbifUrl ? (
                         <a
-                          href={`https://www.gbif.org/occurrence/search?taxon_key=${details.gbifUrl.split('/').pop()}&${GBIF_FILTERS}`}
+                          href={`https://www.gbif.org/occurrence/search?taxonKey=${details.gbifUrl.split('/').pop()}&${GBIF_FILTERS}`}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 underline decoration-dotted hover:decoration-solid"
@@ -4986,7 +5002,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                         </a>
                       ) : s.gbif_occurrence_count != null && s.gbif_species_key ? (
                         <a
-                          href={`https://www.gbif.org/occurrence/search?taxon_key=${s.gbif_species_key}&${GBIF_FILTERS}`}
+                          href={`https://www.gbif.org/occurrence/search?taxonKey=${s.gbif_species_key}&${GBIF_FILTERS}`}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 underline decoration-dotted hover:decoration-solid"
@@ -5013,10 +5029,13 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                         const newObs = details?.gbifOccurrencesSinceAssessment ?? s.gbif_observations_after_assessment_year;
                         if (newObs == null) return "—";
                         const key = details?.gbifUrl?.split('/').pop() ?? s.gbif_species_key;
-                        if (key && assessmentYear) {
+                        // A species assessed this year has no "since" range to
+                        // link to — year=<next year>,<this year> is a reversed,
+                        // meaningless range — so show the number unlinked.
+                        if (key && assessmentYear && assessmentYear < currentYear) {
                           return (
                             <a
-                              href={`https://www.gbif.org/occurrence/search?taxon_key=${key}&year=${assessmentYear + 1},${currentYear}&${GBIF_FILTERS}`}
+                              href={`https://www.gbif.org/occurrence/search?taxonKey=${key}&year=${assessmentYear + 1},${currentYear}&${GBIF_FILTERS}`}
                               target="_blank"
                               rel="noopener noreferrer"
                               className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 underline decoration-dotted hover:decoration-solid"


### PR DESCRIPTION
Every GBIF occurrence link on the species table currently lands on a search reading **0 records**. One file, 24 lines.

## Cause

GBIF [relaunched gbif.org on 18 June 2026](https://data-blog.gbif.org/post/catalogue-of-life-taxonomic-backbone/) with **Catalogue of Life Extended Release** as its default taxonomy. Every `gbif_species_key` we store is a GBIF *Backbone* key, and a backbone key resolves to nothing under CoL. GBIF answers that with an **empty result set rather than an error**, which is why this broke silently — the link looks fine, the page just says 0.

GBIF's own guidance: *"An old occurrence search link without the `checklistKey` parameter will return nothing."*

## Fix

- Name the backbone checklist explicitly: `checklistKey=d7dddbf4-2cf0-4f39-9b2a-bb099caae36c`
- Move the filters to the camelCase the new site documents (`taxonKey`, `hasCoordinate`, `basisOfRecord`) — the old snake_case spellings currently survive only via GBIF's redirect layer, which is what silently rewrote them before
- Stop linking the "since assessment" cell for species assessed in the **current** year, where the link built a reversed, meaningless range (`year=2027,2026`)

## Verified

Through the GBIF API (gbif.org itself is Cloudflare bot-blocked to automation, so the API — which serves the same index — was used instead):

| query | count |
|---|---|
| `taxonKey=2434814` under CoL (the site's new default) | **0** ← the bug |
| `taxonKey=2434814` + backbone `checklistKey` (this fix) | **1,097,125** |
| `taxonKey=2436221` + backbone `checklistKey` | **5** — exactly what the dashboard shows for *Euroscaptor klossi* |
| `taxonKey=5219243&year=2017,2026` + backbone | **1,099,437** |

And in a real browser against the current data sync: every rendered href carries `checklistKey` and camelCase filters; "since assessment" links carry the right year range for older assessments (*Vulpes vulpes* → `year=2017,2026`) and are correctly absent for species assessed this year.

![Species table with fixed links](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-442-gbif-link-fix/01-links-fixed.png)

`tsc` clean, `eslint` clean, 754 tests passing.

## Why this is the narrow fix

The backbone is frozen at 2023, so the durable answer is to store CoL keys in the pipeline. That migration was attempted in #441 and **should not be merged** — two independent reviews found it ships silently wrong data (whole coral and insect groups losing occurrence data, and 102 threatened species displaying *another species'* records). #441 is parked as a draft with the findings.

Nothing here depends on that work: `checklistKey` is GBIF's documented backward-compatibility contract and holds as long as they host the backbone. This restores every link today, with no data re-sync and no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)