### PR TITLE
Hide the Microsoft sign-in button (keep the provider working)

### DIFF
--- a/app/src/app/login/SignInForm.tsx
+++ b/app/src/app/login/SignInForm.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useSyncExternalStore } from "react";
-import { OAUTH_PROVIDERS } from "@/config/oauth-providers";
+import { VISIBLE_OAUTH_PROVIDERS } from "@/config/oauth-providers";
 import { signInWithOAuth } from "@/lib/auth/actions";
 
 // Each provider's own mark, drawn in its brand colours (GitHub's is
 // monochrome by design, so it follows the button's text colour and works in
-// both themes).
+// both themes). Keyed by provider id and kept for every provider in
+// OAUTH_PROVIDERS, including hidden ones, so unhiding is a one-flag change.
 const PROVIDER_ICONS: Record<string, React.ReactNode> = {
   github: (
     <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
@@ -79,7 +80,7 @@ export function SignInForm({ next }: { next?: string }) {
     <form action={signInWithOAuth} className="flex flex-col gap-3">
       <input type="hidden" name="origin" value={origin} />
       <input type="hidden" name="next" value={next ?? ""} />
-      {OAUTH_PROVIDERS.map(({ id, label }) => (
+      {VISIBLE_OAUTH_PROVIDERS.map(({ id, label }) => (
         <button
           key={id}
           type="submit"
@@ -87,8 +88,8 @@ export function SignInForm({ next }: { next?: string }) {
           value={id}
           className="relative w-full flex items-center justify-center px-12 py-2.5 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-700 dark:text-zinc-200 font-medium hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors"
         >
-          {/* Absolute so the three icons line up with each other, while the
-              labels stay centred as they were with the single button. */}
+          {/* Absolute so the icons line up with each other, while the labels
+              stay centred as they were with the single button. */}
           <span className="absolute left-4 flex items-center">{PROVIDER_ICONS[id]}</span>
           Sign in with {label}
         </button>

--- a/app/src/config/__tests__/oauth-providers.test.ts
+++ b/app/src/config/__tests__/oauth-providers.test.ts
@@ -1,5 +1,26 @@
 import { describe, expect, it } from "vitest";
-import { OAUTH_PROVIDERS, resolveOAuthProvider } from "../oauth-providers";
+import {
+  OAUTH_PROVIDERS,
+  VISIBLE_OAUTH_PROVIDERS,
+  resolveOAuthProvider,
+} from "../oauth-providers";
+
+describe("VISIBLE_OAUTH_PROVIDERS", () => {
+  it("leaves hidden providers off the sign-in page", () => {
+    expect(VISIBLE_OAUTH_PROVIDERS.map((p) => p.id)).not.toContain("azure");
+    expect(VISIBLE_OAUTH_PROVIDERS.every((p) => !p.hidden)).toBe(true);
+  });
+
+  it("still offers the providers that aren't hidden", () => {
+    expect(VISIBLE_OAUTH_PROVIDERS.map((p) => p.id)).toEqual(["google", "github"]);
+  });
+
+  it("is a subset of the full list, not a separate one", () => {
+    for (const provider of VISIBLE_OAUTH_PROVIDERS) {
+      expect(OAUTH_PROVIDERS).toContain(provider);
+    }
+  });
+});
 
 describe("resolveOAuthProvider", () => {
   it("accepts each provider the sign-in page offers", () => {
@@ -23,5 +44,12 @@ describe("resolveOAuthProvider", () => {
 
   it("asks Microsoft for the email scope, since it withholds email otherwise", () => {
     expect(resolveOAuthProvider("azure")?.scopes).toBe("email");
+  });
+
+  it("still resolves a hidden provider, so hiding a button can't break a sign-in in flight", () => {
+    // azure has no button as of 2026-07-30, but a form post already on its way
+    // — or anyone re-submitting a cached page — must still complete rather than
+    // fall through to the "unsupported provider" path.
+    expect(resolveOAuthProvider("azure")?.id).toBe("azure");
   });
 });

--- a/app/src/config/oauth-providers.ts
+++ b/app/src/config/oauth-providers.ts
@@ -12,25 +12,55 @@ type OAuthProvider = {
   // Extra OAuth scopes to request, beyond whatever the provider returns by
   // default. Omitted for providers that need none.
   scopes?: string;
+  // Set to keep a provider working while taking its button off the sign-in
+  // page. Anyone who already signed in this way keeps their session and their
+  // linked identity — only the button goes. See VISIBLE_OAUTH_PROVIDERS.
+  hidden?: true;
 };
 
-// This is the order the buttons appear in, and the first one reads as the
-// recommended one — so it leads with whichever works for the most people.
-// Google has no gate at all. Microsoft is blocked at organisations that disable
-// third-party user consent (Cambridge's tenant does, answering "Approval
-// required"), which is common at universities and NGOs. GitHub is a developer
-// account most of this audience won't have, and the few people already signed
-// in that way know where to look.
+// Every provider the app can complete a sign-in with. `resolveOAuthProvider`
+// searches this list, not the visible one, so a hidden provider still works for
+// anyone mid-flow or holding a link.
+//
+// Order matters for the buttons: the first reads as the recommended one, so it
+// leads with whichever works for the most people. Google has no gate at all.
+// GitHub is a developer account most of this audience won't have, and the few
+// people already signed in that way know where to look.
 export const OAUTH_PROVIDERS: readonly OAuthProvider[] = [
   { id: "google", label: "Google" },
+  // Hidden 2026-07-30, not removed. Microsoft is blocked at organisations that
+  // disable third-party user consent — Cambridge's tenant answers "Approval
+  // required", and iucn.org is on Entra ID too (its DNS carries the
+  // enterpriseregistration.windows.net CNAME), so the population this button
+  // was added for is the population most likely to hit the wall. The requested
+  // permissions are already the floor (User.Read + offline_access), so there is
+  // no app-side fix; it's tenant consent policy.
+  //
+  // The sharper reason for hiding rather than leaving it: range-map access is a
+  // hand-inserted user_roles row keyed to one user_id, and Supabase only links
+  // identities when the verified email matches. Microsoft is the button most
+  // likely to return someone's *work* address when their existing account is a
+  // personal Google/GitHub one — silently forking a second, role-less account
+  // for a user who already had access.
+  //
+  // Bring it back when either is true: an IUCN user confirms their tenant
+  // permits consent, or the app becomes a verified publisher (which needs an
+  // institutional sponsor — Microsoft's business verification wants a legally
+  // registered entity, and the app registration must belong to a tenant tied to
+  // that organisation's Partner Global Account).
+  //
   // Azure only returns an email claim if the email scope is asked for
   // explicitly, and the rest of the app leans on email throughout — it labels
   // the account menu, it's the fallback avatar initial, and it's how an
   // account is looked up to grant the admin role in user_roles. A Microsoft
   // user without one would sign in to a half-broken session.
-  { id: "azure", label: "Microsoft", scopes: "email" },
+  { id: "azure", label: "Microsoft", scopes: "email", hidden: true },
   { id: "github", label: "GitHub" },
 ];
+
+// The providers the sign-in page actually renders a button for.
+export const VISIBLE_OAUTH_PROVIDERS: readonly OAuthProvider[] =
+  OAUTH_PROVIDERS.filter((provider) => !provider.hidden);
 
 /**
  * Narrow the untrusted `provider` field posted by the sign-in form to one of
@@ -40,6 +70,10 @@ export const OAUTH_PROVIDERS: readonly OAuthProvider[] = [
  * call which redirects the browser off-site, so it gets the same treatment as
  * the origin posted alongside it (see resolvePublicOrigin): checked against a
  * fixed list rather than trusted.
+ *
+ * Deliberately searches OAUTH_PROVIDERS rather than VISIBLE_OAUTH_PROVIDERS:
+ * hiding a button shouldn't break a sign-in already in flight, and the check
+ * here is about what Supabase has enabled, not about what the page offers.
  */
 export function resolveOAuthProvider(value: unknown): OAuthProvider | null {
   return OAUTH_PROVIDERS.find((provider) => provider.id === value) ?? null;


### PR DESCRIPTION
## Summary

Takes the **Microsoft** button off the sign-in page. Google and GitHub remain. The provider itself stays enabled and fully working — this is a UI change, not a removal.

**Why.** Microsoft sign-in dead-ends at organisations that disable third-party user consent. Cambridge's tenant answers *"Approval required … This app requires your admin's approval"*, reported by **Anil Madhavapeddy** when he tried `@cam.ac.uk`. The permissions requested are already the floor — `User.Read` + `offline_access` — so there is nothing app-side to trim; it's tenant consent policy.

That would be tolerable if it only affected outsiders, but `iucn.org` is on Entra ID as well:

```
$ dig +short CNAME enterpriseregistration.iucn.org
enterpriseregistration.windows.net.          # the Entra device-registration CNAME
$ dig +short TXT iucn.org | grep spf1
"v=spf1 … include:spf.protection.outlook.com …"
```

So the population this button was added to serve is the population most likely to hit the wall. (Their MX is `fortimailcloud.com`, which is only a filtering gateway — it says nothing about the IdP. Worth knowing if anyone re-checks this.)

**The sharper reason, which is what tipped it.** Range-map access is a hand-inserted `user_roles` row keyed to a single `user_id`, and Supabase links identities only when the *verified email matches*. Microsoft is the button most likely to return someone's **work** address when their existing account is a personal Google/GitHub one — silently forking a second, role-less `auth.users` row for a user who already had access. They then report "I've lost the range maps." With access hand-curated one row at a time, extra providers carry that risk while buying almost nothing.

## Hidden, not removed

A `hidden?: true` flag on the provider entry. The two lists are deliberately different:

- `OAUTH_PROVIDERS` — everything the app can complete a sign-in with. **`resolveOAuthProvider` searches this one**, so a form post already in flight (or a cached page re-submitted) still completes rather than falling through to the unsupported-provider path.
- `VISIBLE_OAUTH_PROVIDERS` — what `SignInForm` renders buttons for.

Everything else is left in place: the Supabase provider stays enabled, the Entra app registration is untouched, the `azure` brand icon stays in `PROVIDER_ICONS`, and the `scopes: "email"` workaround stays attached to the entry. Anyone with an azure identity already linked keeps their session — hiding a button doesn't unlink anything. **Unhiding is deleting one flag.**

The reasoning is recorded as a comment on the entry itself rather than only here, since in three months this otherwise reads as an oversight.

**What brings it back** — either trigger is enough:
1. An IUCN user confirms their tenant permits consent (one person pressing the button on a preview deployment settles it).
2. The app becomes a verified publisher. That needs an institutional sponsor: Microsoft's business verification wants a legally registered entity with formation documents, and the app registration must live in a tenant tied to that organisation's Partner Global Account. Not something a solo publisher clears.

## Test plan

`npx tsc --noEmit`, `npm run lint`, `npm test` — all clean (**761 passed**, 6 skipped). New tests in `config/__tests__/oauth-providers.test.ts` cover both halves: that `azure` is absent from `VISIBLE_OAUTH_PROVIDERS`, that the visible list is exactly `["google", "github"]` and is a subset of the full list, and — the one that matters — that `resolveOAuthProvider("azure")` **still resolves**, so hiding a button can't break a sign-in already in flight.

### Browser drive-through (Playwright, real Chromium)

Own dev server on port 3025; only its own PID was killed on restart.

**1. Sign-in page — two buttons, Google first:**

![sign-in page, light](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-447-hide-microsoft-signin/01-login-light.png)

Read back from the live DOM rather than the source:

```
BUTTONS: [{"value":"google","label":"Sign in with Google"},
          {"value":"github","label":"Sign in with GitHub"}]
```

Server-rendered HTML agrees — `value="google"` and `value="github"` are present, `value="azure"` is not — so the button is gone before hydration, not hidden by CSS.

**2. Dark theme** — the buttons are theme-styled, so both were checked:

![sign-in page, dark](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-447-hide-microsoft-signin/02-login-dark.png)

**3. Google still starts a real sign-in.** Pressed the button, let the **real server action** run, and intercepted the redirect at Supabase's `/authorize` (aborting the hop to Google, since there are no credentials here):

```
provider    = google
redirect_to = http://localhost:3025/auth/callback
```

**4. #446's `?next=` behaviour survives this change.** From a filtered view, the header sign-in link still captures the URL:

```
LOGIN URL:  /login?next=%2F%3Ftaxa%3Dmammals%26categories%3DCR%252CEN
decodes to: /?taxa=mammals&categories=CR,EN
href attr:  /login          (unchanged, so modified-click still works)
```

### Not verified

- **A completed OAuth round trip** — no provider credentials in this environment, so the flow was verified up to the hand-off to Supabase and no further. Unchanged by this PR either way; only the button list moved.
- **That a hidden provider still completes end to end.** `resolveOAuthProvider("azure")` returning the right entry is unit-tested, but no real azure sign-in was driven through the server action.
- The dashboard's species table 500s in this worktree (`app/data/redlist/` is unpopulated and the checked-in `duckdb-ext` build is `linux_amd64`). Pre-existing local-environment gaps in a fresh worktree, unrelated to this change and not touching the login page or the header link that were under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
