### PR TITLE
Update v2.19.0 and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the IUCN Red List Assessments Dashboard.
 - Added sign-in — GitHub, Google and Microsoft accounts via Supabase Auth, backed by a generic `user_roles` table so permissions aren't hardcoded per user. Signing in returns you to the page and query string you were on, and works across all the custom domains (Microsoft is wired up and working, but its button is hidden for now)
 - Added a Compare mode — two dashboard panels side by side, each with its own filters and view mode, reachable from the View dropdown
 - Added Criteria, Habitat and "Number of Assessments" filter charts, and unified all three hierarchical filters (Criteria, Threats, Habitat) on a single pattern: a bar chart at the top level that drills into pills, rather than a second nested bar chart. Criteria deliberately stays in A–E order rather than sorting by count, since that ordering is the standard one
+- Added IUCN range map and Area of Habitat (AOH) layers to the species occurrence map, served as rasters from R2 and gated to admin accounts
 - Reworked the taxa-view header controls and filter cards: the View selector moved into the taxa breadcrumb table itself (landing-only), "More Filters" became a full-width card row and now holds the Country map and Threats chart, and the taxon stat card shows the filtered count instead of a static total
 - Reworked the Country view to lead with the map, revealing the table on click, and restored the landing map's full height
 - Moved the header controls onto the title row and the iNaturalist photos below the map on mobile

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ The GBIF map is more than a scatter of points:
 - **Basis of record** — human observations (incl. an iNaturalist subset), preserved specimens, machine observations
 - **Overlays** — protected areas, POWO native range, IUCN native range
 
+### Range maps and Area of Habitat
+IUCN range maps and Area of Habitat (AOH) rasters can be overlaid on the species occurrence map, served from the `dashboard-maps` R2 bucket via `/api/species/[key]/range-map` and `/api/species/[key]/aoh`. Both are **gated to `admin` accounts** — the routes return 403 otherwise. Rasters are uploaded out of band with `scripts/upload-range-maps.ts` and `scripts/upload-aoh-maps.ts`.
+
 ### Country view
 A per-country landing page and country list, combining live DuckDB queries with a precomputed all-species country aggregate — assessment coverage, endemics, and occurrence totals for a single country.
 
@@ -69,7 +72,7 @@ A per-country landing page and country list, combining live DuckDB queries with 
 An MCP server at `/api/mcp` (`@modelcontextprotocol/sdk` + `mcp-handler`) exposes the dashboard's data to agents. Results carry a verifiable `dashboard_url` that resolves to the equivalent UI view.
 
 ### Accounts
-Sign-in is handled by Supabase Auth with OAuth providers (GitHub, Google, and Microsoft/Entra). Roles are stored in a `user_roles` table and checked server-side (`src/lib/auth/roles.ts`); `admin` is currently the only role. Schema lives in `app/supabase/migrations/`.
+Sign-in is handled by Supabase Auth with OAuth providers (GitHub, Google, and Microsoft/Entra). Roles are stored in a `user_roles` table and checked server-side (`src/lib/auth/roles.ts`); `admin` is currently the only role, and it gates the range map and AOH layers below. Schema lives in `app/supabase/migrations/`.
 
 ### Dark mode
 Light, dark, and system theme modes.


### PR DESCRIPTION
## Summary

Follow-up to #450, opened before cutting the `v2.19.0` tag so the release notes are complete.

**#207 "Add gated range map layer with R2 storage"** merged on 24 July and was missed. `gh pr list --limit 100` returns PRs ordered by number, and #207 is old enough to have fallen outside that window despite being one of the most recent merges — so it never appeared in the list the changelog was written from. Caught by cross-checking the git first-parent timeline against the PR list rather than trusting the PR list alone.

It's a real user-facing feature and belongs in v2.19.0:

> Added IUCN range map and Area of Habitat (AOH) layers to the species occurrence map, served as rasters from R2 and gated to admin accounts

## Also corrects a claim from #450

That PR's body said `app/.env.example` documents "range-map + aoh API routes that no longer exist". **That was wrong.** They do exist — at `app/src/app/api/species/[key]/range-map/` and `.../aoh/` — nested one level deeper than the `maxdepth 2` search that reported them missing. `.env.example` was accurate about them all along; its only genuine gap is the missing `SUPABASE_URL` / `SUPABASE_PUBLISHABLE_KEY`.

## README

Added a "Range maps and Area of Habitat" feature section, and tied the `admin` role to what it actually gates — the routes return 403 for non-admins (`app/src/app/api/species/[key]/range-map/route.ts:103`), which makes the roles table's purpose concrete rather than abstract.

## Test plan

- [x] Full merged-PR list for 09–31 July re-pulled at `--limit 300` and reconciled against the first-parent git timeline — 59 PRs, and #207 is the only feature-bearing one that was missing. The other delta is #450 itself (docs, and dated 31 July, outside all three release windows)
- [x] Route paths and the `isAdmin` 403 gate verified in the source, not inferred from the PR title
- [x] Changelog diff adds one line to v2.19.0 and touches nothing else; release headings, date ranges and the other sections are unchanged

## After this merges

`v2.17.0`, `v2.18.0` and `v2.19.0` get tagged and published. v2.17.0 and v2.18.0 are unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)