### PR TITLE
Hide the Encyclopedia of Life tab

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -234,7 +234,7 @@ export default function RedListPage() {
           >
             Species+
           </a>
-          ,{" "}
+          , and{" "}
           <a
             href="https://www.catalogueoflife.org"
             target="_blank"
@@ -242,15 +242,6 @@ export default function RedListPage() {
             className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
           >
             Catalogue of Life
-          </a>
-          , and{" "}
-          <a
-            href="https://eol.org"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline hover:text-zinc-600 dark:hover:text-zinc-300"
-          >
-            Encyclopedia of Life
           </a>
           {" "}data. This is a free, non-commercial research tool; commercial users should obtain IUCN Red List data via{" "}
           <a

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -31,6 +31,20 @@ import { getLastSearchResult, clearLastSearchResult, type SearchResult } from ".
 // Species list is served by the DuckDB/Parquet-backed /api/redlist/species route.
 const SPECIES_API = "/api/redlist/species";
 
+type DetailTab = "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol";
+
+// Encyclopedia of Life tab is hidden for now. The tab, its panel and the
+// /api/eol routes are all still here — flip this back to true to bring it back.
+const SHOW_EOL_TAB = false;
+
+// A ?tab=eol link (or a stale one) shouldn't strand the user on a tab with no
+// button in the bar, so fall back to the default tab while EoL is hidden.
+function visibleTab(tab: DetailTab | null | undefined): DetailTab {
+  if (!tab) return "gbif";
+  if (tab === "eol" && !SHOW_EOL_TAB) return "gbif";
+  return tab;
+}
+
 // Dynamically import OccurrenceMapRow to avoid SSR issues with Leaflet
 const OccurrenceMapRow = dynamic(
   () => import("../OccurrenceMapRow"),
@@ -1381,9 +1395,9 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
 
   // Row expansion state (initialized from URL params if present)
   const [selectedSpeciesKey, setSelectedSpeciesKeyRaw] = useState<number | null>(urlSpecies != null && isNewAssessments ? Math.abs(urlSpecies) : urlSpecies);
-  const [activeDetailTab, setActiveDetailTabRaw] = useState<"gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol">(urlTab ?? "gbif");
+  const [activeDetailTab, setActiveDetailTabRaw] = useState<DetailTab>(visibleTab(urlTab));
   // Track which tabs have been visited so we only mount (and fetch data for) a tab on first click
-  const [visitedTabs, setVisitedTabs] = useState<Set<string>>(new Set([urlTab ?? "gbif"]));
+  const [visitedTabs, setVisitedTabs] = useState<Set<string>>(new Set([visibleTab(urlTab)]));
   const urlSpeciesHandledRef = useRef(false);
   // Track whether a tab change was initiated programmatically (click) vs URL navigation (popstate)
   const programmaticTabChangeRef = useRef(false);
@@ -1406,7 +1420,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     }
   }, [setSpeciesParam]);
 
-  const setActiveDetailTab = useCallback((tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol", isManual = true) => {
+  const setActiveDetailTab = useCallback((tab: DetailTab, isManual = true) => {
     setActiveDetailTabRaw(tab);
     programmaticTabChangeRef.current = true;
     if (isManual) manualTabSelectionRef.current = true;
@@ -1437,10 +1451,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
         return;
       }
       setSelectedSpeciesKeyRaw(isNewAssessments ? Math.abs(urlSpecies) : urlSpecies);
-      setActiveDetailTabRaw(urlTab ?? "gbif");
-      setVisitedTabs(new Set([urlTab ?? "gbif"]));
+      setActiveDetailTabRaw(visibleTab(urlTab));
+      setVisitedTabs(new Set([visibleTab(urlTab)]));
       // A tab pinned in the URL counts as an explicit choice, so don't auto-switch.
-      manualTabSelectionRef.current = urlTab != null && urlTab !== "gbif";
+      manualTabSelectionRef.current = visibleTab(urlTab) !== "gbif";
       autoColSwitchedRef.current = false;
       urlSpeciesHandledRef.current = false; // allow auto-page-navigate for new species
     }
@@ -5270,12 +5284,14 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                                 >
                                   Catalogue of Life
                                 </button>
-                                <button
-                                  className={`shrink-0 px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "eol" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
-                                  onClick={() => setActiveDetailTab("eol")}
-                                >
-                                  Encyclopedia of Life
-                                </button>
+                                {SHOW_EOL_TAB && (
+                                  <button
+                                    className={`shrink-0 px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "eol" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
+                                    onClick={() => setActiveDetailTab("eol")}
+                                  >
+                                    Encyclopedia of Life
+                                  </button>
+                                )}
                                 <button
                                   className={`shrink-0 px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "wikipedia" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
                                   onClick={() => setActiveDetailTab("wikipedia")}
@@ -5382,7 +5398,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                             </div>
                             );
                           })()}
-                          {(visitedTabs.has("eol")) && (
+                          {SHOW_EOL_TAB && (visitedTabs.has("eol")) && (
                             <div style={{ display: activeDetailTab === "eol" ? undefined : "none" }}>
                               <EolSummary scientificName={s.scientific_name} />
                             </div>


### PR DESCRIPTION
## Summary

Hides the **Encyclopedia of Life** tab from the species detail panel.

The tab, its `EolSummary` panel and the `/api/eol/*` routes all stay in the tree behind a `SHOW_EOL_TAB` flag in `RedListView.tsx` — flipping it back to `true` restores the tab, so nothing has to be rebuilt if we want it again.

Two follow-on details that come with hiding it:

- **`?tab=eol` deep links no longer strand the user.** A link shared or bookmarked while the tab was visible would otherwise open the panel on a tab that has no button in the bar. A small `visibleTab()` helper maps `eol` back to the default GBIF tab while the flag is off, applied both on first render and on `popstate` (back/forward) navigation.
- **EoL comes off the footer's data-source list.** With the tab hidden, no EoL data is shown anywhere in the app, so crediting it as a source would be inaccurate. The footer now reads `… CITES, Species+, and Catalogue of Life data.`

Also folds the tab union type (repeated in three places) into a single `DetailTab` alias — no behaviour change.

## Screenshots

**Assessed species — tab bar, no Encyclopedia of Life**

![Assessed species tab bar](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-472-hide-eol-tab/01-tabs.png)

**Not-evaluated species — same, with its own Suggested Assessors/Reviewers tabs**

![NE species tab bar](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-472-hide-eol-tab/02-ne-tabs.png)

**Footer data-source line**

![Footer](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-472-hide-eol-tab/03-footer.png)

## Test plan

Browser drive-through against a local dev server (Playwright, Chromium), reading the live tab bar out of the DOM:

- `/?taxa=all&species=244&tab=gbif` (assessed, *Acipenser baerii*) → tabs are `GBIF, Literature, IUCN Red List, CITES, Catalogue of Life, Wikipedia`; no EoL tab. ✅
- `/?taxa=all&species=244&tab=eol` (stale deep link) → same tab set, **GBIF** is the active tab rather than a blank panel. ✅
- `/?taxa=mammals&view=new-assessments`, first species expanded → tabs are `GBIF, Literature, CITES, Catalogue of Life, Wikipedia, Suggested Assessors, Suggested Reviewers`; no EoL tab. ✅
- Footer text read back from the page: `… OpenAlex, CITES, Species+, and Catalogue of Life data.` ✅
- No console errors beyond the headless-Chromium WebGL warning maplibre always emits (the occurrence map can't get a GL context in headless, which is why the map pane is blank in the screenshots).

`npx tsc --noEmit` clean, `eslint` clean, `vitest run` — 843 tests across 48 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
