### PR TITLE
Key species rows on one namespaced id instead of a signed hash

### DIFF
--- a/app/src/app/browse/__tests__/browse.test.ts
+++ b/app/src/app/browse/__tests__/browse.test.ts
@@ -21,7 +21,7 @@ const json = (qs: string) => GET(req(qs)).then((r) => r.json());
 // A minimal querySpecies row (the fields /browse reads).
 function row(over: Record<string, unknown> = {}) {
   return {
-    id: Math.floor(Math.random() * 1e9), scientific_name: "Acropora sp.", common_name: null,
+    species_key: `sis-${Math.floor(Math.random() * 1e9)}`, scientific_name: "Acropora sp.", common_name: null,
     category: "EN", countries: ["AU"], systems: [], population_trend: null, movement_pattern: null,
     threat_codes: ["11.1"], growth_forms: [], gbif_occurrence_count: 5,
     assessment_date: "2020-01-01", taxon_group: "corals", class_name: "anthozoa",
@@ -105,20 +105,20 @@ describe("/browse", () => {
 
   it("expands an IUCN region to its countries (country filter)", async () => {
     const euCode = iucnRegionCountries("Europe")[0];
-    querySpecies.mockResolvedValue({ species: [row({ id: 1, countries: [euCode] }), row({ id: 2, countries: ["ZZ"] })], truncated: false, tooLarge: false, neTotal: null });
+    querySpecies.mockResolvedValue({ species: [row({ species_key: "sis-1", countries: [euCode] }), row({ species_key: "sis-2", countries: ["ZZ"] })], truncated: false, tooLarge: false, neTotal: null });
     const d = await json("?taxa=corals&region=Europe&format=json");
     expect(d.total).toBe(1);
     expect(d.species[0].countries).toEqual([euCode]);
   });
 
   it("filters by assessor name (substring)", async () => {
-    querySpecies.mockResolvedValue({ species: [row({ id: 1, latest_assessors: "Smith, J.A." }), row({ id: 2, latest_assessors: "Jones, B." })], truncated: false, tooLarge: false, neTotal: null });
+    querySpecies.mockResolvedValue({ species: [row({ species_key: "sis-1", latest_assessors: "Smith, J.A." }), row({ species_key: "sis-2", latest_assessors: "Jones, B." })], truncated: false, tooLarge: false, neTotal: null });
     expect((await json("?taxa=corals&assessors=smith&format=json")).total).toBe(1);
     expect((await json("?taxa=corals&assessors=nobody&format=json")).total).toBe(0);
   });
 
   it("filters by described-year bounds", async () => {
-    querySpecies.mockResolvedValue({ species: [row({ id: 1, described_year: 1850 }), row({ id: 2, described_year: 2010 })], truncated: false, tooLarge: false, neTotal: null });
+    querySpecies.mockResolvedValue({ species: [row({ species_key: "sis-1", described_year: 1850 }), row({ species_key: "sis-2", described_year: 2010 })], truncated: false, tooLarge: false, neTotal: null });
     const d = await json("?taxa=corals&minDescribedYear=1900&format=json");
     expect(d.total).toBe(1);
   });

--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -7,7 +7,15 @@ import { findNode, getViewRootForNode } from "../lib/taxonomy-utils";
 import { ALL_HABITAT_SEASONS, ALL_HABITAT_IMPORTANCE, ALL_HABITAT_SUITABILITY } from "../lib/habitat-filter";
 
 export interface SearchResult {
-  id: number;
+  /**
+   * The row this result selects in the species table — `sis-<sis_taxon_id>` for an
+   * assessed species, `col-<col_id>` for a Not Evaluated one (see lib/species-row-key).
+   * Null for a GBIF species with no CoL link: it has no row in any list, so selecting
+   * it navigates by name only, with no detail panel opened.
+   */
+  species_key: string | null;
+  sis_taxon_id: number | null;
+  col_id: string | null;
   scientific_name: string;
   common_name: string | null;
   taxon_id: string;
@@ -164,7 +172,7 @@ export function SpeciesSearchBar() {
         search: result.scientific_name,
         sortField: null,
         sortDirection: "desc",
-        species: result.id,
+        species: result.species_key,
         tab: "gbif",
       });
 
@@ -356,7 +364,7 @@ export function SpeciesSearchBar() {
               const i = taxaResults.length + ri;
               return (
               <button
-                key={`${result.id}-${result.taxon_group}`}
+                key={`${result.species_key ?? result.scientific_name}-${result.taxon_group}`}
                 onClick={() => selectResult(result)}
                 onMouseEnter={() => setHighlightIndex(i)}
                 className={`w-full text-left px-3 py-2 text-sm flex items-center gap-2 ${

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -27,6 +27,7 @@ import { isOutdated, outdatedCutoffDate } from "@/lib/outdated";
 import AssessorCandidatesTable from "../AssessorCandidatesTable";
 import ReviewerCandidatesTable from "../ReviewerCandidatesTable";
 import { getLastSearchResult, clearLastSearchResult, type SearchResult } from "../SpeciesSearchBar";
+import { migratePinnedSpecies } from "@/lib/species-row-key";
 
 // Species list is served by the DuckDB/Parquet-backed /api/redlist/species route.
 const SPECIES_API = "/api/redlist/species";
@@ -403,10 +404,15 @@ interface SpeciesDetails {
 // assessment-only fields (trend, criteria, threats, assessors, …) left empty — the same
 // shape and the same absent-field handling as a Not-Evaluated row from the species list.
 // Lets the searched species be rendered before (or without) the taxon's own list.
-function previewFromSearchResult(r: SearchResult): RedListSpecies {
+// Null for a search hit the table can't address — a GBIF species with no CoL link,
+// which is in no node's NE list to be previewed into. The search still navigates to
+// it by name; only the auto-opened detail panel is skipped.
+function previewFromSearchResult(r: SearchResult): RedListSpecies | null {
+  if (!r.species_key) return null;
   return {
-    id: r.id,
-    sis_taxon_id: r.id > 0 ? r.id : null,
+    species_key: r.species_key,
+    sis_taxon_id: r.sis_taxon_id,
+    col_id: r.col_id,
     assessment_id: r.assessment_id,
     scientific_name: r.scientific_name,
     common_name: r.common_name,
@@ -1385,7 +1391,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   [selectedHabitat, habitatBreadth, selectedHabitatImportance, selectedHabitatSeasons, selectedHabitatSuitability]);
 
   // Species details cache (images, criteria, common names)
-  const [speciesDetails, setSpeciesDetails] = useState<Record<number, SpeciesDetails>>({});
+  const [speciesDetails, setSpeciesDetails] = useState<Record<string, SpeciesDetails>>({});
   // Lazy assessment-history cache, keyed by sis_taxon_id. The species list no
   // longer carries the full history array; it's fetched when a detail row opens.
   const [assessmentHistory, setAssessmentHistory] = useState<Record<number, Species["previous_assessments"]>>({});
@@ -1394,7 +1400,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   const [synonymsBySpecies, setSynonymsBySpecies] = useState<Record<string, SynInfo>>({});
 
   // Row expansion state (initialized from URL params if present)
-  const [selectedSpeciesKey, setSelectedSpeciesKeyRaw] = useState<number | null>(urlSpecies != null && isNewAssessments ? Math.abs(urlSpecies) : urlSpecies);
+  const [selectedSpeciesKey, setSelectedSpeciesKeyRaw] = useState<string | null>(urlSpecies);
   const [activeDetailTab, setActiveDetailTabRaw] = useState<DetailTab>(visibleTab(urlTab));
   // Track which tabs have been visited so we only mount (and fetch data for) a tab on first click
   const [visitedTabs, setVisitedTabs] = useState<Set<string>>(new Set([visibleTab(urlTab)]));
@@ -1409,7 +1415,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   const autoColSwitchedRef = useRef(false);
 
   // Wrap setters to sync with URL
-  const setSelectedSpeciesKey = useCallback((key: number | null) => {
+  const setSelectedSpeciesKey = useCallback((key: string | null) => {
     setSelectedSpeciesKeyRaw(key);
     setSpeciesParam(key, key != null ? "gbif" : "gbif");
     if (key != null) {
@@ -1441,8 +1447,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     autoColSwitchedRef.current = true;
     setActiveDetailTab("col", false);
   }, [setActiveDetailTab]);
-  // Sync species/tab from URL params (fires on popstate, e.g. back/forward or search bar navigation)
-  // In new-assessments mode, row keys use Math.abs(id) so selectedSpeciesKey must match.
+  // Sync species/tab from URL params (fires on popstate, e.g. back/forward or search bar navigation).
+  // The param IS the row key (`sis-…`/`col-…`), so it needs no per-view translation.
   useEffect(() => {
     if (urlSpecies != null) {
       // Skip visitedTabs reset for programmatic (click) tab changes – only reset on URL navigation
@@ -1450,7 +1456,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
         programmaticTabChangeRef.current = false;
         return;
       }
-      setSelectedSpeciesKeyRaw(isNewAssessments ? Math.abs(urlSpecies) : urlSpecies);
+      setSelectedSpeciesKeyRaw(urlSpecies);
       setActiveDetailTabRaw(visibleTab(urlTab));
       setVisitedTabs(new Set([visibleTab(urlTab)]));
       // A tab pinned in the URL counts as an explicit choice, so don't auto-switch.
@@ -1458,7 +1464,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       autoColSwitchedRef.current = false;
       urlSpeciesHandledRef.current = false; // allow auto-page-navigate for new species
     }
-  }, [urlSpecies, urlTab, isNewAssessments]);
+  }, [urlSpecies, urlTab]);
 
   // Single-species fast path: use cached search result to render the detail panel
   // immediately without waiting for the bulk table to load.
@@ -1472,14 +1478,14 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
     const bulkTaxon = selectedTaxa.size === 1 ? [...selectedTaxa][0] : "all";
     const bulkUrl = speciesApiUrl(bulkTaxon, isNewAssessments ? "&category=NE" : "");
     const allSpecies = cache.entries[bulkUrl]?.species ?? [];
-    if (allSpecies.some(s => s.id === urlSpecies)) {
+    if (allSpecies.some(s => s.species_key === urlSpecies)) {
       setSingleSpeciesPreview(null);
       return;
     }
 
     // Use cached search result to construct preview (no API call needed)
     const cached = getLastSearchResult();
-    if (cached && cached.id === urlSpecies) {
+    if (cached && cached.species_key === urlSpecies) {
       clearLastSearchResult();
       setSingleSpeciesPreview(previewFromSearchResult(cached));
       urlSpeciesHandledRef.current = true;
@@ -1497,7 +1503,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       .then(r => (r.ok ? r.json() : null))
       .then((data: { results?: SearchResult[] } | null) => {
         if (cancelled || !data) return;
-        const hit = data.results?.find(r => r.id === urlSpecies);
+        const hit = data.results?.find(r => r.species_key === urlSpecies);
         if (!hit) return;
         setSingleSpeciesPreview(previewFromSearchResult(hit));
         urlSpeciesHandledRef.current = true;
@@ -1509,7 +1515,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // Clear preview once the species appears in bulk-loaded data
   useEffect(() => {
     if (!singleSpeciesPreview) return;
-    if (assessedSpecies.some(s => s.id === singleSpeciesPreview.id)) {
+    if (assessedSpecies.some(s => s.species_key === singleSpeciesPreview.species_key)) {
       setSingleSpeciesPreview(null);
     }
   }, [assessedSpecies, singleSpeciesPreview]);
@@ -1521,14 +1527,15 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // (a synonym mismatch — Pararge aegeria's id is held by the assessed Pararge xiphioides)
   // is filtered out of the not-evaluated universe as "already assessed", so search is the
   // only way to reach it and the list it lands in will never list it.
-  // Dedupe as paginatedSpecies does — by id, and for NE also by name, since a row loaded
-  // from the NE list is keyed on its CoL id while the search result is keyed on its GBIF one.
+  // Dedupe by row key alone. This used to need a name-equality fallback for NE species,
+  // because a row from the NE list was keyed on its CoL id while the same species from
+  // search was keyed on its GBIF one — two different keys for one species. Both sides
+  // resolve through species_link to the same `col-…` key now, so the keys match.
   const taxaFilteredSpecies = useMemo(() => {
     if (!singleSpeciesPreview) return taxaFilteredSpeciesNoPreview;
-    if (taxaFilteredSpeciesNoPreview.some(s =>
-      s.id === singleSpeciesPreview.id ||
-      (singleSpeciesPreview.category === "NE" && s.scientific_name === singleSpeciesPreview.scientific_name)
-    )) return taxaFilteredSpeciesNoPreview;
+    if (taxaFilteredSpeciesNoPreview.some(s => s.species_key === singleSpeciesPreview.species_key)) {
+      return taxaFilteredSpeciesNoPreview;
+    }
     return [singleSpeciesPreview, ...taxaFilteredSpeciesNoPreview];
   }, [taxaFilteredSpeciesNoPreview, singleSpeciesPreview]);
 
@@ -1536,12 +1543,12 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
 
 
   // Pinned species as ordered array (persisted to localStorage)
-  const [pinnedSpecies, setPinnedSpecies] = useState<number[]>([]);
+  const [pinnedSpecies, setPinnedSpecies] = useState<string[]>([]);
   const pinnedSet = useMemo(() => new Set(pinnedSpecies), [pinnedSpecies]); // For O(1) lookup
 
   // Drag state for reordering pinned species
-  const [draggedSpecies, setDraggedSpecies] = useState<number | null>(null);
-  const [dragOverSpecies, setDragOverSpecies] = useState<number | null>(null);
+  const [draggedSpecies, setDraggedSpecies] = useState<string | null>(null);
+  const [dragOverSpecies, setDragOverSpecies] = useState<string | null>(null);
 
   const pinnedStorageKey = isNewAssessments ? "new-assessments-pinned-species" : "redlist-pinned-species";
 
@@ -1553,14 +1560,16 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   useEffect(() => {
     try {
       const stored = localStorage.getItem(pinnedStorageKey);
-      setPinnedSpecies(stored ? JSON.parse(stored) : []);
+      // Pins were stored as numbers before the key was namespaced; migrate in place so
+      // existing pins survive (assessed ones exactly — see migratePinnedSpecies).
+      setPinnedSpecies(migratePinnedSpecies(stored ? JSON.parse(stored) : []));
     } catch {
       setPinnedSpecies([]);
     }
   }, [pinnedStorageKey]);
 
   // Save pinned species to localStorage
-  const savePinnedSpecies = (newPinned: number[]) => {
+  const savePinnedSpecies = (newPinned: string[]) => {
     setPinnedSpecies(newPinned);
     try {
       localStorage.setItem(pinnedStorageKey, JSON.stringify(newPinned));
@@ -1570,32 +1579,32 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   };
 
   // Toggle pin status
-  const togglePinned = (speciesId: number) => {
-    if (pinnedSet.has(speciesId)) {
-      savePinnedSpecies(pinnedSpecies.filter(id => id !== speciesId));
+  const togglePinned = (speciesKey: string) => {
+    if (pinnedSet.has(speciesKey)) {
+      savePinnedSpecies(pinnedSpecies.filter(k => k !== speciesKey));
     } else {
-      savePinnedSpecies([...pinnedSpecies, speciesId]);
+      savePinnedSpecies([...pinnedSpecies, speciesKey]);
     }
   };
 
   // Drag handlers for reordering
-  const handleDragStart = (e: React.DragEvent, speciesId: number) => {
-    if (!pinnedSet.has(speciesId)) return;
-    setDraggedSpecies(speciesId);
+  const handleDragStart = (e: React.DragEvent, speciesKey: string) => {
+    if (!pinnedSet.has(speciesKey)) return;
+    setDraggedSpecies(speciesKey);
     e.dataTransfer.effectAllowed = 'move';
   };
 
-  const handleDragOver = (e: React.DragEvent, speciesId: number) => {
+  const handleDragOver = (e: React.DragEvent, speciesKey: string) => {
     e.preventDefault();
-    if (!draggedSpecies || !pinnedSet.has(speciesId)) return;
-    setDragOverSpecies(speciesId);
+    if (!draggedSpecies || !pinnedSet.has(speciesKey)) return;
+    setDragOverSpecies(speciesKey);
   };
 
   const handleDragLeave = () => {
     setDragOverSpecies(null);
   };
 
-  const handleDrop = (e: React.DragEvent, targetId: number) => {
+  const handleDrop = (e: React.DragEvent, targetId: string) => {
     e.preventDefault();
     if (!draggedSpecies || draggedSpecies === targetId) {
       setDraggedSpecies(null);
@@ -2303,20 +2312,15 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
         s.common_name?.toLowerCase().includes(searchFilter);
       const matchesAssessor = matchesAssessorsFilter(s);
       const matchesReviewer = matchesReviewersFilter(s);
-      const pinnedKey = isNewAssessments ? Math.abs(s.id) : s.sis_taxon_id;
-      const matchesStarred = !showOnlyStarred || (pinnedKey != null && pinnedSet.has(pinnedKey));
+      const matchesStarred = !showOnlyStarred || pinnedSet.has(s.species_key);
       return matchesCategory && matchesYear && matchesDescribed && matchesObs && matchesAssessmentCount && matchesCountry && matchesSystem && matchesTrend && matchesMovement && matchesThreat && matchesCriteria && matchesHabitat && matchesEndemic && matchesGrowth && matchesSearch && matchesAssessor && matchesReviewer && matchesStarred;
     });
 
     const sorted = [...filtered].sort((a, b) => {
       if (showOnlyStarred) {
-        const aKey = isNewAssessments ? Math.abs(a.id) : a.sis_taxon_id;
-        const bKey = isNewAssessments ? Math.abs(b.id) : b.sis_taxon_id;
-        if (aKey != null && bKey != null) {
-          const aIdx = pinnedSpecies.indexOf(aKey);
-          const bIdx = pinnedSpecies.indexOf(bKey);
-          if (aIdx !== -1 && bIdx !== -1) return aIdx - bIdx;
-        }
+        const aIdx = pinnedSpecies.indexOf(a.species_key);
+        const bIdx = pinnedSpecies.indexOf(b.species_key);
+        if (aIdx !== -1 && bIdx !== -1) return aIdx - bIdx;
       }
 
       let comparison = 0;
@@ -2352,8 +2356,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       const gbifCmp = (b.gbif_occurrence_count ?? -1) - (a.gbif_occurrence_count ?? -1);
       if (gbifCmp !== 0) return gbifCmp;
 
-      // Tertiary tiebreaker: stable ID order
-      return (a.sis_taxon_id ?? a.id) - (b.sis_taxon_id ?? b.id);
+      // Tertiary tiebreaker: stable row-key order
+      return a.species_key.localeCompare(b.species_key);
     });
 
     return { filteredSpecies: filtered, sortedSpecies: sorted };
@@ -2400,13 +2404,11 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // Include single-species preview at the top of the page when bulk data hasn't loaded yet
   const paginatedSpecies = useMemo(() => {
     if (!singleSpeciesPreview) return paginatedSpeciesBase;
-    // De-dupe by id, and (for NE search results, whose cached-preview id differs from the
-    // loaded NE row's synthetic id) also by scientific name — so a searched CoL species
-    // shows the loaded row once the list arrives, not a duplicate alongside the preview.
-    if (paginatedSpeciesBase.some(s =>
-      s.id === singleSpeciesPreview.id ||
-      (singleSpeciesPreview.category === "NE" && s.scientific_name === singleSpeciesPreview.scientific_name)
-    )) return paginatedSpeciesBase;
+    // De-dupe by row key — a searched species and its loaded list row now carry the
+    // same one, so the preview collapses into the row instead of doubling it.
+    if (paginatedSpeciesBase.some(s => s.species_key === singleSpeciesPreview.species_key)) {
+      return paginatedSpeciesBase;
+    }
     return [singleSpeciesPreview, ...paginatedSpeciesBase];
   }, [paginatedSpeciesBase, singleSpeciesPreview]);
 
@@ -2463,10 +2465,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // Auto-navigate to the page containing the URL-selected species
   useEffect(() => {
     if (urlSpeciesHandledRef.current || selectedSpeciesKey == null || sortedSpecies.length === 0) return;
-    const idx = sortedSpecies.findIndex(s => {
-      const key = isNewAssessments ? Math.abs(s.id) : (s.sis_taxon_id ?? s.id);
-      return key === selectedSpeciesKey;
-    });
+    const idx = sortedSpecies.findIndex(s => s.species_key === selectedSpeciesKey);
     if (idx >= 0) {
       const page = Math.floor(idx / PAGE_SIZE) + 1;
       setCurrentPage(page);
@@ -2477,12 +2476,12 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // Populate basic speciesDetails from DB data (GBIF counts instant, no API calls)
   // inatDefaultImage / openAlexPaperCount / papersAtAssessment are left as undefined → spinner
   useEffect(() => {
-    const newDetails: Record<number, SpeciesDetails> = {};
+    const newDetails: Record<string, SpeciesDetails> = {};
     for (const s of paginatedSpecies) {
-      if (speciesDetails[s.id]) continue; // Already have details
+      if (speciesDetails[s.species_key]) continue; // Already have details
 
       if (s.gbif_species_key) {
-        newDetails[s.id] = {
+        newDetails[s.species_key] = {
           criteria: null,
           commonName: s.common_name || null,
           gbifUrl: `https://www.gbif.org/species/${s.gbif_species_key}`,
@@ -2492,7 +2491,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           inatDefaultImage: undefined, // Loading — fetched per-page below
         };
       } else {
-        newDetails[s.id] = {
+        newDetails[s.species_key] = {
           criteria: null,
           commonName: s.common_name || null,
           gbifUrl: null,
@@ -2513,7 +2512,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   useEffect(() => {
     const speciesToFetch = paginatedSpecies.filter(
       (s) => {
-        const d = speciesDetails[s.id];
+        const d = speciesDetails[s.species_key];
         // Fetch if we have basic details but inatDefaultImage is still undefined (not yet fetched)
         return d && d.inatDefaultImage === undefined;
       }
@@ -2571,18 +2570,18 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             };
           }
 
-          return { id: s.id, inatDefaultImage, gbifMatchStatus };
+          return { key: s.species_key, inatDefaultImage, gbifMatchStatus };
         } catch {
-          return { id: s.id, inatDefaultImage: null, gbifMatchStatus: null };
+          return { key: s.species_key, inatDefaultImage: null, gbifMatchStatus: null };
         }
       });
 
       const results = await Promise.all(promises);
       if (signal.aborted) return;
 
-      const updates: Record<number, Partial<SpeciesDetails>> = {};
+      const updates: Record<string, Partial<SpeciesDetails>> = {};
       for (const r of results) {
-        updates[r.id] = {
+        updates[r.key] = {
           inatDefaultImage: r.inatDefaultImage,
           gbifMatchFetched: true,
           ...(r.gbifMatchStatus ? { gbifMatchStatus: r.gbifMatchStatus } : {}),
@@ -2590,10 +2589,9 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       }
       setSpeciesDetails((prev) => {
         const next = { ...prev };
-        for (const [id, update] of Object.entries(updates)) {
-          const numId = Number(id);
-          if (next[numId]) {
-            next[numId] = { ...next[numId], ...update };
+        for (const [key, update] of Object.entries(updates)) {
+          if (next[key]) {
+            next[key] = { ...next[key], ...update };
           }
         }
         return next;
@@ -2607,9 +2605,9 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // Fetch IUCN criteria on row expansion (lightweight — no GBIF calls; the map handles those)
   useEffect(() => {
     if (!selectedSpeciesKey) return;
-    const s = paginatedSpecies.find((sp) => sp.id === selectedSpeciesKey);
+    const s = paginatedSpecies.find((sp) => sp.species_key === selectedSpeciesKey);
     if (!s || s.category === "NE") return;
-    const existing = speciesDetails[s.id];
+    const existing = speciesDetails[s.species_key];
     if (!existing || existing.criteriaFetched) return;
 
     async function fetchCriteria() {
@@ -2622,8 +2620,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           const data = await res.json();
           setSpeciesDetails((prev) => ({
             ...prev,
-            [s.id]: {
-              ...prev[s.id],
+            [s.species_key]: {
+              ...prev[s.species_key],
               criteria: data.criteria || null,
               criteriaFetched: true,
             },
@@ -2642,7 +2640,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // here on demand for the Red List Assessments tab).
   useEffect(() => {
     if (!selectedSpeciesKey) return;
-    const s = paginatedSpecies.find((sp) => sp.id === selectedSpeciesKey);
+    const s = paginatedSpecies.find((sp) => sp.species_key === selectedSpeciesKey);
     const sis = s?.sis_taxon_id;
     if (!s || s.category === "NE" || !sis || assessmentHistory[sis]) return;
     let aborted = false;
@@ -2661,13 +2659,12 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   }, [selectedSpeciesKey, paginatedSpecies, assessmentHistory]);
 
   // Lazily fetch CoL synonyms for the open species — only once the CoL tab is opened.
-  // Keyed by col_id (NE rows carry it) or sis_taxon_id (assessed, resolved server-side).
-  const synKey = useCallback((s: Species | undefined): string | null =>
-    s?.col_id ? `col:${s.col_id}` : (s?.sis_taxon_id != null ? `sis:${s.sis_taxon_id}` : null), []);
+  // Keyed by the row key, which already encodes which id the lookup uses (`col-…` →
+  // by CoL id, `sis-…` → resolved server-side through species_link).
   useEffect(() => {
     if (selectedSpeciesKey == null || !visitedTabs.has("col")) return;
-    const s = paginatedSpecies.find((sp) => (isNewAssessments ? Math.abs(sp.id) : sp.id) === selectedSpeciesKey);
-    const key = synKey(s);
+    const s = paginatedSpecies.find((sp) => sp.species_key === selectedSpeciesKey);
+    const key = s?.species_key ?? null;
     if (!s || !key || synonymsBySpecies[key]) return;
     const qs = s.col_id ? `col=${encodeURIComponent(s.col_id)}` : `sis=${s.sis_taxon_id}`;
     let aborted = false;
@@ -2678,7 +2675,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
       } catch { /* panel falls back to empty */ }
     })();
     return () => { aborted = true; };
-  }, [selectedSpeciesKey, visitedTabs, paginatedSpecies, isNewAssessments, synonymsBySpecies, synKey]);
+  }, [selectedSpeciesKey, visitedTabs, paginatedSpecies, synonymsBySpecies]);
 
   // Handle category bar click (Cmd/Ctrl+click for multi-select, regular click replaces)
   const handleCategoryClick = (data: { payload?: { code?: string } }, event: React.MouseEvent) => {
@@ -3819,7 +3816,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
           )}
           {/* Single species header */}
           {isSingleSpecies && singleSpecies && (() => {
-            const details = speciesDetails[singleSpecies.id];
+            const details = speciesDetails[singleSpecies.species_key];
             return (
               <div
                 className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl px-5 py-4 flex items-center gap-4"
@@ -5011,19 +5008,19 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             </thead>
             <tbody className="divide-y divide-zinc-200 dark:divide-zinc-800">
               {paginatedSpecies.map((s) => {
-                const speciesKey = isNewAssessments ? Math.abs(s.id) : (s.sis_taxon_id ?? s.id);
+                const speciesKey = s.species_key;
                 const assessmentDateObj = s.assessment_date ? new Date(s.assessment_date) : null;
                 const assessmentYear = assessmentDateObj ? assessmentDateObj.getFullYear() : null;
                 const yearsSinceAssessment = assessmentDateObj
                   ? Math.floor((Date.now() - assessmentDateObj.getTime()) / (365.25 * 24 * 60 * 60 * 1000))
                   : null;
-                const details = speciesDetails[s.id];
+                const details = speciesDetails[s.species_key];
                 const gbifSpeciesKey = s.gbif_species_key || details?.gbifUrl?.split('/').pop() || null;
                 const isPinned = pinnedSet.has(speciesKey);
                 const isDragging = draggedSpecies === speciesKey;
                 const isDragOver = dragOverSpecies === speciesKey && draggedSpecies !== speciesKey;
                 return (
-                  <React.Fragment key={s.id}>
+                  <React.Fragment key={speciesKey}>
                   <tr
                     className={`hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer ${selectedSpeciesKey === speciesKey ? "bg-zinc-100 dark:bg-zinc-800" : ""} ${isDragging ? "opacity-50" : ""} ${isDragOver ? "border-t-2 border-amber-500" : ""}`}
                     onClick={() => { setSelectedSpeciesKey(selectedSpeciesKey === speciesKey ? null : speciesKey); }}
@@ -5351,7 +5348,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                             </div>
                           )}
                           {(visitedTabs.has("col")) && (() => {
-                            const syn = synonymsBySpecies[synKey(s) ?? ""];
+                            const syn = synonymsBySpecies[s.species_key];
                             return (
                             <div style={{ display: activeDetailTab === "col" ? undefined : "none" }}>
                               {!syn ? (

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -18,6 +18,7 @@ import { TAXONOMY_VIEWS } from "@/config/taxonomy-views";
 import { IUCN_SOURCE_URL } from "@/config/taxonomy-tree";
 import { isLiveDrilldownNode, nextDynamicRank, isDynamicNodeId, dynamicNodeDisplayName, dynamicNodeFilter, dynamicNodeRankInfo, parseDynamicNodeId } from "@/lib/dynamic-taxon";
 import type { RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
+import { sisRowKey } from "@/lib/species-row-key";
 
 // See scripts/build-taxa-summary.ts's classifyNoMatch for what each reason means.
 // Modular/additive on top of colBreakdown[].noMatchIds — safe to drop independently
@@ -345,11 +346,11 @@ function nodeSpeciesListHref(
 // Builds a real URL (not a pushState-only path) for a single species' detail view —
 // used with target="_blank" so opening a species from the popover doesn't lose the
 // caller's place in the current tab.
-function speciesHref(nodeId: string, id: number, view: "reassessments" | "new-assessments"): string {
+function speciesHref(nodeId: string, speciesKey: string, view: "reassessments" | "new-assessments"): string {
   const params = new URLSearchParams();
   params.set("taxa", stripNodePrefix(nodeId));
   if (view === "new-assessments") params.set("view", "new-assessments");
-  params.set("species", String(id));
+  params.set("species", speciesKey);
   return `/?${params.toString()}`;
 }
 
@@ -664,10 +665,10 @@ function SpeciesListPanel({
                 const split = s.col_id != null ? splitByColId.get(s.col_id) : undefined;
                 const year = isNe ? s.described_year : (s.assessment_date ? s.assessment_date.slice(0, 4) : null);
                 return (
-                  <tr key={s.id} className="border-t border-zinc-700/60 align-top">
+                  <tr key={s.species_key} className="border-t border-zinc-700/60 align-top">
                     <td className="py-1 pr-2">
                       <a
-                        href={speciesHref(nodeId, s.id, isNe ? "new-assessments" : "reassessments")}
+                        href={speciesHref(nodeId, s.species_key, isNe ? "new-assessments" : "reassessments")}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-blue-300 hover:text-blue-200 underline"
@@ -692,7 +693,7 @@ function SpeciesListPanel({
                               <>
                                 {" "}
                                 <a
-                                  href={speciesHref(nodeId, detail.detailId, "reassessments")}
+                                  href={speciesHref(nodeId, sisRowKey(detail.detailId), "reassessments")}
                                   target="_blank"
                                   rel="noopener noreferrer"
                                   className="text-blue-300 hover:text-blue-200 underline"
@@ -710,7 +711,7 @@ function SpeciesListPanel({
                         >
                           {"Likely split from "}
                           <a
-                            href={speciesHref(nodeId, split.parentId, "reassessments")}
+                            href={speciesHref(nodeId, sisRowKey(split.parentId), "reassessments")}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-blue-300 hover:text-blue-200 underline"

--- a/app/src/hooks/__tests__/filterParams.test.ts
+++ b/app/src/hooks/__tests__/filterParams.test.ts
@@ -186,8 +186,8 @@ describe("parseParams", () => {
   });
 
   it("parses species param", () => {
-    const result = parseParams("?species=176168");
-    expect(result.species).toBe(176168);
+    const result = parseParams("?species=sis-176168");
+    expect(result.species).toBe("sis-176168");
   });
 
   it("defaults species to null when absent", () => {
@@ -196,7 +196,7 @@ describe("parseParams", () => {
   });
 
   it("parses tab param", () => {
-    const result = parseParams("?species=176168&tab=assessors");
+    const result = parseParams("?species=sis-176168&tab=assessors");
     expect(result.tab).toBe("assessors");
   });
 
@@ -266,7 +266,7 @@ describe("buildQs", () => {
     subgroups: new Set<string>(),
     sortField: null as "year" | "category" | "totalGbif" | "newGbif" | "pctNewGbif" | null,
     sortDirection: "desc" as const,
-    species: null as number | null,
+    species: null as string | null,
     tab: null as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | null,
   };
 
@@ -409,9 +409,11 @@ describe("buildQs", () => {
   });
 
   it("includes species when set", () => {
-    const qs = buildQs({ ...emptyState, species: 176168, tab: "gbif" });
+    const qs = buildQs({ ...emptyState, species: "sis-176168", tab: "gbif" });
     const params = new URLSearchParams(qs);
-    expect(params.get("species")).toBe("176168");
+    expect(params.get("species")).toBe("sis-176168");
+    // The namespace separator must survive URL encoding unmangled — see species-row-key.
+    expect(qs).toContain("species=sis-176168");
   });
 
   it("omits species when null", () => {
@@ -420,13 +422,13 @@ describe("buildQs", () => {
   });
 
   it("includes tab when species set and tab is non-default", () => {
-    const qs = buildQs({ ...emptyState, species: 176168, tab: "assessors" });
+    const qs = buildQs({ ...emptyState, species: "sis-176168", tab: "assessors" });
     const params = new URLSearchParams(qs);
     expect(params.get("tab")).toBe("assessors");
   });
 
   it("omits tab when it is gbif (default)", () => {
-    const qs = buildQs({ ...emptyState, species: 176168, tab: "gbif" });
+    const qs = buildQs({ ...emptyState, species: "sis-176168", tab: "gbif" });
     const params = new URLSearchParams(qs);
     expect(params.has("tab")).toBe(false);
   });
@@ -543,7 +545,7 @@ describe("parseParams ↔ buildQs round-trip", () => {
       search: "",
       sortField: null as "year" | "category" | "totalGbif" | "newGbif" | "pctNewGbif" | null,
       sortDirection: "desc" as const,
-      species: null as number | null,
+      species: null as string | null,
       tab: null as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | null,
     };
 
@@ -582,7 +584,7 @@ describe("parseParams ↔ buildQs round-trip", () => {
     search: "",
     sortField: null as "year" | "category" | "totalGbif" | "newGbif" | "pctNewGbif" | null,
     sortDirection: "desc" as const,
-    species: null as number | null,
+    species: null as string | null,
     tab: null as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | null,
   };
 
@@ -691,7 +693,7 @@ describe("parseParams ↔ buildQs round-trip", () => {
       search: "",
       sortField: null as "year" | "category" | "totalGbif" | "newGbif" | "pctNewGbif" | null,
       sortDirection: "desc" as const,
-      species: null as number | null,
+      species: null as string | null,
       tab: null as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | null,
     };
 
@@ -730,7 +732,7 @@ describe("parseParams ↔ buildQs round-trip", () => {
       search: "",
       sortField: null as "year" | "category" | "totalGbif" | "newGbif" | "pctNewGbif" | null,
       sortDirection: "desc" as const,
-      species: null as number | null,
+      species: null as string | null,
       tab: null as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | null,
     };
 
@@ -768,7 +770,7 @@ describe("parseParams ↔ buildQs round-trip", () => {
       search: "",
       sortField: "newGbif" as const,
       sortDirection: "desc" as const,
-      species: null as number | null,
+      species: null as string | null,
       tab: null as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | null,
     };
 
@@ -807,7 +809,7 @@ describe("param suffixing (compare mode)", () => {
     subgroups: new Set<string>(),
     sortField: null as "year" | "category" | "totalGbif" | "newGbif" | "pctNewGbif" | "describedYear" | null,
     sortDirection: "desc" as const,
-    species: null as number | null,
+    species: null as string | null,
     tab: null as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol" | null,
   };
 
@@ -944,7 +946,7 @@ describe("OWN_PARAM_NAMES stays in sync with buildQs", () => {
       mapViewMode: "list" as const,
       mapSortKey: "outdated" as const,
       mapSortDirection: "asc" as const,
-      species: 12345,
+      species: "sis-12345",
       tab: "literature" as const,
     };
 

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -5,6 +5,7 @@ import { canonicalizeTaxonId } from "@/lib/data/taxonomy-constants";
 import { resolveRegions } from "@/lib/regions";
 import { expandTaxaToken, collapseTaxaToTokens, getViewRootForNode, type FilterRank } from "@/lib/taxonomy-utils";
 import { ALL_HABITAT_SEASONS, ALL_HABITAT_IMPORTANCE, ALL_HABITAT_SUITABILITY } from "@/lib/habitat-filter";
+import { parseSpeciesParam } from "@/lib/species-row-key";
 
 // Both habitat checkbox-dropdowns (Importance, Season) default to "everything
 // checked" (nothing excluded) rather than "nothing checked" — see
@@ -260,7 +261,9 @@ export function parseParams(search: string, suffix: string = "") {
       "species"
     ) as MapSortKey,
     mapSortDirection: (p.get(k("mapdir")) === "asc" ? "asc" : "desc") as "asc" | "desc",
-    species: p.get(k("species")) ? Number(p.get(k("species"))) : null,
+    // The row key, namespaced (`sis-…`/`col-…`). parseSpeciesParam also accepts the
+    // pre-namespace bare-number form so existing links keep working — see its doc.
+    species: parseSpeciesParam(p.get(k("species"))),
     tab: (p.get(k("tab")) || null) as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol" | null,
   };
 }
@@ -306,7 +309,7 @@ export function buildQs(state: {
   mapViewMode?: MapViewMode;
   mapSortKey?: MapSortKey;
   mapSortDirection?: "asc" | "desc";
-  species: number | null;
+  species: string | null;
   tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol" | null;
 }, suffix: string = ""): string {
   const p = new URLSearchParams();
@@ -353,7 +356,7 @@ export function buildQs(state: {
   if (state.maxAssessmentYear != null) p.set(k("maxAssessmentYear"), String(state.maxAssessmentYear));
   if (state.minDescribedYear != null) p.set(k("minDescribedYear"), String(state.minDescribedYear));
   if (state.maxDescribedYear != null) p.set(k("maxDescribedYear"), String(state.maxDescribedYear));
-  if (state.species != null) p.set(k("species"), String(state.species));
+  if (state.species != null) p.set(k("species"), state.species);
   if (state.species != null && state.tab && state.tab !== "gbif") p.set(k("tab"), state.tab);
   // null / "year" desc is the default — only write non-default sort to URL
   const isDefaultSort = state.sortField === null || state.sortField === "year";
@@ -925,7 +928,7 @@ export function useFilterParams(paramSuffix: string = "") {
   );
 
   const setSpeciesParam = useCallback(
-    (species: number | null, tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol" = "gbif") => {
+    (species: string | null, tab: "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol" = "gbif") => {
       setState(prev => {
         const next = { ...prev, species, tab: species != null ? tab : null };
         queueMicrotask(() => syncUrl(next, true));

--- a/app/src/hooks/useRedListSpeciesQuery.ts
+++ b/app/src/hooks/useRedListSpeciesQuery.ts
@@ -3,7 +3,13 @@
 // canonical type definition imported across the app.)
 
 export interface RedListSpecies {
-  id: number;
+  /**
+   * This row's identity everywhere in the UI — selection, pinning, React keys,
+   * per-species caches, the `species=` URL param. `sis-<sis_taxon_id>` for an
+   * assessed species, `col-<col_id>` for a Not Evaluated one. See
+   * lib/species-row-key for why it's namespaced rather than a bare number.
+   */
+  species_key: string;
   sis_taxon_id: number | null;
   col_id?: string | null; // CoL id (on NE rows); used for the detail panel's synonyms/CoL tab
   assessment_id: number | null;

--- a/app/src/lib/__tests__/browse-query.test.ts
+++ b/app/src/lib/__tests__/browse-query.test.ts
@@ -11,7 +11,7 @@ import { runBrowseQuery } from "../browse-query";
 
 function row(over: Record<string, unknown> = {}) {
   return {
-    id: Math.floor(Math.random() * 1e9), scientific_name: "Acropora sp.", common_name: null,
+    species_key: `sis-${Math.floor(Math.random() * 1e9)}`, scientific_name: "Acropora sp.", common_name: null,
     category: "EN", countries: ["AU"], systems: [], population_trend: null, movement_pattern: null,
     threat_codes: ["11.4"], growth_forms: [], gbif_occurrence_count: 5,
     assessment_date: "2020-01-01", taxon_group: "corals", class_name: "anthozoa",
@@ -50,7 +50,7 @@ describe("runBrowseQuery", () => {
 
   it("looks up a species via searchSpecies (synonym-aware)", async () => {
     searchSpecies.mockResolvedValue([
-      { id: -1, scientific_name: "Acinonyx jubatus", common_name: "Cheetah", taxon_id: "mammals",
+      { species_key: "sis-219", sis_taxon_id: 219, col_id: null, scientific_name: "Acinonyx jubatus", common_name: "Cheetah", taxon_id: "mammals",
         taxon_group: "mammals", category: "VU", gbif_species_key: null, assessment_id: null,
         assessment_date: "2021-01-01", countries: ["NA"], matched_synonym: "Felis jubata" },
     ]);
@@ -63,7 +63,7 @@ describe("runBrowseQuery", () => {
   it("expands an IUCN region to its countries", async () => {
     const { iucnRegionCountries } = await import("@/lib/regions");
     const eu = iucnRegionCountries("Europe")[0];
-    querySpecies.mockResolvedValue({ species: [row({ id: 1, countries: [eu] }), row({ id: 2, countries: ["ZZ"] })], truncated: false, tooLarge: false, neTotal: null });
+    querySpecies.mockResolvedValue({ species: [row({ species_key: "sis-1", countries: [eu] }), row({ species_key: "sis-2", countries: ["ZZ"] })], truncated: false, tooLarge: false, neTotal: null });
     const r = await runBrowseQuery({ taxa: ["corals"], region: ["Europe"] });
     expect(r.total).toBe(1);
   });

--- a/app/src/lib/browse-query.ts
+++ b/app/src/lib/browse-query.ts
@@ -142,15 +142,15 @@ export async function runBrowseQuery(input: BrowseInput): Promise<BrowseResult> 
   if (taxa.ids.length) {
     const includeNE = criteria.categories?.has("NE") ?? false;
     const results = await Promise.all(taxa.ids.map((id) => querySpecies({ taxon: id, includeNE })));
-    const seen = new Set<number>();
+    const seen = new Set<string>();
     results.forEach((res, i) => {
       if (res.tooLarge) tooLarge = true;
       const id = taxa.ids[i];
       const isNode = !!findNode(id);
       for (const r of res.species as unknown as RedListSpecies[]) {
         if (isNode && !speciesMatchesNode(r, id)) continue;
-        if (seen.has(r.id)) continue;
-        seen.add(r.id);
+        if (seen.has(r.species_key)) continue;
+        seen.add(r.species_key);
         if (matchesSpeciesFilter(r, criteria)) matched.push(r);
       }
     });

--- a/app/src/lib/data/__tests__/species-duckdb.test.ts
+++ b/app/src/lib/data/__tests__/species-duckdb.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { resolveWhere, toSpeciesRow, colIdToSearchId, nodeIdForSpecies } from "@/lib/data/species-duckdb";
+import { resolveWhere, toSpeciesRow, nodeIdForSpecies } from "@/lib/data/species-duckdb";
+import { speciesRowKey, parseSpeciesRowKey, parseSpeciesParam, migratePinnedSpecies } from "@/lib/species-row-key";
 
 // Unit tests for the parity-critical pure logic of the DuckDB read layer (#261):
 // the taxon→SQL resolver and the row→SpeciesRow mapping. (Full v1-vs-v2 parity is
@@ -43,27 +44,79 @@ describe("resolveWhere", () => {
 // fetch) — so the same species got a DIFFERENT id depending on which taxon scope it was
 // fetched through, while two UNRELATED species from two different queries could easily
 // land on the identical counter value. RedListView.tsx's client-side speciesDetails
-// cache is keyed purely by id and never revalidates an existing entry, so the second
-// species silently rendered under the first's cached iNaturalist photo/common name (a
-// Giraffe's cached thumbnail showing for Fictidomys parvidens after drilling from
-// Mammals into Rodentia — the Giraffe's query-local id and the squirrel's query-local id
-// collided). Fixed by deriving the id from col_id via this function instead — stable
-// across queries (same species, same id, however it was fetched) and collision-resistant
-// across species (a hash, not a fixed decrementing range every query restarts).
-describe("colIdToSearchId", () => {
-  it("is stable: the same col_id always maps to the same id", () => {
-    expect(colIdToSearchId("3LLS")).toBe(colIdToSearchId("3LLS"));
+// cache is keyed purely by that key and never revalidates an existing entry, so the
+// second species silently rendered under the first's cached iNaturalist photo/common
+// name (a Giraffe's cached thumbnail showing for Fictidomys parvidens after drilling
+// from Mammals into Rodentia — the Giraffe's query-local id and the squirrel's
+// query-local id collided). Hashing col_id fixed it; keying on col_id itself makes the
+// property hold by construction — the key IS the identity, so it cannot vary by query.
+describe("speciesRowKey", () => {
+  it("keys an assessed species on its SIS id", () => {
+    expect(speciesRowKey({ sis_taxon_id: 18, col_id: null })).toBe("sis-18");
   });
 
-  it("gives different col_ids different ids (spot-checked, not exhaustive)", () => {
-    const ids = new Set(["3LLS", "6255W", "3Z5", "KTYZ7", "B3FVX"].map(colIdToSearchId));
-    expect(ids.size).toBe(5);
+  it("keys a Not Evaluated species on its CoL id", () => {
+    expect(speciesRowKey({ sis_taxon_id: null, col_id: "3LLS" })).toBe("col-3LLS");
   });
 
-  it("is always negative, so it never collides with a real positive sis/gbif id", () => {
-    for (const colId of ["3LLS", "6255W", "3Z5", "", "a", "zzzzzz"]) {
-      expect(colIdToSearchId(colId)).toBeLessThan(0);
+  it("is stable: the same species always gets the same key, whatever query produced it", () => {
+    expect(speciesRowKey({ col_id: "3LLS" })).toBe(speciesRowKey({ col_id: "3LLS" }));
+  });
+
+  it("gives different species different keys", () => {
+    const keys = new Set(["3LLS", "6255W", "3Z5", "KTYZ7", "B3FVX"].map((c) => speciesRowKey({ col_id: c })));
+    expect(keys.size).toBe(5);
+  });
+
+  it("prefers the SIS id, so a species keeps its key when a CoL link appears", () => {
+    expect(speciesRowKey({ sis_taxon_id: 18, col_id: "3LLS" })).toBe("sis-18");
+  });
+
+  it("is null for a species with neither id (no row can address it)", () => {
+    expect(speciesRowKey({ sis_taxon_id: null, col_id: null })).toBeNull();
+  });
+
+  it("never collides across the two namespaces, even for an all-digit CoL id", () => {
+    expect(speciesRowKey({ col_id: "176168" })).not.toBe(speciesRowKey({ sis_taxon_id: 176168 }));
+  });
+});
+
+describe("parseSpeciesRowKey", () => {
+  it("round-trips both namespaces", () => {
+    expect(parseSpeciesRowKey("sis-176168")).toEqual({ kind: "sis", sisTaxonId: 176168 });
+    expect(parseSpeciesRowKey("col-6CX6F")).toEqual({ kind: "col", colId: "6CX6F" });
+  });
+
+  it("rejects anything outside them", () => {
+    for (const bad of [null, undefined, "", "176168", "sis-", "col-", "gbif-5"]) {
+      expect(parseSpeciesRowKey(bad)).toBeNull();
     }
+  });
+});
+
+// Links written before the key was namespaced carry a bare number.
+describe("parseSpeciesParam", () => {
+  it("reads a namespaced key as-is", () => {
+    expect(parseSpeciesParam("col-6CX6F")).toBe("col-6CX6F");
+  });
+
+  it("upgrades a legacy positive id (a SIS id) so old links still resolve", () => {
+    expect(parseSpeciesParam("176168")).toBe("sis-176168");
+  });
+
+  it("drops a legacy negative id — it was a one-way hash, so guessing risks the wrong species", () => {
+    expect(parseSpeciesParam("-1938472651")).toBeNull();
+  });
+});
+
+describe("migratePinnedSpecies", () => {
+  it("keeps assessed pins, drops un-invertible hash pins, passes new keys through", () => {
+    expect(migratePinnedSpecies([176168, -1938472651, "col-6CX6F"])).toEqual(["sis-176168", "col-6CX6F"]);
+  });
+
+  it("survives absent or corrupt storage", () => {
+    expect(migratePinnedSpecies(null)).toEqual([]);
+    expect(migratePinnedSpecies("nonsense")).toEqual([]);
   });
 });
 
@@ -97,6 +150,7 @@ describe("toSpeciesRow", () => {
       latest_reviewers: "Z, A.",
     });
     expect(row.sis_taxon_id).toBe(18);
+    expect(row.species_key).toBe("sis-18");
     expect(row.assessment_id).toBe(123456);
     expect(row.countries).toEqual(["CO", "EC"]);
     expect(row.systems).toEqual(["Terrestrial"]);
@@ -111,9 +165,13 @@ describe("toSpeciesRow", () => {
     expect(row.previous_assessments).toEqual([]);
   });
 
-  it("maps an NE row: negative id → null sis_taxon_id, no history, group → invertebrates", () => {
+  // toSpeciesRow is the assessed path only — Not Evaluated rows are built inline by
+  // querySpecies' NE branch (they come from a different parquet with a slimmer schema),
+  // so what matters here is that a row missing every assessment-only column degrades to
+  // empty rather than throwing.
+  it("maps a row with no assessment columns: empty history, group → invertebrates", () => {
     const row = toSpeciesRow({
-      id: -BigInt(99),
+      id: BigInt(99),
       scientific_name: "Beetlus novus",
       common_name: null,
       family: "x",
@@ -125,17 +183,12 @@ describe("toSpeciesRow", () => {
       gbif_species_key: BigInt(99),
       gbif_occurrence_count: BigInt(5),
     });
-    expect(row.sis_taxon_id).toBeNull();
     expect(row.previous_assessments).toEqual([]);
     expect(row.taxon_id).toBe("invertebrates"); // mapTaxonId("beetles")
     expect(row.gbif_observations_after_assessment_year).toBeNull();
   });
 });
 
-// Which node a search result opens in. The taxa table renders the ancestor chain of
-// whatever is selected, so this is what puts a species' lineage on screen — and on the
-// not-evaluated side it also decides whether the species can be listed at all, since that
-// view loads exactly ONE node's NE list and refuses anything over NE_CAP (#453).
 describe("nodeIdForSpecies", () => {
   const butterfly = { class_name: "insecta", order_name: "lepidoptera", family: "nymphalidae" };
 

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -17,6 +17,7 @@ import { canonicalizeTaxonId, mapTaxonId } from "@/lib/data/taxonomy-constants";
 import { getTaxaSummary } from "@/lib/data/species-store";
 import { isDynamicNodeId, dynamicNodeFilter, buildDynamicNodeId, rankOrderFor, isLiveDrilldownNode, type DynamicSegment } from "@/lib/dynamic-taxon";
 import { filterToSql, sqlStrList } from "@/lib/taxonomy-sql";
+import { sisRowKey, colRowKey, type SpeciesRowKey } from "@/lib/species-row-key";
 import { COL_DOMESTIC_EXCLUDE_NAMES } from "@/config/col-described-overrides";
 
 const DATA_DIR = path.join(process.cwd(), "data");
@@ -153,12 +154,18 @@ const splitList = (s: unknown): string[] => (typeof s === "string" && s ? s.spli
 const num = (v: unknown): number | null => (v == null ? null : Number(v));
 const str = (v: unknown): string | null => (v == null ? null : String(v));
 
+/**
+ * Assessed rows only — the NE branch of querySpecies builds its own (slimmer) row.
+ * `id` here is assessed.parquet's own id column, which IS the SIS taxon id.
+ */
 export function toSpeciesRow(r: Record<string, unknown>) {
-  const id = Number(r.id);
+  const sisTaxonId = Number(r.id);
   const taxonGroup = String(r.taxon_group);
   return {
-    id,
-    sis_taxon_id: id > 0 ? id : null,
+    // Namespaced row key — see lib/species-row-key. Assessed species always have a
+    // SIS id, so this branch is always `sis-…`; NE rows get `col-…` in querySpecies.
+    species_key: sisRowKey(sisTaxonId),
+    sis_taxon_id: sisTaxonId,
     col_id: (r.col_id as string) ?? null, // CoL id — set on NE rows (assessed resolve via sis)
     assessment_id: num(r.assessment_id),
     scientific_name: r.scientific_name ?? "",
@@ -334,22 +341,27 @@ export async function querySpecies(opts: {
         // null/empty/false for NE, so omitting them ~halves the payload + server
         // serialization (beetles ~262k rows: 178MB → ~90MB). The client handles their
         // absence exactly as the nulls it receives today (audited: every access is
-        // optional-chained, falsy-checked, or NE-skipped). Synthetic negative id (no IUCN
-        // sis) derived from col_id via colIdToSearchId — stable across queries, unlike a
-        // per-query decrementing counter (the previous approach): a species fetched once
-        // as part of "Mammals" and again scoped to "Rodentia" got a DIFFERENT counter-based
-        // id each time (each query restarts its own count from -2,000,000,000), while an
-        // unrelated species from the two different queries could easily land on the exact
-        // same id — RedListView.tsx's speciesDetails cache is keyed by id and never
-        // revalidates an existing entry, so the second species silently rendered under the
-        // first's cached photo/common name/etc (reported: a cached Giraffe thumbnail
-        // showing for Fictidomys parvidens after drilling from Mammals into Rodentia).
-        // colIdToSearchId is already proven collision-free/stable for this exact purpose
-        // (search results); taxon_group is the REAL CoL group (sub-group filter), taxon_id
-        // forced to the requested taxon (top-level filter); GBIF key/count/countries/
-        // common_name overlaid when the species is GBIF-observed.
+        // optional-chained, falsy-checked, or NE-skipped).
+        //
+        // The row key is the CoL id itself (`col-…`). This list IS the CoL universe —
+        // one row per col_id by construction, so the id it keys on is the id it was
+        // selected by, and it identifies the same species no matter which query
+        // produced the row. That last property is load-bearing and used not to hold:
+        // when the key was a per-query decrementing counter, a species fetched once
+        // under "Mammals" and again scoped to "Rodentia" got a different key each time
+        // (every query restarted from -2,000,000,000) while two unrelated species could
+        // collide on one — and RedListView's speciesDetails cache, keyed on it and never
+        // revalidated, then rendered the second species under the first's cached photo
+        // and common name (a Giraffe thumbnail on Fictidomys parvidens, after drilling
+        // from Mammals into Rodentia). Hashing col_id fixed that; using col_id directly
+        // makes it true by construction.
+        //
+        // taxon_group is the REAL CoL group (sub-group filter), taxon_id forced to the
+        // requested taxon (top-level filter); GBIF key/count/countries/common_name
+        // overlaid when the species is GBIF-observed.
         result.push({
-          id: colIdToSearchId((r.col_id as string) ?? (r.scientific_name as string) ?? String(taxonId)),
+          species_key: colRowKey(String(r.col_id)),
+          sis_taxon_id: null,
           col_id: (r.col_id as string) ?? null,
           scientific_name: r.scientific_name ?? "",
           common_name: r.common_name ?? null,
@@ -376,7 +388,16 @@ export async function querySpecies(opts: {
 // ─── Cross-taxa search ──────────────────────────────────────────────────────
 
 export interface SearchResult {
-  id: number;
+  /**
+   * The row key this result selects in the species table (see lib/species-row-key).
+   * Null when the species has neither identity the table can address — a GBIF-observed
+   * species with no CoL link (~9.2k of them). Those still search, and still open their
+   * own /mapping page; they just can't be pointed at a row, because the NE list is the
+   * CoL universe and they aren't in it.
+   */
+  species_key: SpeciesRowKey | null;
+  sis_taxon_id: number | null;
+  col_id: string | null;
   scientific_name: string;
   common_name: string | null;
   taxon_id: string;
@@ -454,15 +475,28 @@ export function nodeIdForSpecies(taxonGroup: string, lineage: Lineage): string |
   return deepest === -1 ? leafRoot : idFor(deepest + 1);
 }
 
-// Stable negative int id for a CoL-only species (no IUCN sis id / GBIF key). Used as the
-// search result's id — the URL `species=` param + the cached-preview key — and never
-// collides with real positive sis/gbif ids. Also used by the NE branch of querySpecies
-// above (same reasoning: a stable, collision-free id independent of which query produced
-// the row — see that call site's comment for the bug a per-query counter caused here).
-export function colIdToSearchId(colId: string): number {
-  let h = 0;
-  for (let i = 0; i < colId.length; i++) h = (Math.imul(h, 31) + colId.charCodeAt(i)) | 0;
-  return -(Math.abs(h) || 1);
+/**
+ * CoL ids for GBIF species keys, via species_link — the bridge build-matching writes.
+ *
+ * The search fast path reads unassessed.parquet, which is one row per GBIF species
+ * key and carries no col_id; the NE list it has to agree with is one row per col_id.
+ * The two grains genuinely differ (3,756 col_ids have more than one GBIF key), so a
+ * search hit's row key has to come from the link table rather than from its GBIF key.
+ * Assuming key == col_id would be wrong for ~4.3k species even though it holds for
+ * 99.4% of them.
+ *
+ * Batched by the keys actually matched (a handful per search), so this reads two
+ * columns of species_link filtered to those keys rather than scanning it whole.
+ */
+async function colIdsForGbifKeys(conn: DuckDBConnection, keys: string[]): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  if (!keys.length) return out;
+  const list = keys.map((k) => `'${k.replace(/'/g, "''")}'`).join(",");
+  const rows = (await conn.runAndReadAll(
+    `SELECT gbif_species_key, col_id FROM read_parquet('${parquetUri("species_link.parquet")}')
+     WHERE src = 'gbif' AND col_id IS NOT NULL AND gbif_species_key IN (${list})`, {})).getRowObjects();
+  for (const r of rows) out.set(String(r.gbif_species_key), String(r.col_id));
+  return out;
 }
 
 // Substring search over both parquets (replaces the in-memory search-index.json).
@@ -477,7 +511,7 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
   const proj = (src: string, assessed: boolean) => `
     SELECT id, scientific_name, common_name, taxon_group, iucn_category AS category, gbif_species_key, gbif_occurrence_count,
            ${assessed ? "assessment_id, CAST(assessment_date AS VARCHAR) AS assessment_date" : "NULL AS assessment_id, NULL AS assessment_date"},
-           countries, class_name, order_name, family
+           countries, class_name, order_name, family, ${assessed} AS assessed
     FROM '${parquetUri(src)}'
     WHERE scientific_name ILIKE '%' || $q || '%'
        OR (common_name IS NOT NULL AND common_name ILIKE '%' || $q || '%')`;
@@ -490,14 +524,24 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
              lower(scientific_name)
     LIMIT ${lim}`;
   const rows = (await conn.runAndReadAll(sql, { q: query.toLowerCase() })).getRowObjects();
-  const fast: SearchResult[] = rows.map((r) => {
+  // An unassessed hit is keyed by the col_id its GBIF key links to, which is what the
+  // NE list keys its rows on — resolved for the whole page of hits in one lookup.
+  const neKeys = rows.filter((r) => !r.assessed).map((r) => str(r.gbif_species_key)).filter((k): k is string => !!k);
+  const colIdByGbifKey = await colIdsForGbifKeys(conn, neKeys);
+  const hits: SearchResult[] = rows.map((r) => {
     const tg = String(r.taxon_group);
     const cat = String(r.category ?? "");
     const lineage = { class_name: str(r.class_name), order_name: str(r.order_name), family: str(r.family) };
+    // assessed.parquet's id column IS the SIS taxon id; unassessed.parquet's is an
+    // internal build-time key that never leaves the pipeline (see build-parquet).
+    const sisTaxonId = r.assessed ? Number(r.id) : null;
+    const colId = r.assessed ? null : (colIdByGbifKey.get(str(r.gbif_species_key) ?? "") ?? null);
     // Both views browse via the top-level taxon, plus the sub-group node the species
     // itself sits in — see nodeIdForSpecies.
     return {
-      id: Number(r.id),
+      species_key: sisTaxonId != null ? sisRowKey(sisTaxonId) : colId ? colRowKey(colId) : null,
+      sis_taxon_id: sisTaxonId,
+      col_id: colId,
       scientific_name: String(r.scientific_name ?? ""),
       common_name: (r.common_name as string) ?? null,
       taxon_id: mapTaxonId(tg),
@@ -512,6 +556,25 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
       node_id: nodeIdForSpecies(tg, lineage),
     };
   });
+
+  // One entry per species. unassessed.parquet is one row per GBIF species key, and CoL
+  // lumps some of those: 3,756 col_ids carry more than one key, so a name like Abutilon
+  // halophilum matched twice (keys VLWL9 and 8N4F) and listed twice in the dropdown —
+  // two rows that now resolve to the same species and would select the same table row.
+  // The NE list already shows one row per col_id (ne_gbif_by_col groups by it), so
+  // collapsing here is what makes search agree with the list it selects into. Keep the
+  // best-observed key of the group, which is the most useful one to preview from.
+  // Null keys are never collapsed — those species have no shared identity to merge on.
+  const bestByKey = new Map<string, SearchResult>();
+  for (const r of hits) {
+    if (!r.species_key) continue;
+    const prev = bestByKey.get(r.species_key);
+    if (!prev || (r.gbif_occurrence_count ?? -1) > (prev.gbif_occurrence_count ?? -1)) {
+      bestByKey.set(r.species_key, r);
+    }
+  }
+  const fast: SearchResult[] = hits.filter((r) => !r.species_key || bestByKey.get(r.species_key) === r);
+
   // Return as soon as the direct search (assessed ∪ unassessed, ~16MB) finds anything.
   // The CoL-only and synonym tiers below each full-scan a large parquet over R2 (species/
   // ~36MB, synonym-index ~77MB) with no pruning — ~10s on a cold function. They exist to
@@ -542,7 +605,9 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
     const tg = String(r.taxon_group);
     const lineage = { class_name: str(r.class_name), order_name: str(r.order_name), family: str(r.family) };
     fast.push({
-      id: colIdToSearchId(String(r.col_id)),
+      species_key: colRowKey(String(r.col_id)),
+      sis_taxon_id: null,
+      col_id: String(r.col_id),
       scientific_name: name,
       common_name: null,
       taxon_id: mapTaxonId(tg),
@@ -593,8 +658,11 @@ export async function searchSpecies(query: string, limit = 10): Promise<SearchRe
       const tg = String(r.taxon_group);
       const cat = String(r.category ?? "NE");
       const sis = r.sis_id == null ? null : Number(r.sis_id);
+      const colId = r.accepted_col_id == null ? null : String(r.accepted_col_id);
       const result: SearchResult = {
-        id: sis ?? colIdToSearchId(String(r.accepted_col_id)),
+        species_key: sis != null ? sisRowKey(sis) : colId ? colRowKey(colId) : null,
+        sis_taxon_id: sis,
+        col_id: colId,
         scientific_name: accName,
         common_name: null,
         taxon_id: mapTaxonId(tg),

--- a/app/src/lib/species-row-key.ts
+++ b/app/src/lib/species-row-key.ts
@@ -1,0 +1,120 @@
+/**
+ * The dashboard's row key for a species — one concept, two namespaces.
+ *
+ * A species reaches the dashboard through one of exactly two identity systems,
+ * and which one it has is a fact about the species, not about the view:
+ *
+ *   - IUCN-assessed  → `sis-<sis_taxon_id>`  (SIS taxon id; every assessed row
+ *                       has one, unique across assessed.parquet)
+ *   - Not Evaluated  → `col-<col_id>`        (Catalogue of Life id; the NE list
+ *                       IS the CoL universe, one row per col_id by construction)
+ *
+ * Neither id can serve for both. 823 assessed species have no CoL link at all
+ * (build-matching leaves them unmatched), so col_id is not universal; NE species
+ * have no assessment, so sis is not either. Namespacing them into one string key
+ * is what lets every consumer — row identity, selection, pinning, caches, the
+ * `species=` URL param — hold a single value with no branching.
+ *
+ * What this replaces
+ * ------------------
+ * Previously the row key was a *number* carrying the same information as a sign
+ * trick: positive = sis id, negative = a hash of the CoL id. That forced every
+ * consumer to know which view it was in (`isNewAssessments ? Math.abs(s.id) :
+ * s.sis_taxon_id`) and, worse, there were two different hash functions for the
+ * negative case — a DuckDB `hash(gbif_species_key)` baked into unassessed.parquet
+ * and a JS 31-hash (`colIdToSearchId`) in the query layer. The same NE species
+ * got a different id depending on which query produced the row, so selecting an
+ * NE species from the search bar could not match the row in the table (the
+ * `species=` param it wrote never equalled any row's key). Keys are strings now:
+ * the sign trick, both hashes, and every `Math.abs` around them are gone.
+ *
+ * The numeric ids themselves are untouched — `sis_taxon_id` still addresses IUCN
+ * assessments, range maps and AOH layers; `col_id` still addresses CoL synonymy.
+ * Only the *row key* changed.
+ */
+
+/** `sis-<n>` for an assessed species, `col-<id>` for a Not Evaluated one. */
+export type SpeciesRowKey = string;
+
+/**
+ * Hyphen rather than the more conventional colon: `URLSearchParams` percent-encodes
+ * `:` but leaves `-` alone, so `?species=col-6CX6F` stays readable in the address
+ * bar (and in a shared link) instead of becoming `?species=col%3A6CX6F`. CoL ids are
+ * uppercase alphanumeric, so a hyphen can't be ambiguous with the id that follows.
+ */
+export const sisRowKey = (sisTaxonId: number | string): SpeciesRowKey => `sis-${sisTaxonId}`;
+export const colRowKey = (colId: string): SpeciesRowKey => `col-${colId}`;
+
+/**
+ * The row key for a species row, from whichever identity it has. Assessed wins when
+ * a row somehow carries both (an assessed row's col_id is only ever informational —
+ * the detail panel's CoL/synonyms tab uses it), so a species never changes key when
+ * a CoL link is added or removed by a resync.
+ *
+ * Null only for a row with neither id, which the table cannot address; callers
+ * treat that as "not selectable" rather than inventing a key for it.
+ */
+export function speciesRowKey(row: {
+  sis_taxon_id?: number | null;
+  col_id?: string | null;
+}): SpeciesRowKey | null {
+  if (row.sis_taxon_id != null) return sisRowKey(row.sis_taxon_id);
+  if (row.col_id) return colRowKey(row.col_id);
+  return null;
+}
+
+export type ParsedRowKey =
+  | { kind: "sis"; sisTaxonId: number }
+  | { kind: "col"; colId: string };
+
+/** Inverse of the builders above; null for anything not in either namespace. */
+export function parseSpeciesRowKey(key: string | null | undefined): ParsedRowKey | null {
+  if (!key) return null;
+  if (key.startsWith("sis-")) {
+    const n = Number(key.slice(4));
+    return Number.isFinite(n) && n > 0 ? { kind: "sis", sisTaxonId: n } : null;
+  }
+  if (key.startsWith("col-")) {
+    const colId = key.slice(4);
+    return colId ? { kind: "col", colId } : null;
+  }
+  return null;
+}
+
+/**
+ * Read the `species=` URL param, accepting the pre-namespace numeric form.
+ *
+ * A bare positive integer was a SIS id and still resolves exactly — that covers
+ * every shared link to an assessed species, which is all of them that were stable.
+ * A bare negative integer was the synthetic hash, which no longer exists in any
+ * form that can be inverted (it was a one-way hash of the CoL id, and of two
+ * different hash functions at that); those resolve to null, so the view loads
+ * normally with no row expanded rather than silently opening the wrong species.
+ */
+export function parseSpeciesParam(raw: string | null | undefined): SpeciesRowKey | null {
+  if (!raw) return null;
+  if (/^-?\d+$/.test(raw)) {
+    const n = Number(raw);
+    return n > 0 ? sisRowKey(n) : null;
+  }
+  return parseSpeciesRowKey(raw) ? raw : null;
+}
+
+/**
+ * Migrate a persisted pin list (localStorage held `number[]` before namespacing).
+ * Positive entries were SIS ids; negative entries were the un-invertible hash and
+ * are dropped, so a user's pinned assessed species survive and pinned NE species
+ * are lost rather than resurfacing as the wrong row.
+ */
+export function migratePinnedSpecies(stored: unknown): SpeciesRowKey[] {
+  if (!Array.isArray(stored)) return [];
+  const keys: SpeciesRowKey[] = [];
+  for (const entry of stored) {
+    if (typeof entry === "number") {
+      if (entry > 0) keys.push(sisRowKey(entry));
+    } else if (typeof entry === "string" && parseSpeciesRowKey(entry)) {
+      keys.push(entry);
+    }
+  }
+  return keys;
+}


### PR DESCRIPTION
## Summary

The dashboard identified a species row by a **number whose sign carried its meaning**: positive was a SIS taxon id, negative was a hash of the CoL id. Reading it meant knowing which view you were in — `isNewAssessments ? Math.abs(s.id) : (s.sis_taxon_id ?? s.id)`, repeated at six call sites — and the negative case had *two different hash functions* behind it:

| where | what it hashed | e.g. *Dictyostega orobanchoides* |
|---|---|---|
| `unassessed.parquet.id` (what `/api/search` returned) | DuckDB `hash(gbif_species_key)` | `-120863532220949` |
| `colIdToSearchId` (what the NE list returned) | JS 31-hash of `col_id` | `-48763640` |

**One species, two ids, depending on which query produced the row.** So selecting a Not Evaluated species from the search bar wrote a `species=` param matching no row in the list it navigated to, and its detail panel never opened. Assessed species were unaffected (their id is the SIS id on both sides), which is why this stayed invisible — it was total for the ~1.8M NE species and silent for everything else.

Row keys are strings now, namespaced by the identity the species actually has:

```
assessed       → sis-<sis_taxon_id>     (always present; unique across all 175,909)
not evaluated  → col-<col_id>           (the NE list IS the CoL universe, one row per col_id)
```

Both namespaces are load-bearing — **823 assessed species have no CoL link**, so `col_id` can't be universal, and NE species have no assessment, so `sis` can't be either. Namespacing lets a single value serve row identity, selection, pinning, React keys, every per-species cache, and the URL param with no branching anywhere.

### Before / after

Searching a Not Evaluated species and selecting it. Same species, same flow.

| Before (main) — row lands, panel stays shut | After — panel opens |
|---|---|
| <img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-475-col-id-row-key/01-before-ne-search-no-panel.png" width="100%"> | <img src="https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-475-col-id-row-key/02-after-ne-search-panel-opens.png" width="100%"> |

Measured on both servers side by side:

```
                            main                              this branch
Panthera leo (VU)           species=15951          panel ✅   species=sis-15951   panel ✅
Dictyostega orobanchoides   species=-120863532…    panel ❌   species=col-35VNR   panel ✅
```

### Search now agrees with the list it selects into

`unassessed.parquet` is one row per **GBIF key**; the NE list is one row per **col_id** (`ne_gbif_by_col` groups by it). Those grains genuinely differ — 3,756 col_ids carry more than one GBIF key — so search resolves a hit's col_id through `species_link` rather than assuming key == col_id. That assumption holds for 698,311 of 702,658 linked rows, *not* all of them (`Abutilon halophilum`: GBIF `VLWL9`, CoL `8N4F`).

A side effect worth calling out: a species GBIF splits and CoL lumps used to appear **twice** in the search dropdown as two entries that now resolve identically, so search dedupes by row key, keeping the better-observed of the pair.

### Removed, not replaced

Both hashes · the sign convention · every `Math.abs` around a row key · the per-view key expressions · the two name-equality dedupes that existed only to paper over the mismatch (their comments named it outright: *"a row loaded from the NE list is keyed on its CoL id while the search result is keyed on its GBIF one"*) · the synonyms cache's hand-rolled `col:`/`sis:` keying, which had independently reinvented this exact scheme.

### Compatibility

- A bare positive `?species=` is read as a SIS id, so existing links to assessed species resolve unchanged.
- A bare negative one was the un-invertible hash — it opens no species rather than risking the wrong one. The list still renders normally.
- Pinned species migrate on read: assessed pins survive exactly, NE pins (hashes) are dropped rather than resurfacing as the wrong row.
- `?species=col-6CX6F` survives `URLSearchParams` unencoded — hence `-` rather than the more usual `:`, which would render as `col%3A6CX6F`.

## Test plan

Typecheck, lint, and **854/854 tests** pass. New unit coverage for the key builders, the parser, the legacy-param path and the pin migration replaces the old hash-function suite.

Browser drive-through (Playwright, dev server on real data — **11/11**):

- [x] Assessed row click → `sis-…` in the URL, detail panel opens
- [x] Assessed deep link reload → panel reopens
- [x] Legacy `?species=<sis>` → still opens the panel
- [x] Legacy `?species=-1938472651` → opens nothing, list renders normally
- [x] NE row click → `col-…` in the URL, panel opens
- [x] NE deep link reload → panel reopens
- [x] **Search → NE species → writes `col-35VNR`, panel opens** (the fixed case)
- [x] Pinning writes `["sis-287996422"]` to localStorage
- [x] Verified against a main checkout side by side to confirm the before-state

Remaining console errors are environmental only (headless WebGL/maplibre, the Sentry proxy).

## Notes for the reviewer

- **No data-pipeline change** — parquet schemas are untouched, so this ships against the current sync with no resync. `unassessed.parquet.id` still exists but is now purely an internal build-time join key for `species_link`; it no longer reaches the UI.
- **One follow-up worth doing:** search pays an extra `species_link` lookup per query with unassessed hits. Carrying `col_id` on `unassessed.parquet` would remove it, but `build-matching` reads that parquet to *produce* `species_link`, so it needs a pipeline reorder + full resync — deliberately out of scope here.
- **Conflict warning:** the unmerged `occurrence-list-view` branch adds `getSpeciesByGbifKey`/`dashboard_row_id`, which call `colIdToSearchId` (deleted here). It should adopt `species_key` when rebased — `getSpeciesByGbifKey` wants `col-<col_id>` resolved via `species_link` for unassessed species.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
