### PR TITLE
Land a search on the species' own family

### DIFF
--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -21,7 +21,7 @@ export interface SearchResult {
   class_name: string | null;
   order_name: string | null;
   family: string | null;
-  // The node whose species list holds this species (NE results only) — see selectResult.
+  // The node this species sits in — its family where known — see selectResult.
   node_id: string | null;
   matched_synonym?: string | null;
 }
@@ -124,14 +124,14 @@ export function SpeciesSearchBar() {
       lastSelectedResult = result;
       const viewMode: ViewMode = result.category === "NE" ? "new-assessments" : "reassessments";
 
-      // A not-evaluated species opens in the new-assessments view, which loads ONE node's
-      // NE list — and its top-level taxon can be far over the load cap (Invertebrates has
-      // ~1.3M NE species), in which case that view can only offer a "too many to load at
-      // once" drill-down prompt and never shows the species (#453). So select the node the
-      // species actually sits in (node_id, resolved server-side to something loadable),
-      // split into display-root + sub-group exactly like selectTaxon does — which is also
-      // what populates the ancestor-breadcrumb rows above the table. Assessed results keep
-      // browsing the whole top-level taxon (reassessments is assessed-only, always small).
+      // Open on the node the species actually sits in — its family where CoL knows one
+      // (node_id, resolved server-side) — split into display-root + sub-group exactly like
+      // selectTaxon does. That is what puts its lineage on screen as the taxa table's
+      // ancestor rows (Invertebrates → Insects → Lepidoptera → Nymphalidae) instead of
+      // dropping the user at the bare top-level taxon, and on the not-evaluated side it is
+      // also what makes the species listable at all: that view loads one node's NE list and
+      // an aggregate like Invertebrates (~1.3M NE) is over the cap, so it could only ever
+      // show the "too many to load at once" prompt there (#453).
       const viewRoot = result.node_id ? getViewRootForNode(result.node_id) : null;
       const subgroup = viewRoot && result.node_id !== viewRoot ? result.node_id : null;
 

--- a/app/src/lib/data/__tests__/species-duckdb.test.ts
+++ b/app/src/lib/data/__tests__/species-duckdb.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveWhere, toSpeciesRow, colIdToSearchId, neNodeIdForSpecies } from "@/lib/data/species-duckdb";
+import { resolveWhere, toSpeciesRow, colIdToSearchId, nodeIdForSpecies } from "@/lib/data/species-duckdb";
 
 // Unit tests for the parity-critical pure logic of the DuckDB read layer (#261):
 // the taxon→SQL resolver and the row→SpeciesRow mapping. (Full v1-vs-v2 parity is
@@ -132,24 +132,45 @@ describe("toSpeciesRow", () => {
   });
 });
 
-// Which node a not-evaluated search result opens in. The new-assessments view loads exactly
-// ONE node's NE list and refuses anything over NE_CAP, so picking the wrong node means the
-// species is never shown — either the "too many to load at once" prompt (#453: every insect
-// resolved to the ~1.3M-species Invertebrates aggregate) or a list it isn't part of (a
-// ladybird resolving to the Dung Beetle Specialist Group).
-describe("neNodeIdForSpecies", () => {
-  const insect = { class_name: "insecta", order_name: "lepidoptera", family: "nymphalidae" };
+// Which node a search result opens in. The taxa table renders the ancestor chain of
+// whatever is selected, so this is what puts a species' lineage on screen — and on the
+// not-evaluated side it also decides whether the species can be listed at all, since that
+// view loads exactly ONE node's NE list and refuses anything over NE_CAP (#453).
+describe("nodeIdForSpecies", () => {
+  const butterfly = { class_name: "insecta", order_name: "lepidoptera", family: "nymphalidae" };
 
-  it("drills an insect down to its family — Insects itself is over the load cap", () => {
-    expect(neNodeIdForSpecies("butterflies_and_moths", insect))
+  it("drills to the species' family", () => {
+    expect(nodeIdForSpecies("butterflies_and_moths", butterfly))
       .toBe("inv-insects~order:lepidoptera~family:nymphalidae");
+    expect(nodeIdForSpecies("mammals", { class_name: "mammalia", order_name: "carnivora", family: "felidae" }))
+      .toBe("mammals~order:carnivora~family:felidae");
   });
 
-  it("keeps the group's own node when that node is small enough to load", () => {
-    expect(neNodeIdForSpecies("velvet_worms", { class_name: "udeonychophora", order_name: "euonychophora", family: "peripatidae" }))
+  it("starts at class for a class-first root, skipping no rank", () => {
+    expect(nodeIdForSpecies("molluscs", { class_name: "gastropoda", order_name: "littorinimorpha", family: "cypraeidae" }))
+      .toBe("inv-molluscs~class:gastropoda~order:littorinimorpha~family:cypraeidae");
+  });
+
+  it("stops above a gap rather than showing an Unclassified rung", () => {
+    // Velvet worms have no order in CoL; drilling to the family anyway would read
+    // "Velvet Worms → Unclassified Order → Peripatidae".
+    expect(nodeIdForSpecies("velvet_worms", { class_name: null, order_name: null, family: "peripatidae" }))
       .toBe("inv-velvet_worms");
-    expect(neNodeIdForSpecies("mammals", { class_name: "mammalia", order_name: "primates", family: "aotidae" }))
-      .toBe("mammals");
+    // A bivalve keeps the class it does have, and stops before the missing order.
+    expect(nodeIdForSpecies("molluscs", { class_name: "bivalvia", order_name: null, family: "astartidae" }))
+      .toBe("inv-molluscs~class:bivalvia");
+  });
+
+  it("accepts an Unclassified rung when the group's own node can't list the species", () => {
+    // Insects is over NE_CAP, so stopping short would land on the drill-down prompt —
+    // a gap is worth wearing to reach a node that can actually show the species.
+    expect(nodeIdForSpecies("beetles", { class_name: "insecta", order_name: null, family: "coccinellidae" }))
+      .toBe("inv-insects~order:~family:coccinellidae");
+  });
+
+  it("falls back to the group's own node when the species has no lineage at all", () => {
+    expect(nodeIdForSpecies("beetles", {})).toBe("inv-insects");
+    expect(nodeIdForSpecies("velvet_worms", {})).toBe("inv-velvet_worms");
   });
 
   it("never routes to a Specialist Group node — they hold a curated subset, not the group", () => {
@@ -158,24 +179,13 @@ describe("neNodeIdForSpecies", () => {
       ["dragonflies_and_damselflies", { class_name: "insecta", order_name: "odonata", family: "aeshnidae" }],
       ["reptiles", { class_name: "reptilia", order_name: "squamata", family: "dactyloidae" }],
     ] as const) {
-      const id = neNodeIdForSpecies(group, lineage);
+      const id = nodeIdForSpecies(group, lineage);
       expect(id).not.toBeNull();
       expect(id!.startsWith("ssc-")).toBe(false); // "ssc-" is the id convention for them
     }
   });
 
-  it("stops at the deepest rank it knows, coalescing a missing one above it", () => {
-    expect(neNodeIdForSpecies("beetles", { class_name: "insecta", order_name: "coleoptera", family: null }))
-      .toBe("inv-insects~order:coleoptera");
-    expect(neNodeIdForSpecies("beetles", { class_name: "insecta", order_name: null, family: "coccinellidae" }))
-      .toBe("inv-insects~order:~family:coccinellidae");
-  });
-
-  it("falls back to the group's own node when the species has no lineage at all", () => {
-    expect(neNodeIdForSpecies("beetles", {})).toBe("inv-insects");
-  });
-
   it("returns null for a group no taxonomy node covers", () => {
-    expect(neNodeIdForSpecies("not_a_real_group", insect)).toBeNull();
+    expect(nodeIdForSpecies("not_a_real_group", butterfly)).toBeNull();
   });
 });

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -15,7 +15,7 @@ import { DuckDBInstance, type DuckDBConnection } from "@duckdb/node-api";
 import { NODE_INDEX, getCsvGroupsForNode, getAncestors, stripNodePrefix } from "@/lib/taxonomy-utils";
 import { canonicalizeTaxonId, mapTaxonId } from "@/lib/data/taxonomy-constants";
 import { getTaxaSummary } from "@/lib/data/species-store";
-import { isDynamicNodeId, dynamicNodeFilter, buildDynamicNodeId, rankOrderFor, type DynamicSegment } from "@/lib/dynamic-taxon";
+import { isDynamicNodeId, dynamicNodeFilter, buildDynamicNodeId, rankOrderFor, isLiveDrilldownNode, type DynamicSegment } from "@/lib/dynamic-taxon";
 import { filterToSql, sqlStrList } from "@/lib/taxonomy-sql";
 import { COL_DOMESTIC_EXCLUDE_NAMES } from "@/config/col-described-overrides";
 
@@ -221,8 +221,8 @@ const NOT_DOMESTIC_SQL = `coalesce(lower(scientific_name), '') NOT IN (${sqlStrL
 // Cap on how many Not-Evaluated species one query may return. A giant aggregate
 // (insects ~935k, invertebrates ~1.3M) can't be serialized in one response (it 500s /
 // times out), so a taxon over the cap returns no rows with tooLarge=true and the UI
-// prompts a drill-down instead. Also read by neNodeIdForSpecies, which uses it to pick
-// a node a search result can actually be shown in.
+// prompts a drill-down instead. Also read by nodeIdForSpecies, which uses it to decide
+// whether a group's own node can list a search result at all.
 const NE_CAP = 400_000;
 
 // Per-taxon_group not-evaluated counts from the precomputed taxa-summary (in memory),
@@ -394,8 +394,8 @@ export interface SearchResult {
   order_name: string | null;
   family: string | null;
   // The taxonomy node this species should be browsed in — the sub-group the dashboard
-  // selects alongside taxon_id (see neNodeIdForSpecies). Only set for NE results, which
-  // are the ones whose view has to load a single node's not-evaluated list.
+  // selects alongside taxon_id, so the view opens on the species' own lineage rather than
+  // the whole top-level taxon. See nodeIdForSpecies.
   node_id: string | null;
   // Set when the result was matched via a synonym (the old name the user typed) rather than
   // its accepted name — the dropdown shows "(syn. <name>)". scientific_name is the accepted name.
@@ -404,38 +404,54 @@ export interface SearchResult {
 
 interface Lineage { class_name?: string | null; order_name?: string | null; family?: string | null }
 
-// The node an NE search result should open in. Its view (new-assessments) loads exactly
-// one node's not-evaluated list, and mapTaxonId's top-level taxon (invertebrates, ~1.3M NE)
-// is far over NE_CAP — so picking it means the species is never shown, just the "too many
-// to load at once" drill-down prompt (#453).
+// The node a search result should open in — the deepest one the species demonstrably
+// belongs to, down to its family. Selecting that instead of the bare top-level taxon is
+// what puts the species' whole lineage on screen (Invertebrates → Insects → Lepidoptera →
+// Nymphalidae), since the taxa table renders the ancestor chain of whatever is selected.
 //
-// findViewLeafForGroup gives the group's own "By Taxon" container node, which is loadable
-// for most groups (Arachnids, Velvet Worms, Mammals…). For the eight insect groups it is
-// the whole Insects aggregate (~935k NE) — their static per-order nodes were retired in
-// favour of live drilldown — so when the container is over the cap, drill down to the
-// species' own family via a dynamic node id (e.g. inv-insects~order:lepidoptera~family:
-// nymphalidae). That is both small enough to load and a real tree position, so the
-// ancestor-breadcrumb rows and per-taxon stat card resolve exactly as they do when the
-// user drills there by hand. Every rank above the deepest known one must be present in
-// the id (dynamicNodeAncestors/nextDynamicRank read depth positionally) — a null one
-// becomes "", the same Unclassified-bucket convention resolveTaxonSuggestionNode uses.
-export function neNodeIdForSpecies(taxonGroup: string, lineage: Lineage): string | null {
+// findViewLeafForGroup gives the group's own "By Taxon" container node (Arachnids, Velvet
+// Worms, Mammals…), never a Specialist Group; below that, a dynamic drilldown id names the
+// class/order/family the species sits in. Every rank above the deepest segment has to be
+// present in the id — dynamicNodeAncestors/nextDynamicRank read depth positionally — so a
+// gap in the lineage forces a choice, and the two cases want opposite answers:
+//
+//   • Optional depth (the group's own node is loadable). Stop at the last CONTIGUOUS known
+//     rank. A velvet worm has no order in CoL, so drilling to its family would render
+//     "Velvet Worms → Unclassified Order → Peripatidae" — a worse landing spot than the
+//     Velvet Worms node it would otherwise get. Better to show less than to show a hole.
+//   • Required depth (the group's own node is over NE_CAP — Insects, ~935k NE — so the
+//     view can only offer the "too many to load at once" prompt there, #453). Then a gap
+//     is worth wearing: fill it with "", the same Unclassified-bucket convention
+//     resolveTaxonSuggestionNode uses, and reach a node that can actually list the species.
+//
+// genus is never enumerated: the species itself is the target, so a genus node buys nothing
+// over its family while being one more level to climb out of — and querySpecies can't filter
+// by genus outside a dynamic id anyway (see resolveWhere's arbitrary-rank branch).
+export function nodeIdForSpecies(taxonGroup: string, lineage: Lineage): string | null {
   const leafRoot = findViewLeafForGroup(taxonGroup);
   if (!leafRoot) return null;
-  const rootNe = getCsvGroupsForNode(leafRoot).reduce((sum, g) => sum + (neByGroup().get(g) ?? 0), 0);
-  if (rootNe <= NE_CAP) return leafRoot;
+  // A root with no live drilldown has no dynamic ids to offer — its own node is the answer.
+  if (!isLiveDrilldownNode(leafRoot)) return leafRoot;
+
   const valueFor: Partial<Record<DynamicSegment["rank"], string | null | undefined>> = {
     class: lineage.class_name, order: lineage.order_name, family: lineage.family,
   };
-  // genus is never enumerated here: the species itself is the target, and a genus node
-  // buys nothing over its family while being one more level the user has to climb out of.
   const ranks = rankOrderFor(leafRoot).filter((r) => r !== "genus");
-  let deepest = -1;
-  ranks.forEach((r, i) => { if (valueFor[r]) deepest = i; });
-  if (deepest === -1) return leafRoot; // no lineage at all — nothing more precise to offer
-  return buildDynamicNodeId(leafRoot, ranks.slice(0, deepest + 1).map((rank) => ({
+  const idFor = (depth: number) => buildDynamicNodeId(leafRoot, ranks.slice(0, depth).map((rank) => ({
     rank, value: (valueFor[rank] ?? "").toLowerCase(),
   })));
+
+  let contiguous = 0;
+  while (contiguous < ranks.length && valueFor[ranks[contiguous]]) contiguous++;
+  if (contiguous > 0) return idFor(contiguous);
+
+  // Nothing known from the top rank down. Fall back to the group's own node unless it's
+  // unlistable, in which case take the deepest known rank with the gaps coalesced.
+  const rootNe = getCsvGroupsForNode(leafRoot).reduce((sum, g) => sum + (neByGroup().get(g) ?? 0), 0);
+  if (rootNe <= NE_CAP) return leafRoot;
+  let deepest = -1;
+  ranks.forEach((r, i) => { if (valueFor[r]) deepest = i; });
+  return deepest === -1 ? leafRoot : idFor(deepest + 1);
 }
 
 // Stable negative int id for a CoL-only species (no IUCN sis id / GBIF key). Used as the
@@ -478,9 +494,8 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
     const tg = String(r.taxon_group);
     const cat = String(r.category ?? "");
     const lineage = { class_name: str(r.class_name), order_name: str(r.order_name), family: str(r.family) };
-    // Both views browse via the top-level taxon; an NE result additionally carries the
-    // sub-group node its (new-assessments) view has to load — see neNodeIdForSpecies.
-    // Assessed results go to reassessments, which is assessed-only and always loadable.
+    // Both views browse via the top-level taxon, plus the sub-group node the species
+    // itself sits in — see nodeIdForSpecies.
     return {
       id: Number(r.id),
       scientific_name: String(r.scientific_name ?? ""),
@@ -494,7 +509,7 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
       assessment_date: (r.assessment_date as string) ?? null,
       countries: splitList(r.countries),
       ...lineage,
-      node_id: cat === "NE" ? neNodeIdForSpecies(tg, lineage) : null,
+      node_id: nodeIdForSpecies(tg, lineage),
     };
   });
   // Return as soon as the direct search (assessed ∪ unassessed, ~16MB) finds anything.
@@ -539,7 +554,7 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
       assessment_date: null,
       countries: [],
       ...lineage,
-      node_id: neNodeIdForSpecies(tg, lineage),
+      node_id: nodeIdForSpecies(tg, lineage),
     });
     if (fast.length >= lim) break;
   }
@@ -593,7 +608,7 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
         class_name: null,
         order_name: null,
         family: null,
-        node_id: cat === "NE" ? neNodeIdForSpecies(tg, {}) : null,
+        node_id: nodeIdForSpecies(tg, {}),
         matched_synonym: String(r.synonym_name ?? ""),
       };
       fast.push(result);
@@ -619,7 +634,7 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
         result.class_name = str(row.class_name);
         result.order_name = str(row.order_name);
         result.family = str(row.family);
-        result.node_id = neNodeIdForSpecies(result.taxon_group, result);
+        result.node_id = nodeIdForSpecies(result.taxon_group, result);
       }
     }
   } catch { /* synonym index not in this sync prefix — skip */ }


### PR DESCRIPTION
Follow-up to #459. Generalises the lineage landing that fix introduced for insects only.

## What changes

Selecting a species from search dropped you at the bare top-level taxon — `?taxa=mammals`. The taxa table renders the **ancestor chain of whatever is selected**, so selecting the species' *family* instead puts its whole lineage on screen. #459 got this for insects as a side effect of routing around the not-evaluated load cap; this makes it the rule for every search result, assessed included.

| Before — `Panthera leo` | After |
|---|---|
| <img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-465-search-family-lineage/01-before-lion-bare-mammals.png" width="100%"> | <img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-465-search-family-lineage/02-after-lion-felidae.png" width="100%"> |
| All Species → Mammals | All Species → Mammals → Carnivora (Carnivores) → Felidae (Cats) |

## The gap rule

Every rank above the deepest segment has to be present in a dynamic node id (`dynamicNodeAncestors`/`nextDynamicRank` read depth positionally), so a hole in the lineage forces a choice — and the two cases want opposite answers, so they're split:

- **Optional depth** (the group's own node is loadable) → stop at the last **contiguous** known rank. Velvet worms have no `order_name` in CoL at all, so drilling to their family would render *Velvet Worms → **Unclassified Order** → Peripatidae*; they keep landing on Velvet Worms. A bivalve with no order stops at [Molluscs → Bivalvia](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-465-search-family-lineage/03-after-bivalve-stops-at-class.png). Better to show less than to show a hole.
- **Required depth** (the group's own node is over `NE_CAP` — Insects, ~935k NE) → unchanged from #459: fill the gap with `""` and reach a node that can actually list the species, because stopping short means the "too many to load at once" prompt and *no* species at all.

Genus is still never used: `querySpecies` can't filter by it outside a dynamic id, and the median family is only 7 assessed species already — a genus node would be 1–3, so the charts stop saying anything.

## Coverage that motivated the rule

Measured on sync `2026-08-02` — `family` is fully populated on the assessed side, and the holes on the NE side are at `order`, not `family`:

| | missing `family` | missing `order` |
|---|---|---|
| assessed | **0%**, every group | 0% |
| NE (GBIF-observed) | 3.0% overall (worst: beetles 10.9%) | molluscs 35.9%, other-inverts 20.7%, crustaceans 19.2%, **velvet worms 100%** |

## One correction worth flagging

I'd earlier framed this as also a payload win on both sides. It isn't: reassessments **prefetches `?taxon=all` on mount**, so the whole assessed dataset comes down regardless of what's selected — scoping an assessed search narrower changes context only. The not-evaluated side genuinely does fetch per node, so it gets both context and payload.

The cost, stated plainly: clearing the search filter now leaves you in Felidae (45 described) rather than Mammals (6,854). The breadcrumb rows above the table are the way back up. If that trade isn't wanted for assessed species, restricting this to NE is a one-condition change at the `node_id` assignment in `searchSpecies`.

## Test plan

`npm test` (839 pass), `npx tsc --noEmit`, `npm run lint` all clean. The 6 node-resolution unit tests from #459 are updated and extended to 7, now covering: family drilldown on both sides, class-first roots, stopping above a gap (velvet worm + bivalve), accepting an `""` rung only when required, no lineage at all, never an `ssc-` node, unknown group.

Browser-verified on the 2026-08-02 sync:

| Search | Lands on | Lineage shown |
|---|---|---|
| `Panthera leo` (assessed) | `taxa=mammals~order:carnivora~family:felidae` | Mammals → Carnivora → Felidae |
| `Vanda coerulea` (NE plant) | `pl-flowering_plants~order:asparagales~family:orchidaceae` | Plants → Flowering Plants → Asparagales → [Orchidaceae](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-465-search-family-lineage/04-after-orchid-orchidaceae.png) |
| `Pararge aegeria` (NE insect) | unchanged from #459 | Invertebrates → Insects → Lepidoptera → Nymphalidae |
| `Astarte antarctica` (NE, no order) | `inv-molluscs~class:bivalvia` | Molluscs → Bivalvia — no Unclassified rung |
| `Peripatus bavayi` (NE, no order/class) | `taxa=velvet_worms` — unchanged | Invertebrates → Velvet Worms |

All five render the species card and a 1-species table; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
