### PR TITLE
Fix searching for a not-evaluated insect

### DIFF
--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -6,7 +6,7 @@ import { CATEGORY_COLORS } from "../config/taxa";
 import { findNode, getViewRootForNode } from "../lib/taxonomy-utils";
 import { ALL_HABITAT_SEASONS, ALL_HABITAT_IMPORTANCE, ALL_HABITAT_SUITABILITY } from "../lib/habitat-filter";
 
-interface SearchResult {
+export interface SearchResult {
   id: number;
   scientific_name: string;
   common_name: string | null;
@@ -14,9 +14,15 @@ interface SearchResult {
   taxon_group: string;
   category: string;
   gbif_species_key: string | null;
+  gbif_occurrence_count: number | null;
   assessment_id: number | null;
   assessment_date: string | null;
   countries: string[];
+  class_name: string | null;
+  order_name: string | null;
+  family: string | null;
+  // The node whose species list holds this species (NE results only) — see selectResult.
+  node_id: string | null;
   matched_synonym?: string | null;
 }
 
@@ -118,11 +124,22 @@ export function SpeciesSearchBar() {
       lastSelectedResult = result;
       const viewMode: ViewMode = result.category === "NE" ? "new-assessments" : "reassessments";
 
+      // A not-evaluated species opens in the new-assessments view, which loads ONE node's
+      // NE list — and its top-level taxon can be far over the load cap (Invertebrates has
+      // ~1.3M NE species), in which case that view can only offer a "too many to load at
+      // once" drill-down prompt and never shows the species (#453). So select the node the
+      // species actually sits in (node_id, resolved server-side to something loadable),
+      // split into display-root + sub-group exactly like selectTaxon does — which is also
+      // what populates the ancestor-breadcrumb rows above the table. Assessed results keep
+      // browsing the whole top-level taxon (reassessments is assessed-only, always small).
+      const viewRoot = result.node_id ? getViewRootForNode(result.node_id) : null;
+      const subgroup = viewRoot && result.node_id !== viewRoot ? result.node_id : null;
+
       // Build URL with species selected — all filter state is driven from the URL
       const qs = buildQs({
         viewMode,
-        taxa: new Set([result.taxon_id]),
-        subgroups: new Set(),
+        taxa: new Set([viewRoot ?? result.taxon_id]),
+        subgroups: subgroup ? new Set([subgroup]) : new Set(),
         categories: new Set(),
         yearRanges: new Set(),
         assessmentYears: new Set(),

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -26,7 +26,7 @@ import { isOutdated, outdatedCutoffDate } from "@/lib/outdated";
 
 import AssessorCandidatesTable from "../AssessorCandidatesTable";
 import ReviewerCandidatesTable from "../ReviewerCandidatesTable";
-import { getLastSearchResult, clearLastSearchResult } from "../SpeciesSearchBar";
+import { getLastSearchResult, clearLastSearchResult, type SearchResult } from "../SpeciesSearchBar";
 
 // Species list is served by the DuckDB/Parquet-backed /api/redlist/species route.
 const SPECIES_API = "/api/redlist/species";
@@ -385,6 +385,45 @@ interface SpeciesDetails {
   gbifMatchFetched?: boolean;
 }
 
+// A search hit as a species row: everything the search index knows, with the
+// assessment-only fields (trend, criteria, threats, assessors, …) left empty — the same
+// shape and the same absent-field handling as a Not-Evaluated row from the species list.
+// Lets the searched species be rendered before (or without) the taxon's own list.
+function previewFromSearchResult(r: SearchResult): RedListSpecies {
+  return {
+    id: r.id,
+    sis_taxon_id: r.id > 0 ? r.id : null,
+    assessment_id: r.assessment_id,
+    scientific_name: r.scientific_name,
+    common_name: r.common_name,
+    family: r.family,
+    category: r.category,
+    assessment_date: r.assessment_date,
+    year_published: null,
+    population_trend: null,
+    countries: r.countries,
+    class_name: r.class_name,
+    order_name: r.order_name,
+    taxon_group: r.taxon_group,
+    taxon_id: r.taxon_id,
+    described_year: null,
+    gbif_species_key: r.gbif_species_key,
+    gbif_occurrence_count: r.gbif_occurrence_count,
+    gbif_observations_after_assessment_year: null,
+    latest_assessors: null,
+    latest_reviewers: null,
+    previous_assessments: [],
+    systems: [],
+    growth_forms: [],
+    movement_pattern: null,
+    possibly_extinct: false,
+    possibly_extinct_in_the_wild: false,
+    criteria: null,
+    threat_codes: [],
+    habitat_codes: [],
+    assessment_count: null,
+  };
+}
 
 // Debounced search input — manages own state for instant typing, debounces parent updates.
 // Filters the currently-visible species table by name in place, composing with whatever
@@ -1208,7 +1247,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // mutes bars for selectedCategories rather than dropping them. Every other
   // memo/the table uses this outdated-filtered version, so the Outdated button
   // behaves like a real, dashboard-wide filter everywhere except its own chart.
-  const taxaFilteredSpecies = useMemo(() => {
+  const taxaFilteredSpeciesNoPreview = useMemo(() => {
     if (!exactFilters.outdated) return taxaFilteredSpeciesExceptOutdated;
     const wantOutdated = exactFilters.outdated === "yes";
     return taxaFilteredSpeciesExceptOutdated.filter(s => isOutdated(s.assessment_date, dataAsOf) === wantOutdated);
@@ -1447,41 +1486,29 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     const cached = getLastSearchResult();
     if (cached && cached.id === urlSpecies) {
       clearLastSearchResult();
-      setSingleSpeciesPreview({
-        id: cached.id,
-        sis_taxon_id: cached.id > 0 ? cached.id : null,
-        assessment_id: cached.assessment_id,
-        scientific_name: cached.scientific_name,
-        common_name: cached.common_name,
-        family: null,
-        category: cached.category,
-        assessment_date: cached.assessment_date,
-        year_published: null,
-        population_trend: null,
-        countries: cached.countries,
-        class_name: null,
-        order_name: null,
-        taxon_group: cached.taxon_group,
-        taxon_id: cached.taxon_id,
-        described_year: null,
-        gbif_species_key: cached.gbif_species_key,
-        gbif_occurrence_count: null,
-        gbif_observations_after_assessment_year: null,
-        latest_assessors: null,
-        latest_reviewers: null,
-        previous_assessments: [],
-        systems: [],
-        growth_forms: [],
-        movement_pattern: null,
-        possibly_extinct: false,
-        possibly_extinct_in_the_wild: false,
-        criteria: null,
-        threat_codes: [],
-        habitat_codes: [],
-        assessment_count: null,
-      });
+      setSingleSpeciesPreview(previewFromSearchResult(cached));
       urlSpeciesHandledRef.current = true;
+      return;
     }
+
+    // Reload or shared link: the cached result only survives an in-page search, so
+    // re-resolve the species by the name the search bar left in `search=`. Without this
+    // the link renders an empty list whenever the taxon's own list doesn't carry the
+    // species — while it's still loading, or permanently for one excluded from the
+    // not-evaluated universe by a CoL id collision (see taxaFilteredSpecies).
+    if (!searchFilter) return;
+    let cancelled = false;
+    fetch(`/api/search?q=${encodeURIComponent(searchFilter)}&limit=10`)
+      .then(r => (r.ok ? r.json() : null))
+      .then((data: { results?: SearchResult[] } | null) => {
+        if (cancelled || !data) return;
+        const hit = data.results?.find(r => r.id === urlSpecies);
+        if (!hit) return;
+        setSingleSpeciesPreview(previewFromSearchResult(hit));
+        urlSpeciesHandledRef.current = true;
+      })
+      .catch(() => { /* preview is a nicety — the list path still applies */ });
+    return () => { cancelled = true; };
   }, [urlSpecies]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Clear preview once the species appears in bulk-loaded data
@@ -1491,6 +1518,24 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       setSingleSpeciesPreview(null);
     }
   }, [assessedSpecies, singleSpeciesPreview]);
+
+  // Fold the searched species (?species=, previewed from the cached search result) into the
+  // species set the charts and table are built from, so the single-species view resolves
+  // while the taxon's own list is still loading — or when that list simply doesn't contain
+  // it. The latter is real: an NE species whose CoL id was claimed by an assessed congener
+  // (a synonym mismatch — Pararge aegeria's id is held by the assessed Pararge xiphioides)
+  // is filtered out of the not-evaluated universe as "already assessed", so search is the
+  // only way to reach it and the list it lands in will never list it.
+  // Dedupe as paginatedSpecies does — by id, and for NE also by name, since a row loaded
+  // from the NE list is keyed on its CoL id while the search result is keyed on its GBIF one.
+  const taxaFilteredSpecies = useMemo(() => {
+    if (!singleSpeciesPreview) return taxaFilteredSpeciesNoPreview;
+    if (taxaFilteredSpeciesNoPreview.some(s =>
+      s.id === singleSpeciesPreview.id ||
+      (singleSpeciesPreview.category === "NE" && s.scientific_name === singleSpeciesPreview.scientific_name)
+    )) return taxaFilteredSpeciesNoPreview;
+    return [singleSpeciesPreview, ...taxaFilteredSpeciesNoPreview];
+  }, [taxaFilteredSpeciesNoPreview, singleSpeciesPreview]);
 
   const [mounted, setMounted] = useState(false);
 
@@ -3714,7 +3759,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           "all" in that mode as a side effect of loading species for the map's own
           stats (see setLayoutMode), not a real drill-down into All Species. */}
       {selectedTaxa.size > 0 && layoutMode !== "country" && (
-      neTooLarge ? (
+      // The drill-down prompt is about not being able to list a whole giant taxon — it
+      // must not swallow a specific species the user searched for, which is already in
+      // hand (singleSpeciesPreview) and needs no list to render.
+      neTooLarge && !singleSpeciesPreview ? (
         <div className="bg-white dark:bg-zinc-900 rounded-xl border border-amber-200 dark:border-amber-900/40 px-6 py-10 text-center">
           <p className="text-base font-medium text-zinc-700 dark:text-zinc-200">
             {neTooLarge.names.join(" & ")} has {neTooLarge.neTotal.toLocaleString()} not-evaluated species — too many to load at once.

--- a/app/src/lib/data/__tests__/species-duckdb.test.ts
+++ b/app/src/lib/data/__tests__/species-duckdb.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveWhere, toSpeciesRow, colIdToSearchId } from "@/lib/data/species-duckdb";
+import { resolveWhere, toSpeciesRow, colIdToSearchId, neNodeIdForSpecies } from "@/lib/data/species-duckdb";
 
 // Unit tests for the parity-critical pure logic of the DuckDB read layer (#261):
 // the taxon→SQL resolver and the row→SpeciesRow mapping. (Full v1-vs-v2 parity is
@@ -129,5 +129,53 @@ describe("toSpeciesRow", () => {
     expect(row.previous_assessments).toEqual([]);
     expect(row.taxon_id).toBe("invertebrates"); // mapTaxonId("beetles")
     expect(row.gbif_observations_after_assessment_year).toBeNull();
+  });
+});
+
+// Which node a not-evaluated search result opens in. The new-assessments view loads exactly
+// ONE node's NE list and refuses anything over NE_CAP, so picking the wrong node means the
+// species is never shown — either the "too many to load at once" prompt (#453: every insect
+// resolved to the ~1.3M-species Invertebrates aggregate) or a list it isn't part of (a
+// ladybird resolving to the Dung Beetle Specialist Group).
+describe("neNodeIdForSpecies", () => {
+  const insect = { class_name: "insecta", order_name: "lepidoptera", family: "nymphalidae" };
+
+  it("drills an insect down to its family — Insects itself is over the load cap", () => {
+    expect(neNodeIdForSpecies("butterflies_and_moths", insect))
+      .toBe("inv-insects~order:lepidoptera~family:nymphalidae");
+  });
+
+  it("keeps the group's own node when that node is small enough to load", () => {
+    expect(neNodeIdForSpecies("velvet_worms", { class_name: "udeonychophora", order_name: "euonychophora", family: "peripatidae" }))
+      .toBe("inv-velvet_worms");
+    expect(neNodeIdForSpecies("mammals", { class_name: "mammalia", order_name: "primates", family: "aotidae" }))
+      .toBe("mammals");
+  });
+
+  it("never routes to a Specialist Group node — they hold a curated subset, not the group", () => {
+    for (const [group, lineage] of [
+      ["beetles", { class_name: "insecta", order_name: "coleoptera", family: "coccinellidae" }],
+      ["dragonflies_and_damselflies", { class_name: "insecta", order_name: "odonata", family: "aeshnidae" }],
+      ["reptiles", { class_name: "reptilia", order_name: "squamata", family: "dactyloidae" }],
+    ] as const) {
+      const id = neNodeIdForSpecies(group, lineage);
+      expect(id).not.toBeNull();
+      expect(id!.startsWith("ssc-")).toBe(false); // "ssc-" is the id convention for them
+    }
+  });
+
+  it("stops at the deepest rank it knows, coalescing a missing one above it", () => {
+    expect(neNodeIdForSpecies("beetles", { class_name: "insecta", order_name: "coleoptera", family: null }))
+      .toBe("inv-insects~order:coleoptera");
+    expect(neNodeIdForSpecies("beetles", { class_name: "insecta", order_name: null, family: "coccinellidae" }))
+      .toBe("inv-insects~order:~family:coccinellidae");
+  });
+
+  it("falls back to the group's own node when the species has no lineage at all", () => {
+    expect(neNodeIdForSpecies("beetles", {})).toBe("inv-insects");
+  });
+
+  it("returns null for a group no taxonomy node covers", () => {
+    expect(neNodeIdForSpecies("not_a_real_group", insect)).toBeNull();
   });
 });

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -218,6 +218,13 @@ const EXCLUDED_COL_IDS_SQL = `('6MB3T')`; // Homo sapiens
 // taxa like "mammals"), which bypasses filterToSql entirely.
 const NOT_DOMESTIC_SQL = `coalesce(lower(scientific_name), '') NOT IN (${sqlStrList(COL_DOMESTIC_EXCLUDE_NAMES)})`;
 
+// Cap on how many Not-Evaluated species one query may return. A giant aggregate
+// (insects ~935k, invertebrates ~1.3M) can't be serialized in one response (it 500s /
+// times out), so a taxon over the cap returns no rows with tooLarge=true and the UI
+// prompts a drill-down instead. Also read by neNodeIdForSpecies, which uses it to pick
+// a node a search result can actually be shown in.
+const NE_CAP = 400_000;
+
 // Per-taxon_group not-evaluated counts from the precomputed taxa-summary (in memory),
 // used to decide tooLarge instantly without scanning species/ on R2.
 let neByGroupCache: Map<string, number> | null = null;
@@ -245,7 +252,6 @@ export async function querySpecies(opts: {
   // ~1.3M) can't be serialized in one response (it 500s / times out). Return up to
   // NE_CAP, flag `truncated`, and report `neTotal` so the UI can say "showing N of M
   // — drill into a sub-group". Every species stays reachable via its leaf node.
-  const NE_CAP = 400_000;
   // The NE list is never partially truncated now: a group over the cap returns no rows
   // with tooLarge=true (UI prompts a drill-down); groups under the cap load in full.
   const truncated = false;
@@ -377,29 +383,60 @@ export interface SearchResult {
   taxon_group: string;
   category: string;
   gbif_species_key: string | null;
+  // Carried so the single-species preview the dashboard renders from this result (before
+  // — or instead of — the taxon's own list arriving) shows the species' real occurrence
+  // count rather than a blank cell.
+  gbif_occurrence_count: number | null;
   assessment_id: number | null;
   assessment_date: string | null;
   countries: string[];
+  class_name: string | null;
+  order_name: string | null;
+  family: string | null;
+  // The taxonomy node this species should be browsed in — the sub-group the dashboard
+  // selects alongside taxon_id (see neNodeIdForSpecies). Only set for NE results, which
+  // are the ones whose view has to load a single node's not-evaluated list.
+  node_id: string | null;
   // Set when the result was matched via a synonym (the old name the user typed) rather than
   // its accepted name — the dropdown shows "(syn. <name>)". scientific_name is the accepted name.
   matched_synonym?: string | null;
 }
 
-// taxon_group → its representative *leaf* display node (csvGroups===[group], no class/order
-// sub-filter). mapTaxonId maps to the top-level taxon (e.g. invertebrates), which is too
-// large to load in new-assessments; a CoL-only search result must navigate to the leaf node
-// (e.g. dragonflies-damselflies) so its NE list actually loads.
-const GROUP_TO_LEAF_NODE: Map<string, string> = (() => {
-  const m = new Map<string, string>();
-  for (const [id, node] of NODE_INDEX) {
-    const f = node.filter;
-    if (f.csvGroups?.length === 1 && !f.classNames && !f.orderNames && !f.excludeClasses &&
-        !f.excludeOrders && !f.families && !f.excludeFamilies && !m.has(f.csvGroups[0])) {
-      m.set(f.csvGroups[0], id);
-    }
-  }
-  return m;
-})();
+interface Lineage { class_name?: string | null; order_name?: string | null; family?: string | null }
+
+// The node an NE search result should open in. Its view (new-assessments) loads exactly
+// one node's not-evaluated list, and mapTaxonId's top-level taxon (invertebrates, ~1.3M NE)
+// is far over NE_CAP — so picking it means the species is never shown, just the "too many
+// to load at once" drill-down prompt (#453).
+//
+// findViewLeafForGroup gives the group's own "By Taxon" container node, which is loadable
+// for most groups (Arachnids, Velvet Worms, Mammals…). For the eight insect groups it is
+// the whole Insects aggregate (~935k NE) — their static per-order nodes were retired in
+// favour of live drilldown — so when the container is over the cap, drill down to the
+// species' own family via a dynamic node id (e.g. inv-insects~order:lepidoptera~family:
+// nymphalidae). That is both small enough to load and a real tree position, so the
+// ancestor-breadcrumb rows and per-taxon stat card resolve exactly as they do when the
+// user drills there by hand. Every rank above the deepest known one must be present in
+// the id (dynamicNodeAncestors/nextDynamicRank read depth positionally) — a null one
+// becomes "", the same Unclassified-bucket convention resolveTaxonSuggestionNode uses.
+export function neNodeIdForSpecies(taxonGroup: string, lineage: Lineage): string | null {
+  const leafRoot = findViewLeafForGroup(taxonGroup);
+  if (!leafRoot) return null;
+  const rootNe = getCsvGroupsForNode(leafRoot).reduce((sum, g) => sum + (neByGroup().get(g) ?? 0), 0);
+  if (rootNe <= NE_CAP) return leafRoot;
+  const valueFor: Partial<Record<DynamicSegment["rank"], string | null | undefined>> = {
+    class: lineage.class_name, order: lineage.order_name, family: lineage.family,
+  };
+  // genus is never enumerated here: the species itself is the target, and a genus node
+  // buys nothing over its family while being one more level the user has to climb out of.
+  const ranks = rankOrderFor(leafRoot).filter((r) => r !== "genus");
+  let deepest = -1;
+  ranks.forEach((r, i) => { if (valueFor[r]) deepest = i; });
+  if (deepest === -1) return leafRoot; // no lineage at all — nothing more precise to offer
+  return buildDynamicNodeId(leafRoot, ranks.slice(0, deepest + 1).map((rank) => ({
+    rank, value: (valueFor[rank] ?? "").toLowerCase(),
+  })));
+}
 
 // Stable negative int id for a CoL-only species (no IUCN sis id / GBIF key). Used as the
 // search result's id — the URL `species=` param + the cached-preview key — and never
@@ -422,9 +459,9 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
   const conn = await getConn();
   const lim = Math.min(Math.max(limit, 1), 50);
   const proj = (src: string, assessed: boolean) => `
-    SELECT id, scientific_name, common_name, taxon_group, iucn_category AS category, gbif_species_key,
+    SELECT id, scientific_name, common_name, taxon_group, iucn_category AS category, gbif_species_key, gbif_occurrence_count,
            ${assessed ? "assessment_id, CAST(assessment_date AS VARCHAR) AS assessment_date" : "NULL AS assessment_id, NULL AS assessment_date"},
-           countries
+           countries, class_name, order_name, family
     FROM '${parquetUri(src)}'
     WHERE scientific_name ILIKE '%' || $q || '%'
        OR (common_name IS NOT NULL AND common_name ILIKE '%' || $q || '%')`;
@@ -440,20 +477,24 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
   const fast: SearchResult[] = rows.map((r) => {
     const tg = String(r.taxon_group);
     const cat = String(r.category ?? "");
-    // NE results navigate to the new-assessments view, which can't load a giant aggregate
-    // (mapTaxonId's top-level taxon) — send them to the leaf node so the list loads. Assessed
-    // results go to reassessments (assessed-only, always loadable) via the top-level taxon.
+    const lineage = { class_name: str(r.class_name), order_name: str(r.order_name), family: str(r.family) };
+    // Both views browse via the top-level taxon; an NE result additionally carries the
+    // sub-group node its (new-assessments) view has to load — see neNodeIdForSpecies.
+    // Assessed results go to reassessments, which is assessed-only and always loadable.
     return {
       id: Number(r.id),
       scientific_name: String(r.scientific_name ?? ""),
       common_name: (r.common_name as string) ?? null,
-      taxon_id: cat === "NE" ? (GROUP_TO_LEAF_NODE.get(tg) ?? mapTaxonId(tg)) : mapTaxonId(tg),
+      taxon_id: mapTaxonId(tg),
       taxon_group: tg,
       category: cat,
       gbif_species_key: str(r.gbif_species_key),
+      gbif_occurrence_count: num(r.gbif_occurrence_count),
       assessment_id: num(r.assessment_id),
       assessment_date: (r.assessment_date as string) ?? null,
       countries: splitList(r.countries),
+      ...lineage,
+      node_id: cat === "NE" ? neNodeIdForSpecies(tg, lineage) : null,
     };
   });
   // Return as soon as the direct search (assessed ∪ unassessed, ~16MB) finds anything.
@@ -472,7 +513,7 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
   // (name-dedup suffices, no species_link anti-join needed). Render as NE → leaf taxon.
   const seen = new Set(fast.map((r) => r.scientific_name.toLowerCase()));
   const colSql = `
-    SELECT col_id, scientific_name, taxon_group
+    SELECT col_id, scientific_name, taxon_group, class_name, order_name, family
     FROM read_parquet('${parquetUri("species/**/*.parquet")}', hive_partitioning=true)
     WHERE scientific_name ILIKE '%' || $q || '%' AND in_base AND extinct IS NOT TRUE
       AND col_id NOT IN ${EXCLUDED_COL_IDS_SQL}
@@ -484,17 +525,21 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
     if (seen.has(name.toLowerCase())) continue;
     seen.add(name.toLowerCase());
     const tg = String(r.taxon_group);
+    const lineage = { class_name: str(r.class_name), order_name: str(r.order_name), family: str(r.family) };
     fast.push({
       id: colIdToSearchId(String(r.col_id)),
       scientific_name: name,
       common_name: null,
-      taxon_id: GROUP_TO_LEAF_NODE.get(tg) ?? mapTaxonId(tg),
+      taxon_id: mapTaxonId(tg),
       taxon_group: tg,
       category: "NE",
       gbif_species_key: null,
+      gbif_occurrence_count: null,
       assessment_id: null,
       assessment_date: null,
       countries: [],
+      ...lineage,
+      node_id: neNodeIdForSpecies(tg, lineage),
     });
     if (fast.length >= lim) break;
   }
@@ -503,7 +548,7 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
   // Synonym tier: resolve an old/synonym name to its accepted species via synonym-index.parquet
   // (name-sorted → prefix-range prunes to ~1 row group). Reached only when the direct search
   // found nothing (gated above). The accepted species routes like a direct hit — assessed →
-  // reassessments (sis id), NE → new-assessments/leaf node — and carries the matched synonym
+  // reassessments (sis id), NE → new-assessments/its own node — and carries the matched synonym
   // for the UI. Graceful no-op if the index isn't in this sync prefix.
   const synUri = parquetUri("synonym-index.parquet");
   const synLo = `'${query.toLowerCase().replace(/'/g, "''")}'`;
@@ -523,6 +568,9 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
          WHERE synonym_name_lower LIKE '%' || ${synLo} || '%' AND synonym_name_lower NOT LIKE ${synLo} || '%'
          ORDER BY synonym_name_lower LIMIT ${need * 3 + 5}`, {})).getRowObjects();
     }
+    // synonym-index.parquet carries no lineage columns, so NE hits get theirs (and with it
+    // their node_id) from one follow-up lookup below rather than a per-row query.
+    const needLineage: { result: SearchResult; colId: string }[] = [];
     for (const r of synRows) {
       const accName = String(r.accepted_name ?? "");
       if (seen.has(accName.toLowerCase())) continue; // accepted already listed (direct hit, or another synonym of it)
@@ -530,20 +578,49 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
       const tg = String(r.taxon_group);
       const cat = String(r.category ?? "NE");
       const sis = r.sis_id == null ? null : Number(r.sis_id);
-      fast.push({
+      const result: SearchResult = {
         id: sis ?? colIdToSearchId(String(r.accepted_col_id)),
         scientific_name: accName,
         common_name: null,
-        taxon_id: cat === "NE" ? (GROUP_TO_LEAF_NODE.get(tg) ?? mapTaxonId(tg)) : mapTaxonId(tg),
+        taxon_id: mapTaxonId(tg),
         taxon_group: tg,
         category: cat,
         gbif_species_key: null,
+        gbif_occurrence_count: null,
         assessment_id: null,
         assessment_date: null,
         countries: [],
+        class_name: null,
+        order_name: null,
+        family: null,
+        node_id: cat === "NE" ? neNodeIdForSpecies(tg, {}) : null,
         matched_synonym: String(r.synonym_name ?? ""),
-      });
+      };
+      fast.push(result);
+      if (cat === "NE" && r.accepted_col_id != null) {
+        needLineage.push({ result, colId: String(r.accepted_col_id) });
+      }
       if (fast.length >= lim) break;
+    }
+    if (needLineage.length > 0) {
+      // Exact col_id match, partition-pruned to the hits' own taxon_groups — cheap next to
+      // the index scan that got us here. Best-effort: a miss just leaves the group-level
+      // node_id already set above.
+      const lineageRows = (await conn.runAndReadAll(
+        `SELECT col_id, class_name, order_name, family
+         FROM read_parquet('${parquetUri("species/**/*.parquet")}', hive_partitioning=true)
+         WHERE taxon_group = ANY(string_split($tg, '|')) AND col_id = ANY(string_split($ids, '|'))`,
+        { tg: needLineage.map((n) => n.result.taxon_group).join("|"),
+          ids: needLineage.map((n) => n.colId).join("|") })).getRowObjects();
+      const byColId = new Map(lineageRows.map((r) => [String(r.col_id), r]));
+      for (const { result, colId } of needLineage) {
+        const row = byColId.get(colId);
+        if (!row) continue;
+        result.class_name = str(row.class_name);
+        result.order_name = str(row.order_name);
+        result.family = str(row.family);
+        result.node_id = neNodeIdForSpecies(result.taxon_group, result);
+      }
     }
   } catch { /* synonym index not in this sync prefix — skip */ }
   return fast;
@@ -706,7 +783,7 @@ function isSscGroupNode(id: string): boolean {
 // dimension (a single value, no other filters/exclusions), excluding SSC Specialist Group
 // nodes — the same node a user reaches by clicking through the default tree, so a search
 // jump to it gets full ancestor breadcrumbs and curated labels for free. Mirrors
-// GROUP_TO_LEAF_NODE's single-dimension-match pattern above.
+// findViewLeafForGroup's single-dimension-match pattern below.
 const RANK_VALUE_TO_NODE: Map<string, string> = (() => {
   const m = new Map<string, string>();
   const DIMS = ["classNames", "orderNames", "families"] as const;


### PR DESCRIPTION
Fixes #453.

## The bug

Searching for a not-evaluated insect — `Pararge aegeria`, the issue's example — navigated to `?view=new-assessments&taxa=invertebrates`. Invertebrates has ~1.3M not-evaluated species, far over the species API's 400k `NE_CAP`, so the view could only render the drill-down prompt. The species never appeared.

Search resolved NE results through a group→node map that only matched nodes filtering on **exactly one** CSV group. The static per-order insect nodes (Beetles, Butterflies & Moths, …) were retired in favour of live drilldown, so all eight insect groups fell through to the top-level aggregate.

The same map silently mis-resolved two more groups, where the only remaining single-group node is a **Specialist Group**: an NE beetle opened the Dung Beetle SG (0 species for a ladybird), an NE reptile the Reptile SG container.

| Before — `Pararge aegeria` | Before — `Harmonia axyridis` (ladybird) |
|---|---|
| <img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-459-ne-insect-search/01-before-butterfly-banner.png" width="100%"> | <img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-459-ne-insect-search/03-before-beetle-dung-beetle-sg.png" width="100%"> |
| `taxa=invertebrates` → drill-down prompt | `taxa=ssc-dung-beetle` → "No species found" |

## The fix

**1. NE search results carry the node they should be browsed in** (`node_id`), resolved server-side with the same helpers the taxon suggestions already use:

- `findViewLeafForGroup` — the group's own "By Taxon" node, never an SSC one (Arachnids, Velvet Worms, Mammals, Reptiles…);
- when that node is itself over the cap — as Insects (~935k NE) is — drill down to the species' own **family** as a dynamic drilldown id, e.g. `inv-insects~order:lepidoptera~family:nymphalidae`. Small enough to load, and a real tree position, so the ancestor-breadcrumb rows and curated labels resolve exactly as they do when drilling there by hand.

The search bar then selects it as display-root + sub-group, the same split `selectTaxon` does. Assessed results are untouched (reassessments is assessed-only and always loadable).

**2. The searched species is folded into the set the charts and table are built from**, and re-resolved by name on a reload/shared link. Without this a species missing from its own NE list renders an empty view — which is real, not hypothetical: `Pararge aegeria`'s CoL id is claimed by the assessed `Pararge xiphioides` through a synonym mismatch, so the NE universe excludes it as "already assessed" and no list will ever carry it. The `?species=` link is now durable either way.

Search results also carry `class_name`/`order_name`/`family`/`gbif_occurrence_count`, so the preview row shows real values instead of blanks.

| After — `Pararge aegeria` | After — `Harmonia axyridis` |
|---|---|
| <img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-459-ne-insect-search/02-after-butterfly.png" width="100%"> | <img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-459-ne-insect-search/04-after-beetle.png" width="100%"> |
| Invertebrates → Insects → Lepidoptera → Nymphalidae | Invertebrates → Insects → Coleoptera → Coccinellidae |

## Test plan

`npm test` (838 pass, 6 new), `npx tsc --noEmit`, `npm run lint` all clean. Six new unit tests cover the node resolution: insect → family, small group → its own node, never an `ssc-` node, missing intermediate ranks, no lineage at all, unknown group.

Browser-verified against the 2026-08-02 sync (before/after captured on the same data, same dev server):

| Case | Result |
|---|---|
| Search `Pararge aegeria` | `taxa=inv-insects~order:lepidoptera~family:nymphalidae`, breadcrumb + species card, 1 species |
| Search `Harmonia axyridis` | `…~order:coleoptera~family:coccinellidae`, 1 species, 977,919 GBIF observations |
| Search `Apis mellifera`, `Amanita muscaria` | resolve to their family / group node, 1 species |
| Reload the `Pararge aegeria` link (no cached search result) | species still renders, 3,470,238 GBIF observations ([shot](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-459-ne-insect-search/05-after-shared-link-reload.png)) |
| Search `Peripatus bavayi` (velvet worm) | unchanged: `taxa=velvet_worms`, 1 species ([shot](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-459-ne-insect-search/06-after-velvet-worm-unchanged.png)) |
| Search `Panthera leo` (assessed) | unchanged: `?taxa=mammals&species=15951` |
| Browse Invertebrates NE directly | drill-down prompt still shown — it's correct there ([shot](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-459-ne-insect-search/07-after-invertebrates-prompt-intact.png)) |
| Browse Mammals NE, "Browse Nymphalidae" taxon suggestion | unchanged |

No console errors (the headless WebGL warning from the map is environmental).

## Not in scope

`Pararge aegeria` being excluded from the not-evaluated universe is an upstream CoL/synonym-matching defect, not fixed here — this PR makes the species reachable and viewable despite it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
