### PR TITLE
Preserve the page and query string across sign-in

### DIFF
--- a/app/src/app/login/SignInForm.tsx
+++ b/app/src/app/login/SignInForm.tsx
@@ -63,8 +63,14 @@ const noOriginOnServer = () => "";
  * Filled in after hydration (window doesn't exist during SSR). If JavaScript
  * never runs, the field stays empty and the server falls back to the request
  * headers, which is what every Vercel-served domain used before this.
+ *
+ * `next` rides along the same way, but comes from this page's own `?next=`
+ * rather than from `window`: by the time the form is on screen the browser is
+ * on /login, so its current URL is no longer the page worth returning to. The
+ * header's sign-in link is what captured that, one navigation earlier
+ * (components/AuthStatus.tsx).
  */
-export function SignInForm() {
+export function SignInForm({ next }: { next?: string }) {
   const origin = useSyncExternalStore(NEVER_CHANGES, readOrigin, noOriginOnServer);
 
   return (
@@ -72,6 +78,7 @@ export function SignInForm() {
     // name/value is what tells the action which provider to start.
     <form action={signInWithOAuth} className="flex flex-col gap-3">
       <input type="hidden" name="origin" value={origin} />
+      <input type="hidden" name="next" value={next ?? ""} />
       {OAUTH_PROVIDERS.map(({ id, label }) => (
         <button
           key={id}

--- a/app/src/app/login/page.tsx
+++ b/app/src/app/login/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { safeRedirectPath } from "@/config/public-origin";
 import { createClient } from "@/lib/supabase/server";
 import { SignInForm } from "./SignInForm";
 
@@ -10,18 +11,25 @@ const ERROR_MESSAGES: Record<string, string> = {
 export default async function LoginPage({
   searchParams,
 }: {
-  searchParams: Promise<{ error?: string }>;
+  searchParams: Promise<{ error?: string; next?: string }>;
 }) {
   const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
-  if (user) {
-    redirect("/");
-  }
+  // `next` is the page the user was on when they clicked sign in, captured by
+  // the header link (components/AuthStatus.tsx) because the dashboard's whole
+  // filter/view state lives in the query string and would otherwise be lost.
+  // Anyone can put anything in it, so it is only ever handled via
+  // safeRedirectPath — here, and again in the server action and the callback.
+  const { error, next } = await searchParams;
 
-  const { error } = await searchParams;
+  // Already signed in (e.g. /login opened in a second tab): honour `next` too,
+  // rather than dumping them on the home page.
+  if (user) {
+    redirect(safeRedirectPath(next));
+  }
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-zinc-50 dark:bg-zinc-950 px-4">
@@ -35,7 +43,7 @@ export default async function LoginPage({
             {ERROR_MESSAGES[error] ?? "Something went wrong. Please try again."}
           </p>
         )}
-        <SignInForm />
+        <SignInForm next={next} />
       </div>
     </div>
   );

--- a/app/src/components/AuthStatus.tsx
+++ b/app/src/components/AuthStatus.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import Link from "next/link";
 import { signOut } from "@/lib/auth/actions";
 
 type Me = { email: string | null; avatarUrl: string | null };
@@ -52,8 +51,30 @@ export function AuthStatus() {
 
   if (!me?.email) {
     return (
-      <Link
+      // Sign in, remembering where the user was. Everything the dashboard shows
+      // — filters, view mode, drill-down — is encoded in the query string, so
+      // handing /login the current path+search is what lets the callback put
+      // the user back exactly where they were instead of on the home page.
+      //
+      // Read in the click handler rather than baked into `href` at render time
+      // because the dashboard rewrites its own URL with bare
+      // history.pushState (hooks/useFilterParams.ts) — no Next.js navigation,
+      // so no re-render and nothing for usePathname/useSearchParams to observe.
+      // An href computed at render would go stale on the first filter change,
+      // which is precisely the state this exists to preserve.
+      //
+      // The href itself stays a plain "/login", so cmd/middle-click, "copy link
+      // address" and a JavaScript-less browser all still reach a working
+      // sign-in page — they just fall back to landing on "/" afterwards.
+      <a
         href="/login"
+        onClick={(e) => {
+          // Leave modified clicks (open in new tab/window, download) alone.
+          if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+          e.preventDefault();
+          const from = window.location.pathname + window.location.search;
+          window.location.href = `/login?next=${encodeURIComponent(from)}`;
+        }}
         className="flex items-center justify-center w-8 h-8 rounded-full ring-1 ring-zinc-200 dark:ring-zinc-700 text-zinc-500 dark:text-zinc-400 hover:ring-zinc-300 dark:hover:ring-zinc-600 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors"
         aria-label="Sign in"
         title="Sign in"
@@ -66,7 +87,7 @@ export function AuthStatus() {
             d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
           />
         </svg>
-      </Link>
+      </a>
     );
   }
 

--- a/app/src/config/__tests__/public-origin.test.ts
+++ b/app/src/config/__tests__/public-origin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolvePublicOrigin, safeRedirectPath } from "../public-origin";
+import { authCallbackUrl, resolvePublicOrigin, safeRedirectPath } from "../public-origin";
 
 // What the Caddy-proxied domains look like once Vercel sees them: the real
 // domain is gone from the headers entirely.
@@ -95,5 +95,58 @@ describe("safeRedirectPath", () => {
     expect(safeRedirectPath(null)).toBe("/");
     expect(safeRedirectPath(undefined)).toBe("/");
     expect(safeRedirectPath("")).toBe("/");
+  });
+
+  it("defaults to the home page for a non-string form value", () => {
+    // FormData.get returns a File when the field name collides with an upload.
+    expect(safeRedirectPath(new Blob())).toBe("/");
+  });
+});
+
+describe("authCallbackUrl", () => {
+  const ORIGIN = "https://red.cst.cam.ac.uk";
+
+  it("leaves the callback URL untouched when there is nothing to return to", () => {
+    // Byte-identical to the pre-`next` URL, so a plain sign-in doesn't depend
+    // on Supabase's Redirect URLs allow-list having been widened.
+    expect(authCallbackUrl(ORIGIN, null)).toBe("https://red.cst.cam.ac.uk/auth/callback");
+    expect(authCallbackUrl(ORIGIN, "/")).toBe("https://red.cst.cam.ac.uk/auth/callback");
+  });
+
+  it("encodes a filtered dashboard URL so its own query string survives", () => {
+    // Unencoded, the `?` and `&` would be read as part of the callback URL's
+    // query string rather than as part of `next`'s.
+    expect(authCallbackUrl(ORIGIN, "/?taxa=birds&categories=CR,EN")).toBe(
+      "https://red.cst.cam.ac.uk/auth/callback?next=%2F%3Ftaxa%3Dbirds%26categories%3DCR%2CEN"
+    );
+  });
+
+  it("survives the round trip back through the callback route", () => {
+    const cases = [
+      "/?taxa=mammals&categories=CR,EN&years=11-20+years&search=shrew",
+      "/?layout=country&country=ZA&view=new-assessments",
+      "/compare?taxa=birds&taxa_b=amphibians",
+      "/browse?taxon=Aves#top",
+    ];
+    for (const path of cases) {
+      const url = new URL(authCallbackUrl(ORIGIN, path));
+      // What app/auth/callback/route.ts does with the request it receives.
+      expect(safeRedirectPath(url.searchParams.get("next"))).toBe(path);
+    }
+  });
+
+  it("never lets an off-site redirect into the redirectTo", () => {
+    expect(authCallbackUrl(ORIGIN, "https://evil.com")).toBe(
+      "https://red.cst.cam.ac.uk/auth/callback"
+    );
+    expect(authCallbackUrl(ORIGIN, "//evil.com")).toBe("https://red.cst.cam.ac.uk/auth/callback");
+    expect(authCallbackUrl(ORIGIN, "/\\evil.com")).toBe("https://red.cst.cam.ac.uk/auth/callback");
+    expect(authCallbackUrl(ORIGIN, new Blob())).toBe("https://red.cst.cam.ac.uk/auth/callback");
+  });
+
+  it("builds on whichever origin the browser actually reported", () => {
+    expect(authCallbackUrl("http://localhost:3000", "/?taxa=birds")).toBe(
+      "http://localhost:3000/auth/callback?next=%2F%3Ftaxa%3Dbirds"
+    );
   });
 });

--- a/app/src/config/public-origin.ts
+++ b/app/src/config/public-origin.ts
@@ -71,8 +71,40 @@ export function resolvePublicOrigin(
  * normalise to the same thing — are protocol-relative URLs, so as a bare
  * Location they leave the site entirely. Only a single leading slash is
  * same-origin.
+ *
+ * Takes `unknown` because one caller is `formData.get("next")`, which is a
+ * `File` rather than a string if the field name ever collides with an upload.
  */
-export function safeRedirectPath(next: string | null | undefined): string {
+export function safeRedirectPath(next: unknown): string {
+  if (typeof next !== "string") return "/";
   if (!next || next[0] !== "/" || next[1] === "/" || next[1] === "\\") return "/";
   return next;
+}
+
+/**
+ * The OAuth `redirectTo` — where the provider sends the browser once the user
+ * has approved, i.e. this app's auth callback, carrying the page to land on.
+ *
+ * `next` is sanitised here *and* again in the callback route, and both are
+ * load-bearing: this call keeps an attacker-chosen absolute URL out of the
+ * `redirectTo` we hand to Supabase, and the callback's call covers the fact
+ * that the value comes back to us over the open internet — the provider echoes
+ * whatever query string it was given, and nothing stops someone linking
+ * straight at /auth/callback with a `next` of their own.
+ *
+ * The encoding matters too: `next` is itself a path *with a query string*
+ * (the dashboard keeps all of its filter state there), so its `?` and `&` have
+ * to be escaped or the callback URL's own parser would truncate it at the
+ * first one and split the rest into unrelated params.
+ *
+ * "/" is left off entirely rather than encoded, so the overwhelmingly common
+ * case produces the exact same URL it always has. That matters operationally:
+ * Supabase matches `redirectTo` against the Redirect URLs allow-list in its
+ * dashboard, so a plain sign-in keeps working even where that list hasn't yet
+ * been widened to tolerate the new query param.
+ */
+export function authCallbackUrl(origin: string, next: unknown): string {
+  const path = safeRedirectPath(next);
+  const callback = `${origin}/auth/callback`;
+  return path === "/" ? callback : `${callback}?next=${encodeURIComponent(path)}`;
 }

--- a/app/src/lib/auth/actions.ts
+++ b/app/src/lib/auth/actions.ts
@@ -3,7 +3,7 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { resolveOAuthProvider } from "@/config/oauth-providers";
-import { resolvePublicOrigin } from "@/config/public-origin";
+import { authCallbackUrl, resolvePublicOrigin } from "@/config/public-origin";
 import { createClient } from "@/lib/supabase/server";
 
 export async function signInWithOAuth(formData: FormData) {
@@ -31,10 +31,15 @@ export async function signInWithOAuth(formData: FormData) {
     protocol: headersList.get("x-forwarded-proto") ?? "https",
   });
 
+  // ...and where to put the user down afterwards. The dashboard keeps its whole
+  // filter/view state in the query string, so returning everyone to "/" quietly
+  // threw that state away — sign in from a filtered view and you lost the view
+  // (reported by Anil Madhavapeddy). The form posts the page the user was on
+  // before they were sent to /login; authCallbackUrl sanitises and encodes it.
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: provider.id,
     options: {
-      redirectTo: `${origin}/auth/callback`,
+      redirectTo: authCallbackUrl(origin, formData.get("next")),
       ...(provider.scopes ? { scopes: provider.scopes } : {}),
     },
   });


### PR DESCRIPTION
## Summary

Signing in always dropped the user back on `/`. Because this dashboard encodes its **entire** filter/view state in the query string, signing in from a filtered view silently threw that view away. Reported by **Anil Madhavapeddy**:

> minor quality of life thing is to make the redirect_url after login preserve the query string (or you go to the front page)

`app/auth/callback/route.ts` already read a `?next=` param and sanitised it through `safeRedirectPath` — but nothing in the app ever sent it one. This wires up the other half.

**The flow, end to end:**

1. `components/AuthStatus.tsx` — the header's sign-in link now sends the user to `/login?next=<current path+search>`.
2. `app/login/page.tsx` — reads `next` and hands it to the form. If the user is *already* signed in (e.g. `/login` opened in a second tab) it now honours `next` too, instead of dumping them on the home page.
3. `app/login/SignInForm.tsx` — posts `next` as a hidden field, exactly as it already posts the browser's own `origin` (the Caddy/Host-rewrite workaround from #416).
4. `lib/auth/actions.ts` — folds it into the OAuth `redirectTo` via a new `authCallbackUrl()` helper in `config/public-origin.ts`.
5. `app/auth/callback/route.ts` — unchanged; it already knew what to do.

**Why `next` is sanitised at every hop.** Both `safeRedirectPath` calls are load-bearing and neither makes the other redundant. The one in `authCallbackUrl` keeps an attacker-chosen absolute/protocol-relative URL out of the `redirectTo` we hand to Supabase. The one in the callback route covers the fact that the value takes a round trip over the open internet — the provider echoes back whatever query string it was given, and nothing stops someone linking straight at `/auth/callback` with a `next` of their own. `safeRedirectPath` also now accepts `unknown`, since one caller is `formData.get("next")`, which is a `File` rather than a string if the field name ever collides with an upload.

**Why the encoding matters.** `next` is a path *with its own query string*, so its `?` and `&` have to be percent-encoded inside `redirectTo` — otherwise the callback URL's own parser truncates it at the first `?` and splits the rest into unrelated params. Verified round-tripping through the real server action below.

**Two judgement calls worth a look:**

- **`next` comes from the page URL, not from `window` at submit time.** By the time the form is on screen the browser is on `/login`, so its current URL is no longer the page worth returning to — the header link is what captures it, one navigation earlier.
- **The header link reads `window.location` in its click handler, not at render time**, which meant swapping `<Link>` for a plain `<a>`. The dashboard rewrites its own URL with bare `history.pushState` (`hooks/useFilterParams.ts`) — no Next.js navigation, so no re-render and nothing for `usePathname`/`useSearchParams` to observe. An `href` computed at render would go stale on the first filter change, i.e. on exactly the state this exists to preserve. The `href` attribute stays a plain `/login`, so cmd/middle-click, "copy link address" and a JS-less browser still reach a working sign-in page — they just fall back to the old behaviour of landing on `/`.
- **`?next=` is omitted entirely when there is nothing to preserve**, so a plain sign-in produces a `redirectTo` byte-identical to today's. See the deployment note below — this is deliberate, not cosmetic.

## ✅ Deployment: Supabase Redirect URLs allow-list widened (done)

**✅ Done — the trailing `*`s were added to the Supabase dashboard on 2026-07-30, before merge.** No action outstanding; the rest of this section is kept as a record of what was changed and why.

Supabase matches `redirectTo` against the **Redirect URLs** allow-list under **Auth → URL Configuration** in the Supabase dashboard. Every callback entry there needs to tolerate a query param — in practice a trailing `*`:

```
https://dashforlife.org/auth/callback*
https://dashoflife.org/auth/callback*
https://red.cst.cam.ac.uk/auth/callback*
https://en.ki/auth/callback*
https://red-list-dashboard.vercel.app/auth/callback*
… plus the preview-deployment entries
```

The PR could not make that change itself — it's dashboard config, not schema, so `app/supabase/migrations/` can't carry it. The built-in mitigation stands either way: because `?next=` is omitted when it would be `/`, a plain sign-in keeps working regardless of the allow-list, and only sign-in from a *filtered* view would have fallen back to the Site URL. So the failure mode was always quiet degradation, never an auth outage.

## Test plan

`npx tsc --noEmit`, `npm run lint`, `npm test` — all clean (763 tests). New unit tests in `config/__tests__/public-origin.test.ts` cover `authCallbackUrl`: the encoding of a filtered dashboard URL, a round trip back out through `safeRedirectPath` the way the callback route does it, refusal of off-site and non-string values, and the unadorned no-`next` case.

### Browser drive-through (Playwright, local dev server)

**❗ A real end-to-end sign-in was NOT completed** — finishing GitHub's OAuth needs credentials that aren't available to this environment. Everything up to the hand-off to Supabase was driven in a real browser; the final hop was reproduced by navigating to the exact `next` string recovered from the real `redirectTo`. Stated plainly so nobody reads more into the screenshots than is there.

**1. Start on a filtered view** — `/?taxa=mammals&categories=CR,EN&search=lemur` (64 species):

![filtered dashboard](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-446-signin-preserve-query-string/01-filtered-dashboard.png)

**2. Click the header sign-in icon** → lands on
`/login?next=%2F%3Ftaxa%3Dmammals%26categories%3DCR%252CEN%26search%3Dlemur`,
which decodes to `/?taxa=mammals&categories=CR%2CEN&search=lemur` — the original URL exactly. The `href` attribute is still a bare `/login` for modified clicks.

![login page carrying next](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-446-signin-preserve-query-string/02-login-with-next.png)

**3. Press "Sign in with GitHub"** — the real server action runs and redirects to Supabase's `/authorize`. Intercepted there (no credentials to go further) and read back what it built:

```
redirect_to = http://localhost:3021/auth/callback?next=%2F%3Ftaxa%3Dmammals%26categories%3DCR%252CEN%26search%3Dlemur
next inside redirect_to = /?taxa=mammals&categories=CR%2CEN&search=lemur
round-trips to the original URL: true
```

**4. Plain `/login` with no `?next=`** still builds `redirect_to = http://localhost:3021/auth/callback` — unchanged from today:

![plain login](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-446-signin-preserve-query-string/03-plain-login.png)

**5. `/auth/callback?next=…` with no code** returns 200 and bounces to `/login?error=auth_callback_failed` — parses fine, doesn't 500.

**6. Final hop (simulated, not a real sign-in)** — navigating to the `next` string recovered in step 3 lands on a URL byte-identical to step 1's, rendering the same filtered view:

![landed back on the filtered view](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-446-signin-preserve-query-string/04-landed-back.png)

### Not verified

- A real OAuth sign-in through GitHub/Google/Microsoft (no credentials available) — so the callback's *success* branch, `exchangeCodeForSession` → `redirectToPath(next)`, was not executed. That branch is unchanged by this PR; only the value reaching it is new, and that value was verified in steps 3 and 6.
- The already-signed-in `/login?next=…` redirect in `login/page.tsx` — needs a live session.
- Whether Supabase accepts the new `redirect_to` against its allow-list. The allow-list has since been widened (see above), but no real OAuth round trip has been observed on a deployed environment — the remaining check is to sign in from a filtered view on production and confirm the filters survive.

One pre-existing hydration warning appears on `/login` (React complaining about a `caret-color` style on the hidden inputs); it applies identically to the existing `origin` field and is not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

