### PR TITLE
Update the README and changelog; cut v2.17.0–v2.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,46 @@
 
 All notable changes to the IUCN Red List Assessments Dashboard.
 
-## [Unreleased]
+## [v2.19.0] — 2026-07-24 – 2026-07-30 — Sign-in, Compare Mode & Filter Charts
 
+- Added sign-in — GitHub, Google and Microsoft accounts via Supabase Auth, backed by a generic `user_roles` table so permissions aren't hardcoded per user. Signing in returns you to the page and query string you were on, and works across all the custom domains (Microsoft is wired up and working, but its button is hidden for now)
+- Added a Compare mode — two dashboard panels side by side, each with its own filters and view mode, reachable from the View dropdown
+- Added Criteria, Habitat and "Number of Assessments" filter charts, and unified all three hierarchical filters (Criteria, Threats, Habitat) on a single pattern: a bar chart at the top level that drills into pills, rather than a second nested bar chart. Criteria deliberately stays in A–E order rather than sorting by count, since that ordering is the standard one
+- Reworked the taxa-view header controls and filter cards: the View selector moved into the taxa breadcrumb table itself (landing-only), "More Filters" became a full-width card row and now holds the Country map and Threats chart, and the taxon stat card shows the filtered count instead of a static total
+- Reworked the Country view to lead with the map, revealing the table on click, and restored the landing map's full height
+- Moved the header controls onto the title row and the iNaturalist photos below the map on mobile
+- Zoomed the By Country map in one level by default
+- Fixed GBIF occurrence links returning 0 records
+- Fixed wrong species thumbnails for name-ambiguous iNaturalist matches, and cached the thumbnail proxy
+- Fixed a country selection outside Country view silently re-scoping the taxa breadcrumb table's own numbers — only the species list below it is scoped now
+- Fixed the weekly data sync still running DB-dependent phases under `--skip-redlist`
+
+## [v2.18.0] — 2026-07-19 – 2026-07-23 — Native Range, Country View & Dynamic Taxon Browsing
+
+- Added a Country view — a per-country landing page and a sortable country list alongside the existing world map
+- Added trait data from EOL TraitBank to the Encyclopedia of Life tab
+- Added an overall "load more" button and a date-range filter to the GBIF occurrence map
 - Added a "Native range only" check to the GBIF occurrence map's Coordinate cleaning dropdown — hides occurrences reported outside a species' native countries, catching cultivated/naturalized botanical-garden specimens. Two selectable sources (POWO/WCVP default, or the Red List assessment's own locations), which can genuinely disagree on native range. POWO now covers the full WCVP checklist (~983k names, current and synonym), not just already-assessed species — served from a Parquet file queried via DuckDB rather than a JSON import, cutting the cold-start lookup from ~3s to ~200ms
 - Added an "Overlays" dropdown to the GBIF occurrence map (Protected areas, POWO native range, IUCN native range) — shades which countries a source considers native, independent of the occurrence filter above; info icons link to the species' real POWO page and to Protected Planet
 - Tightened the Basis of Record dropdown's layout (narrower) and made its counts, and Coordinate cleaning's, cross-filter consistently with the new native-range check; moved the "Loaded X of Y" summary onto the map itself (top-right)
+- Made the taxonomic browser fully dynamic — every taxon now drills down live against the Catalogue of Life, replacing the hand-crafted described-species citations
+- Showed ancestor breadcrumb rows when jumping straight to a taxon from search, so it's clear where in the tree you've landed
 - Fixed the occurrence map re-fitting its zoom/bounds every time a filter checkbox was toggled — it now only re-fits on genuinely new data (new species, larger sample), not on filter changes
+- Fixed a Not Evaluated count mismatch for Mammals, and stopped the Not Evaluated view being offered for All Species
+- Fixed two weekly data-sync failures: a CoL checklist 404 during the monthly release rollover, and a stale file allowlist that broke the pointer-bump PR
+- Refreshed the GBIF/CoL data sync, adding Red List assessment criteria
+
+## [v2.17.0] — 2026-07-09 – 2026-07-18 — Coordinate Cleaning, SSC Groups & Red List 2026-1
+
+- Added GBIF coordinate cleaning — a TypeScript port of R's CoordinateCleaner checks (country centroids, capitals, biodiversity institutions, sea and urban tests, and range-based checks), together with an overhaul of the occurrence map's filter UI built around it
+- Added an SSC Specialist Groups view, piloted on IUCN's mammal Specialist Groups and then extended to all six taxa (reptiles, fishes, invertebrates, plants, fungi)
+- Synced to IUCN Red List 2026-1, and dropped the `has_map` column since range maps are unavailable
+- Added a "% Outdated" mode to the country map, switched its colouring to a linear gradient, and tidied its loading and Clear-all behaviour
+- Renamed "Assessments by Year" to "Year of Latest Assessment" and gave it an Outdated toggle
+- Defaulted unevaluated species to the Catalogue of Life tab when there's no occurrence data to show
+- Added a weekly data-sync GitHub Action, so the GBIF/CoL refresh and its pointer-bump PR now happen on a schedule instead of by hand
+- Fixed country-map name mismatches that were hiding data for ~40 territories, and folded Kosovo into Serbia as already done for Somaliland and Northern Cyprus
+- Fixed crustaceans missing two SIS-assessed barnacle species
 
 ## [v2.16.0] — 2026-06-30 – 2026-07-07 — Shared Filters, Attribution & Taxon Browsing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Red List Dashboard
 
-A web application for visualizing **IUCN Red List assessment coverage and prioritization**, integrated with GBIF occurrence records. Designed to identify species that may need reassessment based on new evidence.
+A web application for exploring **IUCN Red List assessment coverage and prioritization**, integrated with GBIF occurrence records, CITES trade data and the Catalogue of Life. Designed to identify species that may need reassessment based on new evidence — and, increasingly, to be a general-purpose window onto biodiversity data, including described species that haven't been assessed for the Red List yet.
+
+The same app is served under several brands, chosen by hostname (`src/config/brand.ts`):
+
+| Host | Brand |
+|------|-------|
+| `dashforlife.org` | **Dash for Life** (default — also used for previews and localhost) |
+| `dashoflife.org` | **Dash of Life** |
+| `red.cst.cam.ac.uk` | **Red List Dashboard** |
+| `red-list-dashboard.vercel.app` | **Red List Dashboard** |
 
 ## Core Purpose
 
@@ -8,67 +17,61 @@ The dashboard answers questions like:
 - Which species haven't been reassessed in 10+ years?
 - Have new observations accumulated since the last assessment?
 - Where are the knowledge gaps across taxonomic groups?
-
-## How the Data Works
-
-### Red List Data
-- **Source**: Pre-downloaded IUCN Red List data stored as per-taxon CSV files
-- **Coverage**: 21 taxonomic groups across vertebrates, invertebrates, plants, fungi, and protists
-- **Fields**: Species name, IUCN category (CR/EN/VU/etc.), assessment date, historical assessments, population trend, range countries
-
-### GBIF Integration
-The key innovation — linking assessment data to real-world observations:
-
-1. **Species Matching**: Each IUCN species is matched to GBIF using their species matching API (handles exact, fuzzy, and variant matches). Results stored in `data/mapping.csv`.
-
-2. **Observation Counts**: For each species, the dashboard shows:
-   - **Total GBIF** — all geo-referenced occurrence records
-   - **New GBIF** — count of records added after the assessment year
-   - **% New GBIF** — percentage of records added after the assessment year
-
-3. **Record Type Breakdown**: Shows the source of records:
-   - Human observations (including iNaturalist subset)
-   - Preserved specimens (museum collections)
-   - Machine observations (camera traps, acoustic sensors)
-
-4. **Quality Filters**: Only geo-referenced records without coordinate issues
+- Which described species haven't been assessed for the Red List yet?
 
 ## Features
 
-### Taxa Summary Table
-Shows all taxonomic groups with species counts, assessment coverage, outdated assessment percentages, and GBIF occurrence totals. Click a row to drill down. Includes a Red List vs GBIF focus mode toggle and column visibility controls.
+### Taxa summary and drill-down
+The landing table shows every taxonomic group with species counts, assessment coverage, outdated-assessment percentages, described-species totals from the Catalogue of Life, and GBIF occurrence totals. Click a row to drill into that group and down through the taxonomic tree. Includes a Red List vs GBIF focus-mode toggle and column visibility controls.
 
-### Interactive Filter Charts
-Four clickable charts for filtering species:
+### Filter charts
+Clickable charts cross-filter the species table and each other:
+
 - **Conservation Status** — EX/EW/CR/EN/VU/NT/LC/DD
 - **Years Since Assessed** — highlights species not reassessed in 10+ years
-- **Country** — world map with species/GBIF toggle
-- **GBIF Observations** — distribution by observation count range
+- **Country** — world map with species/GBIF toggle and an endemics filter
+- **GBIF Observations** — distribution by observation-count range
+- **Criteria** — the IUCN criteria under which species were listed
+- **Habitat**, **Systems**, **Threats** — from the assessment record
 
-Charts support multi-select filtering (Cmd/Ctrl+click to select multiple) and cross-filter with the search bar.
+Charts support multi-select (Cmd/Ctrl+click) and cross-filter with the search bar. Filter state lives in the URL through a shared filter registry, so a filtered view is linkable and the MCP tools resolve to the same view the UI shows.
 
-### Species Table
-- Search by scientific name
+### Species table
+- Search by scientific name, including synonyms — an old name resolves to the currently accepted species
 - Sortable by assessment date (default, oldest first), category, total GBIF records, or % new GBIF
 - Secondary sort by total GBIF (descending) when primary values tie
 - Links to IUCN assessment pages and GBIF occurrence search
-- Pin species to the top of the table with drag-to-reorder
+- Pin species to the top with drag-to-reorder
+- Configurable page size
 
-### Expandable Species Rows
-Click any species row to see a tabbed (or stacked) detail view:
-- **GBIF Map** — occurrence points on a MapLibre GL map + iNaturalist photo gallery
+### Expandable species rows
+Click any species row for a tabbed (or stacked) detail view:
+- **GBIF Map** — occurrence points on a MapLibre GL map, plus an iNaturalist photo gallery
 - **Literature** — papers published since the last assessment (from OpenAlex)
-- **Red List** — full assessment details including criteria, population trend, threats, conservation actions, and rationale
-- **CITES** — trade status, suspensions, quotas, and trade flow map
+- **Red List** — full assessment details: criteria, population trend, threats, conservation actions, rationale
+- **CITES** — trade status, suspensions, quotas, and a trade-flow map with history since 1975
+- **EOL** — traits and media from the Encyclopedia of Life
 
-### GBIF Match Status Indicators
-Shows data quality warnings when GBIF species matching is imperfect:
-- **EXACT** — reliable match
-- **FUZZY/VARIANT** — name variations matched
-- **HIGHERRANK** — matched to genus/family only (counts may include other species)
-- **NONE** — species not found in GBIF
+### Occurrence map filtering
+The GBIF map is more than a scatter of points:
+- **Coordinate cleaning** — a port of R's CoordinateCleaner tests (country centroids, capitals, biodiversity institutions, sea/urban, and range-based checks) to flag implausible records
+- **Native range only** — hides occurrences outside a species' native countries, catching cultivated and naturalized specimens. Two selectable sources: POWO/WCVP (default) or the Red List assessment's own locations, which can genuinely disagree
+- **Basis of record** — human observations (incl. an iNaturalist subset), preserved specimens, machine observations
+- **Overlays** — protected areas, POWO native range, IUCN native range
 
-### Dark Mode
+### Country view
+A per-country landing page and country list, combining live DuckDB queries with a precomputed all-species country aggregate — assessment coverage, endemics, and occurrence totals for a single country.
+
+### Compare view
+`/compare` renders two independent dashboard panels side by side, each with its own filters and view mode and both synced to the URL — so two filtered views can be compared directly, and the comparison shared as a link.
+
+### Agent access (MCP)
+An MCP server at `/api/mcp` (`@modelcontextprotocol/sdk` + `mcp-handler`) exposes the dashboard's data to agents. Results carry a verifiable `dashboard_url` that resolves to the equivalent UI view.
+
+### Accounts
+Sign-in is handled by Supabase Auth with OAuth providers (GitHub, Google, and Microsoft/Entra). Roles are stored in a `user_roles` table and checked server-side (`src/lib/auth/roles.ts`); `admin` is currently the only role. Schema lives in `app/supabase/migrations/`.
+
+### Dark mode
 Light, dark, and system theme modes.
 
 ---
@@ -76,25 +79,54 @@ Light, dark, and system theme modes.
 ## Architecture
 
 ```
-Frontend: Next.js 16 + React 19 + Tailwind CSS 4
-Maps:     MapLibre GL (react-map-gl) + react-simple-maps
-Charts:   Recharts
-Data:     SWR for client-side fetching
-Hosting:  Vercel
+Frontend:  Next.js 16 + React 19 + Tailwind CSS 4
+Maps:      MapLibre GL (react-map-gl) + react-simple-maps
+Charts:    Recharts
+Query:     DuckDB (@duckdb/node-api) over Parquet, inside API routes
+Auth:      Supabase (@supabase/ssr)
+Agents:    MCP server at /api/mcp
+Telemetry: Sentry, PostHog (proxied via /ingest), Vercel Analytics
+Hosting:   Vercel
 
 Data Flow:
-┌─────────────────┐  scripts/sync.ts   ┌──────────────────┐  httpfs / prebuild ┌───────────────┐
-│  IUCN Red List   │───────────────────▶│  CSVs + parquets │───────────────────▶│  app/data/     │──▶ API Routes ──▶ UI
-│  GBIF API        │  (offline pipeline)│  in private R2   │  (DuckDB at runtime│  (local copy)  │
-│  Catalogue of Life│                    │                  │   / build-time)    │                │
-└─────────────────┘                    └──────────────────┘                   └───────────────┘
+┌────────────────────┐  scripts/sync.ts    ┌──────────────────┐  httpfs / prebuild  ┌────────────────┐
+│  IUCN Red List DB  │────────────────────▶│  CSVs + parquets │────────────────────▶│  app/data/     │──▶ API Routes ──▶ UI
+│  GBIF API          │  (offline pipeline) │  in private R2   │  (DuckDB at runtime │  (local copy)  │
+│  Catalogue of Life │                     │                  │   / build-time)     │                │
+└────────────────────┘                     └──────────────────┘                     └────────────────┘
                           version pinned by app/latest-sync.txt (git-tracked)
 
 Live external APIs:
   GBIF REST API     → occurrence points, record breakdowns, iNaturalist photos
   Species+ API      → CITES listings, trade data
   OpenAlex          → scientific literature since last assessment
+  EOL TraitBank     → trait data for the EOL tab
 ```
+
+## How the Data Works
+
+### Red List data
+- **Source**: the IUCN Red List Postgres database, pulled into per-taxon CSV files by the sync pipeline
+- **Coverage**: 28 taxonomic groups across vertebrates, invertebrates, plants, fungi, and algae
+- **Version**: Red List 2026-1
+- **Fields**: species name, IUCN category (CR/EN/VU/etc.), assessment date, historical assessments, population trend, range countries, criteria, habitats, threats
+
+### GBIF integration
+The key innovation — linking assessment data to real-world observations:
+
+1. **Species matching**: each IUCN species is matched to GBIF via their species-matching API (exact, fuzzy, and variant matches). Results stored in `data/mapping.csv`.
+2. **Observation counts**: **Total GBIF** (all geo-referenced records), **New GBIF** (records added after the assessment year), and **% New GBIF**.
+3. **Record-type breakdown**: human observations (incl. iNaturalist), preserved specimens, machine observations.
+4. **Quality filters**: only geo-referenced records without coordinate issues.
+
+Match quality is surfaced in the UI, since it affects how far to trust a count:
+- **EXACT** — reliable match
+- **FUZZY/VARIANT** — name variations matched
+- **HIGHERRANK** — matched to genus/family only (counts may include other species)
+- **NONE** — species not found in GBIF
+
+### Catalogue of Life
+CoL supplies the described-species universe behind the new-assessments view — the species CoL knows about that haven't been assessed for the Red List yet — plus the synonym index that makes searching an outdated name work.
 
 ## Data Sync Pipeline
 
@@ -103,6 +135,7 @@ The `scripts/` directory contains a pipeline for refreshing all static data file
 ```bash
 npx tsx scripts/sync.ts                  # Full sync, all taxa
 npx tsx scripts/sync.ts mammalia aves    # Specific taxa only
+npx tsx scripts/sync.ts --skip-redlist   # Phases 2-13 only (no IUCN DB access needed)
 ```
 
 **Pipeline phases:**
@@ -113,7 +146,8 @@ npx tsx scripts/sync.ts mammalia aves    # Specific taxa only
 5. `fetch-gbif-new-counts` — GBIF API → updates GBIF CSVs with temporal splits
 6. `build-parquet` — CSVs → `assessed.parquet` / `unassessed.parquet` (the DuckDB read layer; also powers cross-taxa search)
 
-Phases 7–12 build the **Catalogue of Life backbone** (run on a full sync only) — the described-species universe behind the new-assessments view, which surfaces species CoL knows about that IUCN hasn't yet evaluated:
+Phases 7–12 build the **Catalogue of Life backbone** (run on a full sync only) — the described-species universe behind the new-assessments view, which surfaces species CoL knows about that haven't been assessed for the Red List yet:
+
 7. `fetch-col-xr` — CoL eXtended Release ColDP archive → `NameUsage.tsv` + `Reference.tsv` (downloaded to a temp dir, not `data/`)
 8. `fetch-col-checklist` — curated CoL Checklist ColDP archive → a demotion overlay (col_ids the checklist's editorial reconciliation demotes to synonym/infraspecific, correcting XR's over-splitting)
 9. `build-backbone` — `NameUsage.tsv` (minus the checklist's demotions) → `backbone.parquet` (tree + synonyms) + `species/` (accepted-species universe, partitioned; tagged `extinct`/`in_base`)
@@ -122,6 +156,7 @@ Phases 7–12 build the **Catalogue of Life backbone** (run on a full sync only)
 12. `build-col-taxon-ids` — resolves every taxon name referenced in `taxonomy-tree.ts`'s filters against `backbone.parquet` → `src/config/col-taxon-ids.json` (each name's CoL taxon id, so the dashboard can link a name straight to its CoL page). Small and derived from committed source, so — unlike the other outputs here — it's **committed to git**, not published to R2. Re-run standalone (`npx tsx scripts/build-col-taxon-ids.ts`) whenever a node's filter changes, without needing a full sync.
 
 Phase 13 runs **last**, after the CoL backbone, since it depends on those artifacts:
+
 13. `build-taxa-summary` — aggregates per-taxon CSVs + the CoL backbone (`species/`, `species_link.parquet`) → `data/taxa-summary.json` and `data/table1a-children-summaries.json`/`data/ssc-group-children-summaries.json` (split from a single `node-children-summaries.json` — the old combined name, kept here as a pointer for anyone searching it), including per-group `col_described`/`col_ne` counts
 
 **Publishing a refresh.** `app/data/` lives in a private R2 bucket; the active version is pinned via `app/latest-sync.txt`. To publish a fresh sync:
@@ -136,6 +171,8 @@ git push                               # open PR; merging flips production
 
 Production only switches to the new sync once the pointer-bump PR merges to main and Vercel redeploys.
 
+**Most of this is automated.** The `weekly-sync` workflow runs phases 2–13 every Sunday at 20:00 UTC and opens the pointer-bump PR itself, so the manual flow above is mainly for local work and one-off resyncs. Phase 1 (`fetch-redlist-species`) is skipped there — it's the only phase needing IUCN Postgres access, and the Red List data stays on its own manual ~6-month cadence.
+
 ## Getting Started
 
 ```bash
@@ -145,7 +182,7 @@ npm run fetch-data-from-r2   # populates app/data/ from private R2 (requires R2 
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) in your browser.
+Open [http://localhost:3000](http://localhost:3000).
 
 The Red List CSVs live in a private R2 bucket rather than in the repo, so the first step downloads them locally (~240MB). `npm run build` runs the same fetch automatically as `prebuild`.
 
@@ -164,9 +201,11 @@ The Red List CSVs live in a private R2 bucket rather than in the repo, so the fi
 | `npm run upload-data-to-r2` | Upload current `app/data/` to R2 as a new timestamped sync and bump `app/latest-sync.txt` |
 | `npm run diff-data-vs-r2` | Diff local `app/data/` against the currently-pinned R2 sync |
 
+Other pipeline scripts are run directly with `npx tsx` — see `app/scripts/`, including `fetch-wcvp-native-range.ts` (POWO native ranges), `fetch-coordinate-cleaning-refdata.ts` (CoordinateCleaner reference data), and `upload-range-maps.ts` / `upload-aoh-maps.ts` (raster uploads).
+
 ## Environment Variables
 
-Create `app/.env.local` with at least the R2 credentials (required to fetch `app/data/`):
+Create `app/.env.local`. The R2 credentials are the only ones needed just to run the app locally against a pinned sync; the rest enable individual features.
 
 ```
 # Cloudflare R2 — required for fetch-data-from-r2 / prebuild
@@ -174,29 +213,51 @@ R2_ACCOUNT_ID=your_account_id
 R2_ACCESS_KEY_ID=your_access_key_id
 R2_SECRET_ACCESS_KEY=your_secret_access_key
 R2_DATA_BUCKET_NAME=dashboard-data
+R2_MAPS_BUCKET_NAME=dashboard-maps      # range map / AOH rasters
 
-# Live external APIs — needed at runtime for the Red List assessment-detail and CITES tabs
+# Live external APIs — runtime, for the assessment-detail, CITES and EOL tabs
 RED_LIST_API_KEY=your_iucn_api_key
 SPECIES_PLUS_API_KEY=your_cites_species_plus_api_key
+EOL_TOKEN=your_eol_jwt_token
 
-# IUCN Red List Postgres database — needed only to run the data sync pipeline
-DB_HOST=your_db_host
-DB_PORT=your_db_port
+# Supabase — sign-in and roles
+SUPABASE_URL=your_supabase_project_url
+SUPABASE_PUBLISHABLE_KEY=your_supabase_publishable_key
+
+# Analytics (optional, public). Events are reverse-proxied through /ingest.
+NEXT_PUBLIC_POSTHOG_KEY=your_posthog_key
+
+# IUCN Red List Postgres — needed only to run phase 1 of the sync pipeline
+DB_HOST=localhost
+DB_PORT=5432
 DB_NAME=your_db_name
 DB_USER=your_db_user
 DB_PASSWORD=your_db_password
 ```
 
-See `app/.env.example` for the full list including database and analytics keys.
+`app/.env.example` carries the same list with fuller commentary on each.
+
+## Repo Automation
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| `test` | Pull requests and pushes to `main` | Tests with coverage, lint, and typecheck |
+| `weekly-sync` | Sundays 20:00 UTC | Runs sync phases 2–13, uploads to R2, opens the pointer-bump PR |
+| `supabase-migrations` | Push to `main` touching `app/supabase/migrations/` | Applies new migrations to the Supabase project |
+| `claude` | `@claude` mention | Runs Claude Code on an issue or PR comment |
+
+Contributor conventions (PR descriptions, UI verification, worktrees, screenshot hosting) are in [CLAUDE.md](CLAUDE.md).
 
 ## Tech Stack
 
-- **Next.js 16** — React framework
-- **React 19** — UI library
-- **TypeScript 5** — Type safety
-- **Tailwind CSS 4** — Styling
-- **Recharts** — Charts and graphs
-- **MapLibre GL** (react-map-gl) / **react-simple-maps** — Maps
-- **SWR** — Client-side data fetching
-- **Vitest** — Testing
-- **Vercel** — Hosting and deployment
+- **Next.js 16** / **React 19** / **TypeScript 5** — app framework
+- **Tailwind CSS 4** — styling
+- **DuckDB** (`@duckdb/node-api`) — Parquet query layer behind the API routes
+- **Recharts** — charts
+- **MapLibre GL** (react-map-gl) / **react-simple-maps** — maps
+- **Supabase** — auth and roles
+- **MCP** (`@modelcontextprotocol/sdk`, `mcp-handler`) — agent access
+- **Zod** — schema validation
+- **Vitest** — testing
+- **Sentry** / **PostHog** / **Vercel Analytics** — monitoring and analytics
+- **Vercel** — hosting and deployment


### PR DESCRIPTION
## Summary

Documentation only — no code or workflow changes. Two problems, both from the same drift:

- The changelog had gone untouched since 19 July while **44 PRs merged** — and a further **13 PRs from 9–18 July had never been written up either**. The 19 July entries only covered the native-range work, so that window was silently half-missing.
- The README had drifted into describing an earlier version of the app.

## Changelog: three releases

Wrote up everything merged since v2.16.0 and split it along its natural seams. Your cadence has been small themed releases — v2.13.0 through v2.16.0 each span 2–8 days — so one big 3-week release would have been out of character.

| Release | Range | Theme | Entries |
|---|---|---|---|
| **v2.17.0** | 2026-07-09 – 2026-07-18 | Coordinate Cleaning, SSC Groups & Red List 2026-1 | 9 |
| **v2.18.0** | 2026-07-19 – 2026-07-23 | Native Range, Country View & Dynamic Taxon Browsing | 12 |
| **v2.19.0** | 2026-07-24 – 2026-07-30 | Sign-in, Compare Mode & Filter Charts | 11 |

- **v2.17.0** — none of these existed anywhere before: the CoordinateCleaner TypeScript port and occurrence-map filter overhaul, SSC Specialist Groups across all six taxa, the Red List 2026-1 sync, the country map's % Outdated mode and gradient colouring, the ~40-territory name-mismatch fix, Kosovo folded into Serbia, and the weekly data-sync Action itself.
- **v2.18.0** — the native-range check and Overlays dropdown, the Country view's landing page and sortable list, EOL TraitBank traits, the GBIF map's load-more and date-range filter, and the fully dynamic taxonomic browser.
- **v2.19.0** — sign-in via GitHub/Google/Microsoft, Compare mode, the Criteria/Habitat/Number-of-Assessments charts and their unified drilldown pattern, and the taxa-view header and filter-card rework.

Two threads straddle the 24 July seam — the Country view (landing page on 19 Jul, map-first rework on 26 Jul) and the weekly-sync fixes — so each is written up in the release that actually shipped it rather than lumped into one entry.

Everything since v2.16.0 now sits under a released version, so the `[Unreleased]` heading is dropped. No pre-existing entry was reworded, reordered, or moved between sections — that heading and its blank line are the only lines this PR removes from the changelog (verified against the diff, not assumed).

## README

### Claims that had gone stale

| Claimed | Actually |
|---|---|
| "SWR for client-side fetching", also listed under Tech Stack | Not a dependency at all |
| "21 taxonomic groups" | 28 |
| "Four clickable charts" | Criteria, Habitat, Systems and Threats filters also exist |
| Red List version implied older | 2026-1 |

### Shipped but never documented

Supabase auth (GitHub/Google/Microsoft OAuth, `user_roles`, admin role), the MCP server at `/api/mcp`, the Country view, `/compare`, coordinate cleaning, native-range filtering and map overlays, the EOL tab, and the multi-brand hostname mapping (Dash for Life / Dash of Life / Red List Dashboard). Also corrected the impression that the sync pipeline is run by hand — `weekly-sync` has been automating phases 2–13 since 17 July.

Missing env vars added: `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, `EOL_TOKEN`, `R2_MAPS_BUCKET_NAME`, `NEXT_PUBLIC_POSTHOG_KEY`.

The sync-pipeline phase documentation was already accurate and is kept close to verbatim.

### Wording

Softened the framing around unassessed species — "described species that have never been assessed at all" / "which described species has IUCN never evaluated" now read as "described species that haven't been assessed for the Red List yet". Applied in all four places, including the two that predate this PR.

## Test plan

- [x] `CHANGELOG.md` diff removes only the `## [Unreleased]` heading and its blank line — no entry content touched, verified against the diff. This also proves the four pre-existing native-range entries are byte-identical
- [x] All three new headings match the existing format byte-for-byte (em-dash section separators, en-dash date range), confirmed by extracting each release title with the same parse that reproduces v2.16.0's real release title
- [x] Date ranges are contiguous and non-overlapping: 07-09→07-18, 07-19→07-23, 07-24→07-30
- [x] Section bullet counts verified: v2.19.0 11, v2.18.0 12, v2.17.0 9, v2.16.0 7 (untouched)
- [x] Every changelog entry traced to a merged PR; both the 9–18 July and 19–30 July windows enumerated in full so nothing is dropped
- [x] Every README fact re-verified against `main`: `app/package.json`, `app/scripts/sync.ts` (13 phases), `data/taxa-summary.json` (28 groups), `app/src/config/brand.ts`, `app/src/config/oauth-providers.ts`, the `app/src/app/api/` route tree, and the workflow files behind the automation table

No UI or code surface is touched, so the browser drive-through in CLAUDE.md doesn't apply here.

## After merge

Tags and GitHub releases are **not** created by this PR — a tag must point at a commit on `main`. Once this merges, `v2.17.0`, `v2.18.0` and `v2.19.0` get tagged and published from their changelog sections, matching the existing release format.

## Note for review

`app/.env.example` has drifted too — it documents "range-map + aoh API routes" that no longer exist under `app/src/app/api/`, and it omits the Supabase vars the code actually reads. Left alone to keep this PR to the two files asked for; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)