### PR TITLE
Country view: restore the landing map's full height

### DIFF
--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3517,7 +3517,21 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   return (
     <div className="space-y-1 min-w-0 flex-1 flex flex-col min-h-0">
       {/* Always show Taxa Summary table */}
-      <div ref={taxaSummaryScrollRef}>
+      {/* Country View's landing map is sized by a flex chain that runs from
+          page.tsx's min-h-screen box, through <main>, through this component's
+          root, down to TaxaSummary's own `flex-1 min-h-0` map wrapper — each
+          link has to be a flex container that passes the slack down. This
+          scroll-target wrapper is a plain block box, so it collapsed to the
+          map's intrinsic height and the landing map rendered at roughly half
+          height with dead space below it. Re-join the chain here, but only for
+          the landing state: once a country's picked the map lives in a 2-col
+          grid whose height comes from the table beside it, and in every
+          non-country layout this wrapper holds the full taxa table, which
+          should keep sizing to its own content. */}
+      <div
+        ref={taxaSummaryScrollRef}
+        className={layoutMode === "country" && !countryScope ? "flex-1 min-h-0 flex flex-col" : undefined}
+      >
       <TaxaSummary
         onToggleTaxon={handleToggleTaxon}
         selectedTaxa={selectedTaxa}


### PR DESCRIPTION
## Summary

Country View's landing map is meant to fill the viewport down to the footer, and did until 411a8b7 ("Collapse More Filters into one panel, drop the toolbar sticky, remove the stat-card row") wrapped `TaxaSummary` in a plain `<div ref={taxaSummaryScrollRef}>` as a scroll target.

The map's height comes from a flex chain — `page.tsx`'s `min-h-screen` box → `<main>` → `RedListView`'s root → `TaxaSummary`'s own `flex-1 min-h-0` map wrapper — and every link in it has to be a flex container that passes the slack down. That new block-level wrapper broke the chain, so it collapsed to the map's intrinsic height: **255px of map on a 900px viewport**, with dead space between it and the footer.

The fix re-joins the chain on that wrapper, but only in the landing state (`layoutMode === "country" && !countryScope`):

- once a country **is** picked, the map sits in a 2-col grid and takes its height from the table beside it — it must not grow independently;
- in every non-country layout that wrapper holds the full taxa table, which should keep sizing to its own content.

One file, one conditional class.

### Before — landing map at 255px, dead space below

![before](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-445-country-full-height-map/01-before-landing-half-height.png)

### After — landing map fills to the footer (647px)

![after](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-445-country-full-height-map/02-after-landing-full-height.png)

### After — country-scoped half/half layout unchanged

![scoped](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-445-country-full-height-map/03-after-country-scoped-unchanged.png)

## Test plan

Real-browser drive-through (Playwright, Chromium), measuring the map card's rendered height:

| Case | Before | After |
| --- | --- | --- |
| Landing, Map view (1400×900) | 255px | **647px**, bottom at 789 of 900 |
| Landing, List view (1400×900) | content-sized | content-sized (unchanged) |
| Country-scoped, map / table (1400×900) | 331px / 331px | 331px / 331px (matched, unchanged) |
| Scoped → remove country pill | — | back to **647px** |
| Landing, narrow (500×800) | — | 550px, fills to footer |
| Landing, tall (1600×1200) | — | 947px, scales |
| Standard (non-country) layout | unchanged | unchanged, first card top identical |

Also: `tsc --noEmit` clean, `eslint` clean, `vitest run` 754 tests / 39 files passing. No page errors in any of the browser runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)