### PR TITLE
Shorten the taxa URL token to what isn't recoverable

### DIFF
--- a/app/scripts/__tests__/validate-table1a.test.ts
+++ b/app/scripts/__tests__/validate-table1a.test.ts
@@ -10,7 +10,7 @@ import * as path from "path";
 
 const DATA_DIR = path.join(__dirname, "../../data");
 
-// Assessed-species counts per CSV group, from the official 2026-1 Table 1a
+// Assessed-species counts per taxon group, from the official 2026-1 Table 1a
 // (https://nc.iucnredlist.org/redlist/content/attachment_files/2026-1_RL_Table1a.pdf,
 // "last updated 09 July 2026") cross-checked against our own synced totals.
 // Originally every group matched exactly except crustaceans, off by 2 — not

--- a/app/scripts/build-taxa-summary.ts
+++ b/app/scripts/build-taxa-summary.ts
@@ -398,7 +398,7 @@ export async function run(): Promise<void> {
     let gbifNeSpeciesCount = 0;
     const byCategory: Record<string, number> = {};
 
-    for (const group of filter.csvGroups) {
+    for (const group of filter.taxonGroups) {
       const rows = redlistByGroup.get(group) ?? [];
       for (const row of rows) {
         if (!matchesFilter(row, filter)) continue;
@@ -459,7 +459,7 @@ export async function run(): Promise<void> {
       results.push(summary);
 
       if (child.filter.classNames || child.filter.orderNames) {
-        for (const group of child.filter.csvGroups) {
+        for (const group of child.filter.taxonGroups) {
           const rows = redlistByGroup.get(group) ?? [];
           for (const row of rows) {
             if (matchesFilter(row, child.filter)) {
@@ -484,7 +484,7 @@ export async function run(): Promise<void> {
       let gbifNeSpeciesCount = 0;
       const byCategory: Record<string, number> = {};
 
-      for (const group of child.filter.csvGroups) {
+      for (const group of child.filter.taxonGroups) {
         const rows = redlistByGroup.get(group) ?? [];
         for (const row of rows) {
           if (!matchesFilter(row, child.filter)) continue;

--- a/app/src/app/api/redlist/assessor-candidates-by-country/route.ts
+++ b/app/src/app/api/redlist/assessor-candidates-by-country/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAssessorCandidatesByCountry } from "@/lib/data/species-store";
-import { findNode, getCsvGroupsForNode } from "@/lib/taxonomy-utils";
+import { findNode, getTaxonGroupsForNode } from "@/lib/taxonomy-utils";
 import { CACHE_5M } from "@/lib/cache-headers";
 
 export async function GET(request: NextRequest) {
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
   }
 
   const countries = countriesParam.split(";").filter(Boolean);
-  const groups = getCsvGroupsForNode(taxaId);
+  const groups = getTaxonGroupsForNode(taxaId);
 
   // Extract taxonomy filter from the node (orderNames, classNames, etc.)
   const node = findNode(taxaId);

--- a/app/src/app/api/redlist/reviewer-candidates-by-country/route.ts
+++ b/app/src/app/api/redlist/reviewer-candidates-by-country/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getReviewerCandidatesByCountry } from "@/lib/data/species-store";
-import { findNode, getCsvGroupsForNode } from "@/lib/taxonomy-utils";
+import { findNode, getTaxonGroupsForNode } from "@/lib/taxonomy-utils";
 import { CACHE_5M } from "@/lib/cache-headers";
 
 export async function GET(request: NextRequest) {
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
   }
 
   const countries = countriesParam.split(";").filter(Boolean);
-  const groups = getCsvGroupsForNode(taxaId);
+  const groups = getTaxonGroupsForNode(taxaId);
 
   // Extract taxonomy filter from the node (orderNames, classNames, etc.)
   const node = findNode(taxaId);

--- a/app/src/app/api/redlist/taxa-summary/route.ts
+++ b/app/src/app/api/redlist/taxa-summary/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getTaxaSummary } from "@/lib/data/species-store";
 import { getCountryTaxaSummary } from "@/lib/data/country-taxa-summary-duckdb";
-import { findNode, getCsvGroupsForNode } from "@/lib/taxonomy-utils";
+import { findNode, getTaxonGroupsForNode } from "@/lib/taxonomy-utils";
 import { getView } from "@/config/taxonomy-views";
 import { CACHE_1H } from "@/lib/cache-headers";
 
@@ -66,9 +66,9 @@ export async function GET(request: NextRequest) {
         title: section.title,
         rows: section.nodeIds.map((nodeId) => {
           const node = findNode(nodeId);
-          const csvGroups = getCsvGroupsForNode(nodeId);
+          const taxonGroups = getTaxonGroupsForNode(nodeId);
           // For multi-group nodes, merge
-          const matchedRows = csvGroups
+          const matchedRows = taxonGroups
             .map((g) => rowsByGroup.get(g))
             .filter(Boolean) as typeof data;
           const totalAssessed = matchedRows.reduce(
@@ -151,7 +151,7 @@ export async function GET(request: NextRequest) {
           };
         }
 
-        const groups = getCsvGroupsForNode(nodeId);
+        const groups = getTaxonGroupsForNode(nodeId);
         const matchedRows = groups
           .map((g) => rowsByGroup.get(g))
           .filter(Boolean) as typeof data;

--- a/app/src/app/compare/page.tsx
+++ b/app/src/app/compare/page.tsx
@@ -7,6 +7,7 @@ import { FaGlobeAmericas, FaArrowLeft } from "react-icons/fa";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { useBrand } from "@/components/BrandProvider";
 import { parseParams, type ViewMode } from "@/hooks/useFilterParams";
+import { prettifyQs } from "@/lib/query-string";
 import { SpeciesCacheProvider } from "@/contexts/SpeciesCacheContext";
 
 const RedListView = dynamic(
@@ -47,7 +48,7 @@ function usePanelViewMode(paramSuffix: string) {
     const key = `view${paramSuffix}`;
     if (mode === "reassessments") params.delete(key);
     else params.set(key, "new-assessments");
-    const qs = params.toString();
+    const qs = prettifyQs(params.toString());
     window.history.pushState(null, "", qs ? `/compare?${qs}` : "/compare");
     window.dispatchEvent(new PopStateEvent("popstate"));
   };

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -9,6 +9,7 @@ import { ThemeToggle } from "../components/ThemeToggle";
 import { AuthStatus } from "../components/AuthStatus";
 import { useBrand } from "../components/BrandProvider";
 import { parseParams, type ViewMode } from "../hooks/useFilterParams";
+import { prettifyQs } from "../lib/query-string";
 import { SpeciesCacheProvider } from "../contexts/SpeciesCacheContext";
 
 // Dynamically import view component
@@ -56,7 +57,10 @@ export default function RedListPage() {
     const params = new URLSearchParams(window.location.search);
     if (mode === "reassessments") params.delete("view");
     else params.set("view", "new-assessments");
-    const qs = params.toString();
+    // Re-serializing the whole query here would re-encode the taxa token's `~`/`:`
+    // that buildQs deliberately leaves bare, so the toggle briefly pushes an uglier
+    // URL than the one it replaced. Same treatment keeps it stable.
+    const qs = prettifyQs(params.toString());
     window.history.pushState(null, "", qs ? `/?${qs}` : "/");
     window.dispatchEvent(new PopStateEvent("popstate"));
   };

--- a/app/src/components/__tests__/isPlantOrFungiTaxonGroup.test.ts
+++ b/app/src/components/__tests__/isPlantOrFungiTaxonGroup.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { isPlantOrFungiTaxonGroup } from "../OccurrenceMapRow";
-import { ALL_CSV_GROUPS } from "@/config/taxonomy-tree";
+import { ALL_TAXON_GROUPS } from "@/config/taxonomy-tree";
 
 // ---------------------------------------------------------------------------
 // isPlantOrFungiTaxonGroup — decides whether PRESERVED_SPECIMEN should default
@@ -54,11 +54,11 @@ describe("isPlantOrFungiTaxonGroup", () => {
     expect(isPlantOrFungiTaxonGroup("not_a_real_group")).toBe(false);
   });
 
-  // Guards against forgetting to add newly-introduced CSV groups to the
+  // Guards against forgetting to add newly-introduced taxon groups to the
   // plantae/fungi mapping in taxonomy-constants.ts. Every Table 1a group
   // should classify deterministically as plant/fungi-or-not.
-  it("covers every Table 1a CSV group", () => {
-    for (const group of ALL_CSV_GROUPS) {
+  it("covers every Table 1a taxon group", () => {
+    for (const group of ALL_TAXON_GROUPS) {
       const result = isPlantOrFungiTaxonGroup(group);
       expect(typeof result).toBe("boolean");
     }

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -18,7 +18,7 @@ import { TAXONOMY_VIEWS } from "@/config/taxonomy-views";
 import { IUCN_SOURCE_URL } from "@/config/taxonomy-tree";
 import { isLiveDrilldownNode, nextDynamicRank, isDynamicNodeId, dynamicNodeDisplayName, dynamicNodeFilter, dynamicNodeRankInfo, parseDynamicNodeId } from "@/lib/dynamic-taxon";
 import type { RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
-import { prettifyQs } from "@/hooks/useFilterParams";
+import { prettifyQs } from "@/lib/query-string";
 import { sisRowKey } from "@/lib/species-row-key";
 
 // See scripts/build-taxa-summary.ts's classifyNoMatch for what each reason means.

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -9,7 +9,7 @@ import { HiOutlineAdjustmentsHorizontal } from "react-icons/hi2";
 import TaxaIcon from "@/components/TaxaIcon";
 import { CATEGORY_COLORS, CATEGORY_NAMES, CATEGORY_ORDER } from "@/config/taxa";
 import {
-  hasChildren, findNode, getAncestors, stripNodePrefix, OFFICIAL_IUCN_DESCRIBED_NODE_IDS,
+  hasChildren, findNode, getAncestors, stripNodePrefix, taxaUrlToken, OFFICIAL_IUCN_DESCRIBED_NODE_IDS,
   describeFilter, COL_RELEASE_LABEL, COL_RELEASE_URL, primaryFilterRank, breakdownDisplayName, breakdownHref,
   matchesBreakdownName, speciesMatchesNode,
   type FilterRank, type DescribeFilterSegment,
@@ -18,6 +18,7 @@ import { TAXONOMY_VIEWS } from "@/config/taxonomy-views";
 import { IUCN_SOURCE_URL } from "@/config/taxonomy-tree";
 import { isLiveDrilldownNode, nextDynamicRank, isDynamicNodeId, dynamicNodeDisplayName, dynamicNodeFilter, dynamicNodeRankInfo, parseDynamicNodeId } from "@/lib/dynamic-taxon";
 import type { RedListSpecies } from "@/hooks/useRedListSpeciesQuery";
+import { prettifyQs } from "@/hooks/useFilterParams";
 import { sisRowKey } from "@/lib/species-row-key";
 
 // See scripts/build-taxa-summary.ts's classifyNoMatch for what each reason means.
@@ -329,7 +330,7 @@ function nodeSpeciesListHref(
   breakdown?: { rank: FilterRank; name: string; only?: number[]; excl?: number[] },
 ): string {
   const params = new URLSearchParams();
-  params.set("taxa", stripNodePrefix(nodeId));
+  params.set("taxa", taxaUrlToken(nodeId));
   if (view === "new-assessments") params.set("view", "new-assessments");
   // Narrows to just this breakdown row (e.g. Rodentia within Small Mammal SG), and
   // optionally to/away-from a small explicit id list (CoL Match / No CoL Match — see
@@ -340,7 +341,7 @@ function nodeSpeciesListHref(
     else if (breakdown.excl?.length) bd += `:excl:${breakdown.excl.join(",")}`;
     params.set("bd", bd);
   }
-  return `/?${params.toString()}`;
+  return `/?${prettifyQs(params.toString())}`;
 }
 
 // Builds a real URL (not a pushState-only path) for a single species' detail view —
@@ -348,10 +349,10 @@ function nodeSpeciesListHref(
 // caller's place in the current tab.
 function speciesHref(nodeId: string, speciesKey: string, view: "reassessments" | "new-assessments"): string {
   const params = new URLSearchParams();
-  params.set("taxa", stripNodePrefix(nodeId));
+  params.set("taxa", taxaUrlToken(nodeId));
   if (view === "new-assessments") params.set("view", "new-assessments");
   params.set("species", speciesKey);
-  return `/?${params.toString()}`;
+  return `/?${prettifyQs(params.toString())}`;
 }
 
 // What SpeciesListPanel is currently showing — captured at click time from the

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -1565,7 +1565,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
 
   // SSC groups mode — same flat-table layout as Table 1a mode, sourced from
   // the precomputed SSC wrapper nodes' children instead of the top-level
-  // Table 1a CSV groups (see SSC_SECTIONS above).
+  // Table 1a taxon groups (see SSC_SECTIONS above).
   const [sscData, setSscData] = useState<Table1aSectionData[] | null>(null);
   const [sscLoading, setSscLoading] = useState(false);
   const sscFetchStartedRef = useRef(false);
@@ -2882,18 +2882,18 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
                             } else if (onNavigateToSubgroup) {
                               // Table 1a group under a virtual root (e.g. molluscs → invertebrates).
                               // row.group is a tree node id. Aggregating parent rows (e.g. "insecta",
-                              // which spans 8 order CSV groups) match a child by node id; single-group
-                              // rows match by CSV group.
+                              // which spans 8 order taxon groups) match a child by node id; single-group
+                              // rows match by taxon group.
                               const stripPrefix = (id: string) => id.replace(/^(inv-|pl-|fu-)/, "");
                               for (const rootId of defaultRoots) {
                                 const rootNode = findNode(rootId);
                                 const matchingChild =
                                   rootNode?.children?.find(c => stripPrefix(c.id) === row.group)
                                   ?? rootNode?.children?.find(c =>
-                                    c.filter.csvGroups.length === 1 && c.filter.csvGroups[0] === row.group
+                                    c.filter.taxonGroups.length === 1 && c.filter.taxonGroups[0] === row.group
                                   )
                                   ?? rootNode?.children?.find(c =>
-                                    c.filter.csvGroups.includes(row.group)
+                                    c.filter.taxonGroups.includes(row.group)
                                   );
                                 if (matchingChild) {
                                   onNavigateToSubgroup(rootId, matchingChild.id);

--- a/app/src/config/__tests__/taxonomy-tree.live-col.test.ts
+++ b/app/src/config/__tests__/taxonomy-tree.live-col.test.ts
@@ -49,7 +49,7 @@ type ColRow = { scientific_name: string; class_name: string | null; order_name: 
 // Same "extant, or CoL-extinct but IUCN-confirmed EX/EW" + Homo sapiens exclusion
 // scripts/build-taxa-summary.ts uses for every other CoL-derived count in this app —
 // mirrored here (not imported) since that logic lives inside non-exported functions.
-async function fetchColUniverse(csvGroups: string[]): Promise<ColRow[]> {
+async function fetchColUniverse(taxonGroups: string[]): Promise<ColRow[]> {
   const conn = await (await DuckDBInstance.create(":memory:")).connect();
   await conn.run(`
     CREATE TABLE ex_ew_assessed AS
@@ -58,7 +58,7 @@ async function fetchColUniverse(csvGroups: string[]): Promise<ColRow[]> {
     JOIN read_parquet('${ASSESSED}') a ON a.id = l.id
     WHERE l.src = 'redlist' AND l.col_id IS NOT NULL AND a.iucn_category IN ('EX', 'EW')
   `);
-  const groupList = csvGroups.map((g) => `'${g}'`).join(", ");
+  const groupList = taxonGroups.map((g) => `'${g}'`).join(", ");
   const result = await conn.run(`
     SELECT scientific_name, class_name, order_name, family, taxon_group
     FROM read_parquet('${SPECIES_GLOB}', hive_partitioning=true)
@@ -76,7 +76,7 @@ describe.skipIf(!DATA_AVAILABLE)("SSC Specialist Group filters vs. the live Cata
   beforeAll(async () => {
     for (const wrapperId of SSC_WRAPPER_IDS) {
       const wrapper = NODE_INDEX.get(wrapperId)!;
-      universeByWrapper.set(wrapperId, await fetchColUniverse(wrapper.filter.csvGroups));
+      universeByWrapper.set(wrapperId, await fetchColUniverse(wrapper.filter.taxonGroups));
     }
   }, 180_000);
 

--- a/app/src/config/__tests__/taxonomy-tree.test.ts
+++ b/app/src/config/__tests__/taxonomy-tree.test.ts
@@ -12,7 +12,7 @@ import {
   matchesFilter,
   speciesMatchesNode,
   getNodeDef,
-  getCsvGroupsForNode,
+  getTaxonGroupsForNode,
 } from "@/lib/taxonomy-utils";
 import { TAXONOMY_VIEWS } from "../taxonomy-views";
 import { isLiveDrilldownNode } from "@/lib/dynamic-taxon";
@@ -53,11 +53,11 @@ describe("Taxonomy tree integrity", () => {
     }
   });
 
-  it("every node has at least one csvGroup in its filter", () => {
+  it("every node has at least one taxonGroup in its filter", () => {
     for (const node of allNodes) {
       expect(
-        node.filter.csvGroups.length,
-        `${node.id} has no csvGroups`
+        node.filter.taxonGroups.length,
+        `${node.id} has no taxonGroups`
       ).toBeGreaterThan(0);
     }
   });
@@ -236,28 +236,28 @@ describe("getNodePath", () => {
   });
 });
 
-describe("getCsvGroupsForNode", () => {
+describe("getTaxonGroupsForNode", () => {
   it("returns single group for Table 1a leaf node", () => {
-    expect(getCsvGroupsForNode("mammals")).toEqual(["mammals"]);
-    expect(getCsvGroupsForNode("beetles")).toEqual(["beetles"]);
+    expect(getTaxonGroupsForNode("mammals")).toEqual(["mammals"]);
+    expect(getTaxonGroupsForNode("beetles")).toEqual(["beetles"]);
   });
 
   it("returns the 8 order groups for the insects parent node", () => {
-    const groups = getCsvGroupsForNode("insects");
+    const groups = getTaxonGroupsForNode("insects");
     expect(groups).toContain("beetles");
     expect(groups).toContain("other_insects");
     expect(groups.length).toBe(8);
   });
 
   it("returns multiple groups for virtual node", () => {
-    const groups = getCsvGroupsForNode("invertebrates");
+    const groups = getTaxonGroupsForNode("invertebrates");
     expect(groups).toContain("beetles");
     expect(groups).toContain("molluscs");
     expect(groups).toContain("crustaceans");
   });
 
   it("returns all 28 groups for 'all'", () => {
-    expect(getCsvGroupsForNode("all").length).toBe(28);
+    expect(getTaxonGroupsForNode("all").length).toBe(28);
   });
 });
 
@@ -271,7 +271,7 @@ describe("getCsvGroupsForNode", () => {
 // matching logic is unchanged and still exercised below (families/
 // excludeClasses/genera/speciesNames) and via dynamic-taxon.test.ts's
 // speciesMatchesNode-with-a-dynamic-id regression suite, which covers the
-// same ground (order rejection, csvGroup scoping, family narrowing) against
+// same ground (order rejection, taxonGroup scoping, family narrowing) against
 // the live mechanism that replaced these nodes.
 // =============================================================================
 
@@ -289,25 +289,25 @@ describe("speciesMatchesNode – edge cases", () => {
 describe("matchesFilter – families filter", () => {
   it("matches species with family in include list", () => {
     const row = { class_name: "Mammalia", order_name: "Artiodactyla", family: "Delphinidae" };
-    const filter = { csvGroups: ["mammals"], orderNames: ["artiodactyla", "sirenia"], families: ["delphinidae", "trichechidae", "dugongidae"] };
+    const filter = { taxonGroups: ["mammals"], orderNames: ["artiodactyla", "sirenia"], families: ["delphinidae", "trichechidae", "dugongidae"] };
     expect(matchesFilter(row, filter)).toBe(true);
   });
 
   it("rejects species with family not in include list", () => {
     const row = { class_name: "Mammalia", order_name: "Artiodactyla", family: "Bovidae" };
-    const filter = { csvGroups: ["mammals"], orderNames: ["artiodactyla", "sirenia"], families: ["delphinidae", "trichechidae", "dugongidae"] };
+    const filter = { taxonGroups: ["mammals"], orderNames: ["artiodactyla", "sirenia"], families: ["delphinidae", "trichechidae", "dugongidae"] };
     expect(matchesFilter(row, filter)).toBe(false);
   });
 
   it("excludeFamilies rejects matching family", () => {
     const row = { class_name: "Mammalia", order_name: "Artiodactyla", family: "Delphinidae" };
-    const filter = { csvGroups: ["mammals"], orderNames: ["artiodactyla"], excludeFamilies: ["delphinidae", "ziphiidae"] };
+    const filter = { taxonGroups: ["mammals"], orderNames: ["artiodactyla"], excludeFamilies: ["delphinidae", "ziphiidae"] };
     expect(matchesFilter(row, filter)).toBe(false);
   });
 
   it("excludeFamilies passes non-matching family", () => {
     const row = { class_name: "Mammalia", order_name: "Artiodactyla", family: "Bovidae" };
-    const filter = { csvGroups: ["mammals"], orderNames: ["artiodactyla"], excludeFamilies: ["delphinidae", "ziphiidae"] };
+    const filter = { taxonGroups: ["mammals"], orderNames: ["artiodactyla"], excludeFamilies: ["delphinidae", "ziphiidae"] };
     expect(matchesFilter(row, filter)).toBe(true);
   });
 });
@@ -319,19 +319,19 @@ describe("matchesFilter – families filter", () => {
 describe("matchesFilter – excludeClasses filter", () => {
   it("excludes species with class in exclude list", () => {
     const row = { class_name: "Echinoidea", order_name: null };
-    const filter = { csvGroups: ["other_invertebrates"], excludeClasses: ["asteroidea", "echinoidea", "holothuroidea"] };
+    const filter = { taxonGroups: ["other_invertebrates"], excludeClasses: ["asteroidea", "echinoidea", "holothuroidea"] };
     expect(matchesFilter(row, filter)).toBe(false);
   });
 
   it("passes species with class not in exclude list", () => {
     const row = { class_name: "Bivalvia", order_name: null };
-    const filter = { csvGroups: ["other_invertebrates"], excludeClasses: ["asteroidea", "echinoidea", "holothuroidea"] };
+    const filter = { taxonGroups: ["other_invertebrates"], excludeClasses: ["asteroidea", "echinoidea", "holothuroidea"] };
     expect(matchesFilter(row, filter)).toBe(true);
   });
 
   it("passes species with null class_name", () => {
     const row = { class_name: null, order_name: null };
-    const filter = { csvGroups: ["other_invertebrates"], excludeClasses: ["asteroidea", "echinoidea"] };
+    const filter = { taxonGroups: ["other_invertebrates"], excludeClasses: ["asteroidea", "echinoidea"] };
     expect(matchesFilter(row, filter)).toBe(true);
   });
 });
@@ -343,31 +343,31 @@ describe("matchesFilter – excludeClasses filter", () => {
 describe("matchesFilter – genera filter", () => {
   it("matches species with genus (first token of scientific_name) in include list", () => {
     const row = { class_name: "Mammalia", order_name: "Carnivora", family: "Ursidae", scientific_name: "Ursus arctos" };
-    const filter = { csvGroups: ["mammals"], genera: ["ursus", "helarctos"] };
+    const filter = { taxonGroups: ["mammals"], genera: ["ursus", "helarctos"] };
     expect(matchesFilter(row, filter)).toBe(true);
   });
 
   it("rejects species with genus not in include list", () => {
     const row = { class_name: "Mammalia", order_name: "Carnivora", family: "Felidae", scientific_name: "Panthera leo" };
-    const filter = { csvGroups: ["mammals"], genera: ["ursus", "helarctos"] };
+    const filter = { taxonGroups: ["mammals"], genera: ["ursus", "helarctos"] };
     expect(matchesFilter(row, filter)).toBe(false);
   });
 
   it("excludeGenera rejects matching genus", () => {
     const row = { class_name: "Mammalia", order_name: "Carnivora", family: "Mustelidae", scientific_name: "Lutra lutra" };
-    const filter = { csvGroups: ["mammals"], families: ["mustelidae"], excludeGenera: ["lutra", "pteronura"] };
+    const filter = { taxonGroups: ["mammals"], families: ["mustelidae"], excludeGenera: ["lutra", "pteronura"] };
     expect(matchesFilter(row, filter)).toBe(false);
   });
 
   it("excludeGenera passes non-matching genus", () => {
     const row = { class_name: "Mammalia", order_name: "Carnivora", family: "Mustelidae", scientific_name: "Mustela nivalis" };
-    const filter = { csvGroups: ["mammals"], families: ["mustelidae"], excludeGenera: ["lutra", "pteronura"] };
+    const filter = { taxonGroups: ["mammals"], families: ["mustelidae"], excludeGenera: ["lutra", "pteronura"] };
     expect(matchesFilter(row, filter)).toBe(true);
   });
 
   it("treats a missing scientific_name as no genus (fails an include filter)", () => {
     const row = { class_name: "Mammalia", order_name: "Carnivora", family: "Ursidae" };
-    const filter = { csvGroups: ["mammals"], genera: ["ursus"] };
+    const filter = { taxonGroups: ["mammals"], genera: ["ursus"] };
     expect(matchesFilter(row, filter)).toBe(false);
   });
 });
@@ -375,20 +375,20 @@ describe("matchesFilter – genera filter", () => {
 describe("matchesFilter – speciesNames filter", () => {
   it("matches species with scientific_name in include list (case-insensitive)", () => {
     const row = { class_name: "Mammalia", order_name: "Carnivora", family: "Ursidae", scientific_name: "Ursus Maritimus" };
-    const filter = { csvGroups: ["mammals"], speciesNames: ["ursus maritimus"] };
+    const filter = { taxonGroups: ["mammals"], speciesNames: ["ursus maritimus"] };
     expect(matchesFilter(row, filter)).toBe(true);
   });
 
   it("rejects species with scientific_name not in include list", () => {
     const row = { class_name: "Mammalia", order_name: "Carnivora", family: "Ursidae", scientific_name: "Ursus arctos" };
-    const filter = { csvGroups: ["mammals"], speciesNames: ["ursus maritimus"] };
+    const filter = { taxonGroups: ["mammals"], speciesNames: ["ursus maritimus"] };
     expect(matchesFilter(row, filter)).toBe(false);
   });
 
   it("excludeSpeciesNames carves a single species out of a family-level filter", () => {
     const polarBear = { class_name: "Mammalia", order_name: "Carnivora", family: "Ursidae", scientific_name: "Ursus maritimus" };
     const brownBear = { class_name: "Mammalia", order_name: "Carnivora", family: "Ursidae", scientific_name: "Ursus arctos" };
-    const filter = { csvGroups: ["mammals"], families: ["ursidae"], excludeSpeciesNames: ["ursus maritimus"] };
+    const filter = { taxonGroups: ["mammals"], families: ["ursidae"], excludeSpeciesNames: ["ursus maritimus"] };
     expect(matchesFilter(polarBear, filter)).toBe(false);
     expect(matchesFilter(brownBear, filter)).toBe(true);
   });
@@ -481,10 +481,10 @@ describe("SSC Specialist Groups tree", () => {
     expect(speciesMatchesNode(redPanda, "ssc-small-carnivore")).toBe(true);
   });
 
-  it("all SSC group children use the mammals csvGroup and have a unique id", () => {
+  it("all SSC group children use the mammals taxonGroup and have a unique id", () => {
     const ids = new Set<string>();
     for (const child of sscNode?.children ?? []) {
-      expect(child.filter.csvGroups).toEqual(["mammals"]);
+      expect(child.filter.taxonGroups).toEqual(["mammals"]);
       expect(ids.has(child.id), `duplicate id ${child.id}`).toBe(false);
       ids.add(child.id);
     }
@@ -678,10 +678,10 @@ describe("SSC Specialist Groups tree (reptiles)", () => {
     expect(speciesMatchesNode(shieldTail, "ssc-snake-lizard-rla")).toBe(true);
   });
 
-  it("all ssc-reptile-groups children use the reptiles csvGroup and have a unique id", () => {
+  it("all ssc-reptile-groups children use the reptiles taxonGroup and have a unique id", () => {
     const ids = new Set<string>();
     for (const child of sscReptileNode?.children ?? []) {
-      expect(child.filter.csvGroups).toEqual(["reptiles"]);
+      expect(child.filter.taxonGroups).toEqual(["reptiles"]);
       expect(ids.has(child.id), `duplicate id ${child.id}`).toBe(false);
       ids.add(child.id);
     }
@@ -822,10 +822,10 @@ describe("SSC Specialist Groups tree (fishes)", () => {
     expect(speciesMatchesNode(paddlefish, "ssc-sturgeon")).toBe(true);
   });
 
-  it("all ssc-fish-groups children use the fishes csvGroup and have a unique id", () => {
+  it("all ssc-fish-groups children use the fishes taxonGroup and have a unique id", () => {
     const ids = new Set<string>();
     for (const child of sscFishNode?.children ?? []) {
-      expect(child.filter.csvGroups).toEqual(["fishes"]);
+      expect(child.filter.taxonGroups).toEqual(["fishes"]);
       expect(ids.has(child.id), `duplicate id ${child.id}`).toBe(false);
       ids.add(child.id);
     }
@@ -1019,7 +1019,7 @@ describe("SSC Specialist Groups tree (invertebrates)", () => {
     expect(speciesMatchesNode(riverPrawn, "ssc-other-invertebrates")).toBe(false);
   });
 
-  it("Horseshoe Crab SG matches its whole dedicated CSV group", () => {
+  it("Horseshoe Crab SG matches its whole dedicated taxon group", () => {
     const horseshoeCrab = { class_name: "Merostomata", order_name: "Xiphosura", family: "Limulidae", scientific_name: "Limulus polyphemus", taxon_group: "horseshoe_crabs" };
     expect(speciesMatchesNode(horseshoeCrab, "ssc-horseshoe-crab")).toBe(true);
   });
@@ -1083,7 +1083,7 @@ describe("SSC Specialist Groups tree (plants)", () => {
     }
   });
 
-  it("Bryophyte SG matches its whole dedicated CSV group (mosses, liverworts, and hornworts together)", () => {
+  it("Bryophyte SG matches its whole dedicated taxon group (mosses, liverworts, and hornworts together)", () => {
     const moss = { class_name: "Bryopsida", order_name: "Hypnales", family: "Hypnaceae", scientific_name: "Hypnum cupressiforme", taxon_group: "mosses" };
     const liverwort = { class_name: "Jungermanniopsida", order_name: "Jungermanniales", family: "Lepidoziaceae", scientific_name: "Bazzania trilobata", taxon_group: "mosses" };
     expect(speciesMatchesNode(moss, "ssc-bryophyte")).toBe(true);
@@ -1212,10 +1212,10 @@ describe("SSC Specialist Groups tree (fungi)", () => {
     expect(speciesMatchesNode(hypotheticalChytrid, "ssc-other-fungi")).toBe(false);
   });
 
-  it("all ssc-fungi-groups children use the mushrooms csvGroup and have a unique id", () => {
+  it("all ssc-fungi-groups children use the mushrooms taxonGroup and have a unique id", () => {
     const ids = new Set<string>();
     for (const child of sscFungiNode?.children ?? []) {
-      expect(child.filter.csvGroups).toEqual(["mushrooms"]);
+      expect(child.filter.taxonGroups).toEqual(["mushrooms"]);
       expect(ids.has(child.id), `duplicate id ${child.id}`).toBe(false);
       ids.add(child.id);
     }
@@ -1282,33 +1282,33 @@ describe("Subgroup partition coverage", () => {
 
 // ─── Default view: no double counting ────────────────────────────────
 
-describe("default view CSV group coverage", () => {
+describe("default view taxon group coverage", () => {
   const defaultRoots = TAXONOMY_VIEWS.default.roots;
 
-  it("no CSV group appears in multiple default view roots", () => {
-    const seen = new Map<string, string>(); // csvGroup → rootId
+  it("no taxon group appears in multiple default view roots", () => {
+    const seen = new Map<string, string>(); // taxonGroup → rootId
     for (const rootId of defaultRoots) {
       const node = findNode(rootId)!;
-      for (const csv of node.filter.csvGroups) {
+      for (const csv of node.filter.taxonGroups) {
         expect(seen.has(csv), `"${csv}" is in both "${seen.get(csv)}" and "${rootId}"`).toBe(false);
         seen.set(csv, rootId);
       }
     }
   });
 
-  it("all 28 Table 1a CSV groups are covered by exactly one default view root", () => {
-    const allCsvGroups = new Set<string>();
+  it("all 28 Table 1a taxon groups are covered by exactly one default view root", () => {
+    const allTaxonGroups = new Set<string>();
     for (const rootId of defaultRoots) {
-      for (const csv of findNode(rootId)!.filter.csvGroups) {
-        allCsvGroups.add(csv);
+      for (const group of findNode(rootId)!.filter.taxonGroups) {
+        allTaxonGroups.add(group);
       }
     }
-    expect(allCsvGroups.size).toBe(28);
+    expect(allTaxonGroups.size).toBe(28);
   });
 
   it("brown_algae is in fungi, not plantae", () => {
-    expect(findNode("fungi")!.filter.csvGroups).toContain("brown_algae");
-    expect(findNode("plantae")!.filter.csvGroups).not.toContain("brown_algae");
+    expect(findNode("fungi")!.filter.taxonGroups).toContain("brown_algae");
+    expect(findNode("plantae")!.filter.taxonGroups).not.toContain("brown_algae");
   });
 });
 
@@ -1357,14 +1357,14 @@ describe("Table 1a → default view mapping", () => {
       for (const rootId of defaultRoots) {
         const rootNode = findNode(rootId)!;
         // Mirror TaxaSummary navigation: match by node id (aggregating parents
-        // like "insects"), then by single CSV group, then by CSV-group membership.
+        // like "insects"), then by single taxon group, then by CSV-group membership.
         const match =
           rootNode.children?.find(c => stripPrefix(c.id) === group)
           ?? rootNode.children?.find(c =>
-            c.filter.csvGroups.length === 1 && c.filter.csvGroups[0] === group
+            c.filter.taxonGroups.length === 1 && c.filter.taxonGroups[0] === group
           )
           ?? rootNode.children?.find(c =>
-            c.filter.csvGroups.includes(group)
+            c.filter.taxonGroups.includes(group)
           );
         if (match) { found = true; break; }
       }

--- a/app/src/config/__tests__/taxonomy-tree.test.ts
+++ b/app/src/config/__tests__/taxonomy-tree.test.ts
@@ -53,6 +53,34 @@ describe("Taxonomy tree integrity", () => {
     }
   });
 
+  // taxonGroups is the parquet partition predicate (`taxon_group IN (…)` — see
+  // taxonomy-sql), so a parent that doesn't cover everything its children claim
+  // prunes away its own descendants' rows: the child's node lists species the
+  // parent's node silently omits. Nothing else catches that — the counts just
+  // come back wrong. Verified to hold for all 139 nodes when written, so a
+  // failure here means a new group was added to a child and not to its ancestors
+  // (the likely path: extending ALL_INSECT_GROUPS or a virtual root's list).
+  //
+  // Deliberately a CHECK rather than a derivation. Deriving a node's groups from
+  // its children would let 65 of the 139 declarations be deleted, but it makes a
+  // node's partition scope non-local — you'd have to walk the tree to see why
+  // ssc-otter is [mammals] — in the one config file where being explicit and
+  // greppable is worth more than being short.
+  it("every node's taxonGroups covers the union of its children's", () => {
+    for (const node of allNodes) {
+      if (!node.children?.length) continue;
+      const own = new Set(node.filter.taxonGroups);
+      for (const child of node.children) {
+        for (const group of child.filter.taxonGroups) {
+          expect(
+            own.has(group),
+            `${node.id} is missing taxonGroup "${group}" claimed by its child ${child.id}`
+          ).toBe(true);
+        }
+      }
+    }
+  });
+
   it("every node has at least one taxonGroup in its filter", () => {
     for (const node of allNodes) {
       expect(

--- a/app/src/config/taxonomy-tree.ts
+++ b/app/src/config/taxonomy-tree.ts
@@ -13,7 +13,7 @@
 
 export interface SpeciesFilter {
   /** Which Table 1a CSV files to load */
-  csvGroups: string[];
+  taxonGroups: string[];
   /** Filter by class_name (lowercase) */
   classNames?: string[];
   /** Filter by order_name (lowercase) */
@@ -41,7 +41,7 @@ export interface SpeciesFilter {
   excludeSpeciesNames?: string[];
   /** OR escape hatch: species included regardless of every other clause above
    * (bypasses classNames/orderNames/families/genera entirely, but still respects
-   * csvGroups and the CoL-only universe exclusions). For a group whose own stated
+   * taxonGroups and the CoL-only universe exclusions). For a group whose own stated
    * remit includes named species outside its otherwise-clean taxonomic rule — e.g.
    * the Antelope Specialist Group's own site names Pronghorn (Antilocapridae),
    * Water Chevrotain (Tragulidae), and Wild Camel (Camelidae) as part of its remit
@@ -90,7 +90,7 @@ const CHRISTENHUSZ_URL = "https://doi.org/10.11646/phytotaxa.261.3.1";
 const SPECIES_FUNGORUM = "Species Fungorum Plus via Catalogue of Life";
 const SPECIES_FUNGORUM_URL = "https://doi.org/10.48580/dg9ld-4hj";
 
-// Insect base CSV groups (the Table 1a "Insects" row, split by order)
+// Insect base taxon groups (the Table 1a "Insects" row, split by order)
 const ALL_INSECT_GROUPS = [
   "beetles", "butterflies_and_moths", "flies_and_mosquitoes", "bees_wasps_and_ants",
   "true_bugs", "grasshoppers_crickets_locusts", "dragonflies_and_damselflies", "other_insects",
@@ -109,8 +109,8 @@ const ALL_INSECT_GROUPS = [
 // turned out clean when checked directly) — this comment is about why they
 // never had a STATIC one, not that they're undrillable today.
 
-// All 28 Table 1a CSV groups (Insects split into 8 order-based groups)
-export const ALL_CSV_GROUPS = [
+// All 28 Table 1a taxon groups (Insects split into 8 order-based groups)
+export const ALL_TAXON_GROUPS = [
   "mammals", "birds", "reptiles", "amphibians", "fishes",
   ...ALL_INSECT_GROUPS,
   "arachnids", "molluscs", "crustaceans", "corals",
@@ -152,7 +152,7 @@ function prefixTree(node: TaxonomyNode, prefix: string): TaxonomyNode {
 const INSECTS_NODE: TaxonomyNode = {
   id: "insects",
   name: "Insects",
-  filter: { csvGroups: ALL_INSECT_GROUPS },
+  filter: { taxonGroups: ALL_INSECT_GROUPS },
   estimatedDescribed: 1_008_355,
   estimatedSource: IUCN_SOURCE + " (" + COL_2025 + ")",
   estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -161,7 +161,7 @@ const INSECTS_NODE: TaxonomyNode = {
 const ARACHNIDA_NODE: TaxonomyNode = {
   id: "arachnids",
   name: "Arachnids",
-  filter: { csvGroups: ["arachnids"] },
+  filter: { taxonGroups: ["arachnids"] },
   estimatedDescribed: 98_006,
   estimatedSource: IUCN_SOURCE + " (" + COL_2025 + ")",
   estimatedSourceUrl: COL_2025_URL,
@@ -170,7 +170,7 @@ const ARACHNIDA_NODE: TaxonomyNode = {
 const MOLLUSCA_NODE: TaxonomyNode = {
   id: "molluscs",
   name: "Molluscs",
-  filter: { csvGroups: ["molluscs"] },
+  filter: { taxonGroups: ["molluscs"] },
   estimatedDescribed: 89_129,
   estimatedSource: IUCN_SOURCE + " (MolluscaBase 2025)",
   estimatedSourceUrl: "http://www.molluscabase.org",
@@ -179,7 +179,7 @@ const MOLLUSCA_NODE: TaxonomyNode = {
 const CRUSTACEA_NODE: TaxonomyNode = {
   id: "crustaceans",
   name: "Crustaceans",
-  filter: { csvGroups: ["crustaceans"] },
+  filter: { taxonGroups: ["crustaceans"] },
   estimatedDescribed: 83_805,
   estimatedSource: IUCN_SOURCE + " (" + COL_2025 + "; World Ostracoda Database)",
   estimatedSourceUrl: COL_2025_URL,
@@ -188,7 +188,7 @@ const CRUSTACEA_NODE: TaxonomyNode = {
 const CORALS_NODE: TaxonomyNode = {
   id: "corals",
   name: "Corals & Cnidarians",
-  filter: { csvGroups: ["corals"] },
+  filter: { taxonGroups: ["corals"] },
   estimatedDescribed: 5_695,
   estimatedSource: IUCN_SOURCE + " (WoRMS 2025)",
   estimatedSourceUrl: "https://www.marinespecies.org",
@@ -205,7 +205,7 @@ const CORALS_NODE: TaxonomyNode = {
 const OTHER_INVERTEBRATES_NODE: TaxonomyNode = {
   id: "other_invertebrates",
   name: "Other Invertebrates",
-  filter: { csvGroups: ["other_invertebrates"] },
+  filter: { taxonGroups: ["other_invertebrates"] },
   estimatedDescribed: 171_981,
   estimatedSource: IUCN_SOURCE,
   estimatedSourceUrl: COL_2025_URL,
@@ -214,7 +214,7 @@ const OTHER_INVERTEBRATES_NODE: TaxonomyNode = {
 const VELVET_WORMS_NODE: TaxonomyNode = {
   id: "velvet_worms",
   name: "Velvet Worms",
-  filter: { csvGroups: ["velvet_worms"] },
+  filter: { taxonGroups: ["velvet_worms"] },
   estimatedDescribed: 220,
   estimatedSource: IUCN_SOURCE,
   estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -223,7 +223,7 @@ const VELVET_WORMS_NODE: TaxonomyNode = {
 const HORSESHOE_CRABS_NODE: TaxonomyNode = {
   id: "horseshoe_crabs",
   name: "Horseshoe Crabs",
-  filter: { csvGroups: ["horseshoe_crabs"] },
+  filter: { taxonGroups: ["horseshoe_crabs"] },
   estimatedDescribed: 4,
   estimatedSource: IUCN_SOURCE,
   estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -234,7 +234,7 @@ const HORSESHOE_CRABS_NODE: TaxonomyNode = {
 const FLOWERING_PLANTS_NODE: TaxonomyNode = {
   id: "flowering_plants",
   name: "Flowering Plants",
-  filter: { csvGroups: ["flowering_plants"] },
+  filter: { taxonGroups: ["flowering_plants"] },
   estimatedDescribed: 369_000,
   estimatedSource: IUCN_SOURCE + " (State of the World's Plants 2017)",
   estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -243,7 +243,7 @@ const FLOWERING_PLANTS_NODE: TaxonomyNode = {
 const GYMNOSPERMS_NODE: TaxonomyNode = {
   id: "gymnosperms",
   name: "Gymnosperms",
-  filter: { csvGroups: ["gymnosperms"] },
+  filter: { taxonGroups: ["gymnosperms"] },
   estimatedDescribed: 1_113,
   estimatedSource: IUCN_SOURCE + " (Christenhusz et al. 2011)",
   estimatedSourceUrl: "https://stateoftheworldsplants.org/2017/report/SOTWP_2017.pdf",
@@ -252,7 +252,7 @@ const GYMNOSPERMS_NODE: TaxonomyNode = {
 const FERNS_AND_ALLIES_NODE: TaxonomyNode = {
   id: "ferns_and_allies",
   name: "Ferns & Allies",
-  filter: { csvGroups: ["ferns_and_allies"] },
+  filter: { taxonGroups: ["ferns_and_allies"] },
   estimatedDescribed: 11_800,
   estimatedSource: IUCN_SOURCE + " (State of the World's Plants 2017)",
   estimatedSourceUrl: "https://stateoftheworldsplants.org/2017/report/SOTWP_2017.pdf",
@@ -261,7 +261,7 @@ const FERNS_AND_ALLIES_NODE: TaxonomyNode = {
 const MOSSES_NODE: TaxonomyNode = {
   id: "mosses",
   name: "Mosses, Liverworts & Hornworts",
-  filter: { csvGroups: ["mosses"] },
+  filter: { taxonGroups: ["mosses"] },
   estimatedDescribed: 19_539,
   estimatedSource: IUCN_SOURCE + " (" + CHRISTENHUSZ + ")",
   estimatedSourceUrl: CHRISTENHUSZ_URL,
@@ -270,7 +270,7 @@ const MOSSES_NODE: TaxonomyNode = {
 const GREEN_ALGAE_NODE: TaxonomyNode = {
   id: "green_algae",
   name: "Green Algae",
-  filter: { csvGroups: ["green_algae"] },
+  filter: { taxonGroups: ["green_algae"] },
   estimatedDescribed: 14_739,
   estimatedSource: IUCN_SOURCE,
   estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -279,7 +279,7 @@ const GREEN_ALGAE_NODE: TaxonomyNode = {
 const RED_ALGAE_NODE: TaxonomyNode = {
   id: "red_algae",
   name: "Red Algae",
-  filter: { csvGroups: ["red_algae"] },
+  filter: { taxonGroups: ["red_algae"] },
   estimatedDescribed: 7_812,
   estimatedSource: IUCN_SOURCE,
   estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -290,7 +290,7 @@ const RED_ALGAE_NODE: TaxonomyNode = {
 const MUSHROOMS_NODE: TaxonomyNode = {
   id: "mushrooms",
   name: "Fungi",
-  filter: { csvGroups: ["mushrooms"] },
+  filter: { taxonGroups: ["mushrooms"] },
   estimatedDescribed: 157_648,
   estimatedSource: IUCN_SOURCE + " (" + SPECIES_FUNGORUM + ")",
   estimatedSourceUrl: SPECIES_FUNGORUM_URL,
@@ -299,7 +299,7 @@ const MUSHROOMS_NODE: TaxonomyNode = {
 const BROWN_ALGAE_NODE: TaxonomyNode = {
   id: "brown_algae",
   name: "Brown Algae",
-  filter: { csvGroups: ["brown_algae"] },
+  filter: { taxonGroups: ["brown_algae"] },
   estimatedDescribed: 5_104,
   estimatedSource: IUCN_SOURCE,
   estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -310,7 +310,7 @@ const BROWN_ALGAE_NODE: TaxonomyNode = {
 export const TAXONOMY_TREE: TaxonomyNode = {
   id: "all",
   name: "All Species",
-  filter: { csvGroups: ALL_CSV_GROUPS },
+  filter: { taxonGroups: ALL_TAXON_GROUPS },
   estimatedDescribed: 2_121_262,
   estimatedSource: IUCN_SOURCE,
   estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -324,7 +324,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     {
       id: "mammals",
       name: "Mammals",
-      filter: { csvGroups: ["mammals"] },
+      filter: { taxonGroups: ["mammals"] },
       estimatedDescribed: 6_854,
       estimatedSource: IUCN_SOURCE,
       estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -332,7 +332,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     },
 
     // ─── SSC SPECIALIST GROUPS (pilot: mammals) ─────────────────────────
-    // A second, independent lens over the same "mammals" CSV group, organized
+    // A second, independent lens over the same "mammals" taxon group, organized
     // by IUCN SSC (Species Survival Commission) Specialist Group boundaries
     // instead of by taxonomic order — so an SSC group (e.g. the Small Mammal
     // Specialist Group) can pull up exactly the species it's responsible for.
@@ -352,30 +352,30 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     {
       id: "ssc-groups",
       name: "SSC Specialist Groups",
-      filter: { csvGroups: ["mammals"] },
+      filter: { taxonGroups: ["mammals"] },
       children: [
         {
           id: "ssc-african-elephant",
           name: "African Elephant Specialist Group",
-          filter: { csvGroups: ["mammals"], genera: ["loxodonta"] },
+          filter: { taxonGroups: ["mammals"], genera: ["loxodonta"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-african-elephant-specialist-group",
         },
         {
           id: "ssc-asian-elephant",
           name: "Asian Elephant Specialist Group",
-          filter: { csvGroups: ["mammals"], genera: ["elephas"] },
+          filter: { taxonGroups: ["mammals"], genera: ["elephas"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-asian-elephant-specialist-group",
         },
         {
           id: "ssc-african-rhino",
           name: "African Rhino Specialist Group",
-          filter: { csvGroups: ["mammals"], genera: ["diceros", "ceratotherium"] },
+          filter: { taxonGroups: ["mammals"], genera: ["diceros", "ceratotherium"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-african-rhino-specialist-group",
         },
         {
           id: "ssc-asian-rhino",
           name: "Asian Rhino Specialist Group",
-          filter: { csvGroups: ["mammals"], genera: ["rhinoceros", "dicerorhinus"] },
+          filter: { taxonGroups: ["mammals"], genera: ["rhinoceros", "dicerorhinus"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-asian-rhino-specialist-group",
         },
         {
@@ -388,7 +388,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           // now reflect the group's own current branding.
           name: "Asian Wild Cattle Specialist Group",
           filter: {
-            csvGroups: ["mammals"],
+            taxonGroups: ["mammals"],
             genera: ["bos", "bubalus", "pseudoryx"],
             // The group's own site is explicit: "Asia's nine wild cattle
             // species... All nine of these species are threatened with
@@ -403,7 +403,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-afrotheria",
           name: "Afrotheria Specialist Group",
-          filter: { csvGroups: ["mammals"], orderNames: ["afrosoricida", "macroscelidea", "hyracoidea", "tubulidentata"] },
+          filter: { taxonGroups: ["mammals"], orderNames: ["afrosoricida", "macroscelidea", "hyracoidea", "tubulidentata"] },
           // Own site (afrotheria.net): "1 aardvark, 6 hyraxes, 19 sengis, 21
           // golden moles, 34 tenrecs" = 81 (golden moles + tenrecs are both
           // subsumed under order Afrosoricida in our data, not separate
@@ -413,7 +413,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-anteater-sloth-armadillo",
           name: "Anteater, Sloth and Armadillo Specialist Group",
-          filter: { csvGroups: ["mammals"], orderNames: ["pilosa", "cingulata"] },
+          filter: { taxonGroups: ["mammals"], orderNames: ["pilosa", "cingulata"] },
           // Own site (xenarthrans.org): "seven sloth species, ten anteater
           // species, and 25 armadillo species" = 42; stale MDD-derived figure
           // (31) reflected pre-2025 traditional Xenarthra taxonomy.
@@ -423,7 +423,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-antelope",
           name: "Antelope Specialist Group",
           filter: {
-            csvGroups: ["mammals"],
+            taxonGroups: ["mammals"],
             families: ["bovidae"],
             excludeGenera: [
               "bos", "bubalus", "pseudoryx", "bison",
@@ -463,7 +463,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-australasian-marsupial-monotreme",
           name: "Australasian Marsupial and Monotreme Specialist Group",
           filter: {
-            csvGroups: ["mammals"],
+            taxonGroups: ["mammals"],
             orderNames: ["diprotodontia", "dasyuromorphia", "peramelemorphia", "notoryctemorphia", "monotremata"],
           },
           // Own materials (IUCN 2024-2025 SSC report): "the world's five
@@ -475,38 +475,38 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-bat",
           name: "Bat Specialist Group",
-          filter: { csvGroups: ["mammals"], orderNames: ["chiroptera"] },
+          filter: { taxonGroups: ["mammals"], orderNames: ["chiroptera"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-bat-specialist-group",
         },
         {
           id: "ssc-bear",
           name: "Bear Specialist Group",
-          filter: { csvGroups: ["mammals"], families: ["ursidae"], excludeSpeciesNames: ["ursus maritimus"] },
+          filter: { taxonGroups: ["mammals"], families: ["ursidae"], excludeSpeciesNames: ["ursus maritimus"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-bear-specialist-group",
         },
         {
           id: "ssc-polar-bear",
           name: "Polar Bear Specialist Group",
-          filter: { csvGroups: ["mammals"], speciesNames: ["ursus maritimus"] },
+          filter: { taxonGroups: ["mammals"], speciesNames: ["ursus maritimus"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-polar-bear-specialist-group",
         },
         {
           id: "ssc-bison",
           name: "Bison Specialist Group",
-          filter: { csvGroups: ["mammals"], genera: ["bison"] },
+          filter: { taxonGroups: ["mammals"], genera: ["bison"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-bison-specialist-group",
         },
         {
           id: "ssc-canid",
           name: "Canid Specialist Group",
-          filter: { csvGroups: ["mammals"], families: ["canidae"] },
+          filter: { taxonGroups: ["mammals"], families: ["canidae"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-canid-specialist-group",
         },
         {
           id: "ssc-caprinae",
           name: "Caprinae Specialist Group",
           filter: {
-            csvGroups: ["mammals"],
+            taxonGroups: ["mammals"],
             genera: [
               "capra", "ovis", "ovibos", "rupicapra", "naemorhedus",
               "capricornis", "oreamnos", "budorcas", "pantholops",
@@ -518,14 +518,14 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-cat",
           name: "Cat Specialist Group",
-          filter: { csvGroups: ["mammals"], families: ["felidae"] },
+          filter: { taxonGroups: ["mammals"], families: ["felidae"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-cat-specialist-group",
         },
         {
           id: "ssc-cetacean",
           name: "Cetacean Specialist Group",
           filter: {
-            csvGroups: ["mammals"],
+            taxonGroups: ["mammals"],
             families: [
               "balaenidae", "balaenopteridae", "eschrichtiidae", "physeteridae",
               "kogiidae", "ziphiidae", "hyperoodontidae", "neobalaenidae", "delphinidae", "monodontidae",
@@ -538,7 +538,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-deer",
           name: "Deer Specialist Group",
           filter: {
-            csvGroups: ["mammals"],
+            taxonGroups: ["mammals"],
             families: ["cervidae", "moschidae", "tragulidae"],
             // Deer SG's own stated remit extends beyond true deer to musk deer
             // (Moschidae) and chevrotains (Tragulidae). Hyemoschus aquaticus
@@ -552,37 +552,37 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-equid",
           name: "Equid Specialist Group",
-          filter: { csvGroups: ["mammals"], families: ["equidae"] },
+          filter: { taxonGroups: ["mammals"], families: ["equidae"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-equid-specialist-group",
         },
         {
           id: "ssc-giraffe-okapi",
           name: "Giraffe and Okapi Specialist Group",
-          filter: { csvGroups: ["mammals"], families: ["giraffidae"] },
+          filter: { taxonGroups: ["mammals"], families: ["giraffidae"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-giraffe-and-okapi-specialist-group",
         },
         {
           id: "ssc-hippo",
           name: "Hippo Specialist Group",
-          filter: { csvGroups: ["mammals"], families: ["hippopotamidae"] },
+          filter: { taxonGroups: ["mammals"], families: ["hippopotamidae"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-hippo-specialist-group",
         },
         {
           id: "ssc-hyaena",
           name: "Hyaena Specialist Group",
-          filter: { csvGroups: ["mammals"], families: ["hyaenidae"] },
+          filter: { taxonGroups: ["mammals"], families: ["hyaenidae"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-hyaena-specialist-group",
         },
         {
           id: "ssc-lagomorph",
           name: "Lagomorph Specialist Group",
-          filter: { csvGroups: ["mammals"], orderNames: ["lagomorpha"] },
+          filter: { taxonGroups: ["mammals"], orderNames: ["lagomorpha"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-lagomorph-specialist-group",
         },
         {
           id: "ssc-new-world-marsupial",
           name: "New World Marsupial Specialist Group",
-          filter: { csvGroups: ["mammals"], orderNames: ["didelphimorphia", "paucituberculata", "microbiotheria"] },
+          filter: { taxonGroups: ["mammals"], orderNames: ["didelphimorphia", "paucituberculata", "microbiotheria"] },
           // estimatedDescribed corrected — a prior fix misread this same
           // paper's figure as 108 (which suspiciously matched how many rows
           // happen to be in our own dataset, not the paper's own stated
@@ -596,7 +596,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-otter",
           name: "Otter Specialist Group",
           filter: {
-            csvGroups: ["mammals"],
+            taxonGroups: ["mammals"],
             genera: ["lutra", "pteronura", "aonyx", "lutrogale", "enhydra", "hydrictis", "lontra"],
           },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-otter-specialist-group",
@@ -604,25 +604,25 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-pangolin",
           name: "Pangolin Specialist Group",
-          filter: { csvGroups: ["mammals"], orderNames: ["pholidota"] },
+          filter: { taxonGroups: ["mammals"], orderNames: ["pholidota"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-pangolin-specialist-group",
         },
         {
           id: "ssc-peccary",
           name: "Peccary Specialist Group",
-          filter: { csvGroups: ["mammals"], families: ["tayassuidae"] },
+          filter: { taxonGroups: ["mammals"], families: ["tayassuidae"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-peccary-specialist-group",
         },
         {
           id: "ssc-pinniped",
           name: "Pinniped Specialist Group",
-          filter: { csvGroups: ["mammals"], families: ["otariidae", "phocidae", "odobenidae"] },
+          filter: { taxonGroups: ["mammals"], families: ["otariidae", "phocidae", "odobenidae"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-pinniped-specialist-group",
         },
         {
           id: "ssc-primate",
           name: "Primate Specialist Group",
-          filter: { csvGroups: ["mammals"], orderNames: ["primates"] },
+          filter: { taxonGroups: ["mammals"], orderNames: ["primates"] },
           // MDD's figure (522) was logically impossible — lower than our own
           // data's 527 assessed Primates rows (assessed can't exceed
           // described). Corrected to the Primate SG's own self-reported
@@ -632,14 +632,14 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-sirenia",
           name: "Sirenia Specialist Group",
-          filter: { csvGroups: ["mammals"], orderNames: ["sirenia"] },
+          filter: { taxonGroups: ["mammals"], orderNames: ["sirenia"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-sirenia-specialist-group",
         },
         {
           id: "ssc-small-carnivore",
           name: "Small Carnivore Specialist Group",
           filter: {
-            csvGroups: ["mammals"],
+            taxonGroups: ["mammals"],
             // Verified against the group's own site (smallcarnivore.org), not just
             // iucn.org: explicitly claims "red pandas, the Malagasy carnivores,
             // mongooses, skunks and stink badgers, weasels, martens and badgers,
@@ -654,13 +654,13 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-small-mammal",
           name: "Small Mammal Specialist Group",
-          filter: { csvGroups: ["mammals"], orderNames: ["rodentia", "eulipotyphla", "scandentia"] },
+          filter: { taxonGroups: ["mammals"], orderNames: ["rodentia", "eulipotyphla", "scandentia"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-small-mammal-specialist-group",
         },
         {
           id: "ssc-tapir",
           name: "Tapir Specialist Group",
-          filter: { csvGroups: ["mammals"], families: ["tapiridae"] },
+          filter: { taxonGroups: ["mammals"], families: ["tapiridae"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-tapir-specialist-group",
         },
         {
@@ -671,13 +671,13 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           // sourceUrl slug are kept for stability, same treatment as Asian
           // Wild Cattle SG above.
           name: "South American Camelid Specialist Group",
-          filter: { csvGroups: ["mammals"], genera: ["lama", "vicugna"] },
+          filter: { taxonGroups: ["mammals"], genera: ["lama", "vicugna"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-wild-camelid-specialist-group-0",
         },
         {
           id: "ssc-wild-pig",
           name: "Wild Pig Specialist Group",
-          filter: { csvGroups: ["mammals"], families: ["suidae"] },
+          filter: { taxonGroups: ["mammals"], families: ["suidae"] },
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-wild-pig-specialist-group",
         },
         // Catch-all: mammal orders/families/genera not claimed by any of the 35
@@ -693,7 +693,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-other-mammals",
           name: "No / Other SSC Group",
           filter: {
-            csvGroups: ["mammals"],
+            taxonGroups: ["mammals"],
             excludeOrders: [
               "afrosoricida", "macroscelidea", "hyracoidea", "tubulidentata",
               "pilosa", "cingulata",
@@ -740,7 +740,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
 
     // ─── SSC SPECIALIST GROUPS (reptiles) ───────────────────────────────
     // Same second lens as "ssc-groups" (mammals) above, over the "reptiles"
-    // CSV group instead. Scope for each group was sourced from its own
+    // taxon group instead. Scope for each group was sourced from its own
     // dedicated site (not just its iucn.org listing, which is often a bare
     // contact page), cross-checked against the real family/genus
     // distribution in our reptile data — see each node's comment for the
@@ -752,12 +752,12 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     {
       id: "ssc-reptile-groups",
       name: "SSC Specialist Groups",
-      filter: { csvGroups: ["reptiles"] },
+      filter: { taxonGroups: ["reptiles"] },
       children: [
         {
           id: "ssc-crocodile",
           name: "Crocodile Specialist Group",
-          filter: { csvGroups: ["reptiles"], families: ["crocodylidae", "alligatoridae", "gavialidae"] },
+          filter: { taxonGroups: ["reptiles"], families: ["crocodylidae", "alligatoridae", "gavialidae"] },
           // Own site (iucncsg.org): "There are 26 recognised species of extant
           // crocodilians... divided into three Families - Alligatoridae...
           // Crocodylidae... and Gavialidae" — all of order Crocodylia, no exceptions.
@@ -767,7 +767,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-tortoise-freshwater-turtle",
           name: "Tortoise and Freshwater Turtle Specialist Group",
           filter: {
-            csvGroups: ["reptiles"],
+            taxonGroups: ["reptiles"],
             families: [
               "geoemydidae", "testudinidae", "chelidae", "emydidae", "kinosternidae",
               "trionychidae", "pelomedusidae", "podocnemididae", "chelydridae",
@@ -785,7 +785,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-marine-turtle",
           name: "Marine Turtle Specialist Group",
-          filter: { csvGroups: ["reptiles"], families: ["cheloniidae", "dermochelyidae"] },
+          filter: { taxonGroups: ["reptiles"], families: ["cheloniidae", "dermochelyidae"] },
           // Own site (iucn-mtsg.org): "responsible for providing information on
           // the seven species of sea turtles" — Cheloniidae (6) + Dermochelyidae
           // (1, leatherback), all 7 recognized species, no exceptions.
@@ -794,7 +794,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-skink",
           name: "Skink Specialist Group",
-          filter: { csvGroups: ["reptiles"], families: ["scincidae"] },
+          filter: { taxonGroups: ["reptiles"], families: ["scincidae"] },
           // Own site (skinks.org) + SSC annual report: "aims to complete Red
           // List assessments for all skink species... 1,725 species are
           // recognised by the SSG" — whole family Scincidae, no exceptions
@@ -805,7 +805,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-chameleon",
           name: "Chameleon Specialist Group",
-          filter: { csvGroups: ["reptiles"], families: ["chamaeleonidae"] },
+          filter: { taxonGroups: ["reptiles"], families: ["chamaeleonidae"] },
           // Own site (iucnchameleons.org): "there are currently 228 species of
           // chameleon recognized by the Chameleon Specialist Group" — whole
           // family Chamaeleonidae, no carve-outs.
@@ -814,7 +814,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-monitor-lizard",
           name: "Monitor Lizard Specialist Group",
-          filter: { csvGroups: ["reptiles"], families: ["varanidae", "lanthanotidae"] },
+          filter: { taxonGroups: ["reptiles"], families: ["varanidae", "lanthanotidae"] },
           // Own site (iucn-mlsg.org): "the monotypic Lanthanotus borneensis is
           // also dealt within the IUCN SSC Monitor Lizard Specialist Group...
           // sole member of the family Lanthanotidae [Earless monitor lizards]
@@ -830,7 +830,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-iguana",
           name: "Iguana Specialist Group",
-          filter: { csvGroups: ["reptiles"], families: ["iguanidae"] },
+          filter: { taxonGroups: ["reptiles"], families: ["iguanidae"] },
           // Own site's Iguana Taxonomy Working Group checklist: "A CHECKLIST OF
           // THE IGUANAS OF THE WORLD (IGUANIDAE; IGUANINAE)" — 9 genera
           // (Amblyrhynchus, Brachylophus, Cachryx, Conolophus, Ctenosaura,
@@ -842,7 +842,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-anoline-lizard",
           name: "Anoline Lizard Specialist Group",
-          filter: { csvGroups: ["reptiles"], genera: ["anolis"] },
+          filter: { taxonGroups: ["reptiles"], genera: ["anolis"] },
           // Own site (iucn.org): mission covers "Anolis (anole) lizards...
           // across the entire distribution of Anolis" — genus-scoped, not
           // family-scoped, so filtering by genus (not family) is most
@@ -863,7 +863,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-viper",
           name: "Viper Specialist Group",
-          filter: { csvGroups: ["reptiles"], families: ["viperidae"] },
+          filter: { taxonGroups: ["reptiles"], families: ["viperidae"] },
           // No first-party page could be fetched directly (the group's own
           // domain, viperconservation.org, didn't resolve; the old Orianne
           // Society URL on file now 404s). Scope confirmed instead via the
@@ -879,7 +879,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-sea-snake",
           name: "Sea Snake Specialist Group",
           filter: {
-            csvGroups: ["reptiles"],
+            taxonGroups: ["reptiles"],
             genera: [
               // "True sea snakes" and sea kraits (Elapidae subfamily
               // Hydrophiinae, marine lineages only — NOT the many terrestrial
@@ -920,7 +920,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-gekkota",
           name: "Gekkota Lizard Specialist Group",
           filter: {
-            csvGroups: ["reptiles"],
+            taxonGroups: ["reptiles"],
             families: ["gekkonidae", "eublepharidae", "phyllodactylidae", "sphaerodactylidae", "diplodactylidae", "carphodactylidae", "pygopodidae"],
           },
           // Found missing entirely in a post-review pass — a real group
@@ -936,7 +936,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-boa-python",
           name: "Boa and Python Specialist Group",
           filter: {
-            csvGroups: ["reptiles"],
+            taxonGroups: ["reptiles"],
             families: ["boidae", "pythonidae", "erycidae", "charinaidae", "candoiidae", "sanziniidae", "ungaliophiidae"],
           },
           // LOWER CONFIDENCE than the other reptile groups here — flagging
@@ -989,7 +989,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-snake-lizard-rla",
           name: "Snake and Lizard Red List Authority",
           filter: {
-            csvGroups: ["reptiles"],
+            taxonGroups: ["reptiles"],
             excludeFamilies: [
               "crocodylidae", "alligatoridae", "gavialidae",
               "geoemydidae", "testudinidae", "chelidae", "emydidae", "kinosternidae",
@@ -1025,7 +1025,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     {
       id: "birds",
       name: "Birds",
-      filter: { csvGroups: ["birds"] },
+      filter: { taxonGroups: ["birds"] },
       estimatedDescribed: 11_185,
       estimatedSource: IUCN_SOURCE,
       estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -1041,7 +1041,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     {
       id: "reptiles",
       name: "Reptiles",
-      filter: { csvGroups: ["reptiles"] },
+      filter: { taxonGroups: ["reptiles"] },
       estimatedDescribed: 12_568,
       estimatedSource: IUCN_SOURCE,
       estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -1054,7 +1054,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     {
       id: "amphibians",
       name: "Amphibians",
-      filter: { csvGroups: ["amphibians"] },
+      filter: { taxonGroups: ["amphibians"] },
       estimatedDescribed: 9_075,
       estimatedSource: IUCN_SOURCE,
       estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -1074,7 +1074,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     {
       id: "fishes",
       name: "Fishes",
-      filter: { csvGroups: ["fishes"] },
+      filter: { taxonGroups: ["fishes"] },
       estimatedDescribed: 37_630,
       estimatedSource: IUCN_SOURCE,
       estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -1083,7 +1083,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
 
     // ─── SSC SPECIALIST GROUPS (fishes) ─────────────────────────────────
     // Same second lens as "ssc-groups"/"ssc-reptile-groups" above, over the
-    // "fishes" CSV group. Only 9 of the 10 fish/marine SSC groups are built
+    // "fishes" taxon group. Only 9 of the 10 fish/marine SSC groups are built
     // here — TWO real, named, HABITAT-based groups are DELIBERATELY EXCLUDED
     // (found via a post-review pass that the second one, MFRLA, had gone
     // undocumented despite being the same class of blocker as the first):
@@ -1112,7 +1112,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     {
       id: "ssc-fish-groups",
       name: "SSC Specialist Groups",
-      filter: { csvGroups: ["fishes"] },
+      filter: { taxonGroups: ["fishes"] },
       children: [
         {
           id: "ssc-shark",
@@ -1123,7 +1123,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           // sharks (same fix as canonicalClassColumnSql applies for the live
           // Sharks & Rays class-level bucket, taxonomy-sql.ts).
           filter: {
-            csvGroups: ["fishes"],
+            taxonGroups: ["fishes"],
             classNames: ["chondrichthyes", "elasmobranchii", "holocephali"],
             // Data-quality exclusions found in the unassessed universe: two
             // extinct Oligocene/Miocene fossil mako sharks (not extant
@@ -1139,7 +1139,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-grouper-wrasse",
           name: "Grouper and Wrasse Specialist Group",
-          filter: { csvGroups: ["fishes"], families: ["serranidae", "epinephelidae", "labridae", "scaridae"] },
+          filter: { taxonGroups: ["fishes"], families: ["serranidae", "epinephelidae", "labridae", "scaridae"] },
           // iucn.org: "The GWSG works with groupers and wrasses and their
           // relatives (Families: Epinephelidae; Serranidae; Labridae;
           // Scaridae)" — explicit, both grouper family labels (Epinephelidae
@@ -1150,7 +1150,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-snapper-seabream-grunt",
           name: "Snapper, Seabream and Grunt Specialist Group",
-          filter: { csvGroups: ["fishes"], families: ["lutjanidae", "sparidae", "haemulidae", "nemipteridae", "lethrinidae", "caesionidae"] },
+          filter: { taxonGroups: ["fishes"], families: ["lutjanidae", "sparidae", "haemulidae", "nemipteridae", "lethrinidae", "caesionidae"] },
           // Own iucn.org page names 6 families, not just the 3 in its name:
           // "snappers, seabreams, grunts, threadfin breams, emperors and
           // fusiliers" — Lutjanidae, Sparidae, Haemulidae, Nemipteridae,
@@ -1163,7 +1163,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-seahorse-pipefish-seadragon",
           name: "Seahorse, Pipefish and Seadragon Specialist Group",
           filter: {
-            csvGroups: ["fishes"],
+            taxonGroups: ["fishes"],
             families: ["syngnathidae", "solenostomidae", "aulostomidae", "fistulariidae", "centriscidae"],
           },
           // Own site (iucn-seahorse.org): "dedicated to the conservation of
@@ -1178,7 +1178,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-sciaenid",
           name: "Croaker and Drum Fishes Red List Authority",
-          filter: { csvGroups: ["fishes"], families: ["sciaenidae"] },
+          filter: { taxonGroups: ["fishes"], families: ["sciaenidae"] },
           // Renamed by IUCN to "Croaker and Drum Fishes Red List Authority"
           // (our source DB still lists the legacy name) — iucn.org: "purposes
           // include revising and submitting assessments of all 300 species of
@@ -1189,7 +1189,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-salmonid",
           name: "Salmonid Specialist Group",
-          filter: { csvGroups: ["fishes"], families: ["salmonidae"] },
+          filter: { taxonGroups: ["fishes"], families: ["salmonidae"] },
           // The group's listed dedicated site (stateofthesalmon.org) is
           // defunct (redirects to a broken tool, no scope statement) — scope
           // confirmed via iucn.org instead: covers "salmonids (fishes in the
@@ -1201,7 +1201,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-tuna-billfish",
           name: "Tuna and Billfish Specialist Group",
-          filter: { csvGroups: ["fishes"], families: ["scombridae", "istiophoridae", "xiphiidae"] },
+          filter: { taxonGroups: ["fishes"], families: ["scombridae", "istiophoridae", "xiphiidae"] },
           // No single explicit Latin-family statement found on iucn.org (thin
           // page), but the group's own activity reports state a precise,
           // self-declared total — "the first comprehensive extinction risk
@@ -1216,7 +1216,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-sturgeon",
           name: "Sturgeon Specialist Group",
-          filter: { csvGroups: ["fishes"], families: ["acipenseridae", "polyodontidae"] },
+          filter: { taxonGroups: ["fishes"], families: ["acipenseridae", "polyodontidae"] },
           // iucn.org mission: "conservation, management, recovery and
           // sustainable use of sturgeon and paddlefish populations worldwide"
           // — explicitly both families of order Acipenseriformes (Acipenseridae
@@ -1228,7 +1228,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-anguillid-eel",
           name: "Anguillid Eel Specialist Group",
-          filter: { csvGroups: ["fishes"], families: ["anguillidae"] },
+          filter: { taxonGroups: ["fishes"], families: ["anguillidae"] },
           // Organizationally independent since a 2015 IUCN-SSC Leaders' Meeting
           // decision, per its own materials: "all species within the family
           // Anguillidae" — a monogeneric family (genus Anguilla), all 16 extant
@@ -1245,7 +1245,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-other-fish",
           name: "No / Other SSC Group",
           filter: {
-            csvGroups: ["fishes"],
+            taxonGroups: ["fishes"],
             excludeClasses: ["chondrichthyes", "elasmobranchii", "holocephali"],
             excludeFamilies: [
               "serranidae", "epinephelidae", "labridae", "scaridae",
@@ -1288,10 +1288,10 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     // ─── SSC SPECIALIST GROUPS (invertebrates) ──────────────────────────
     // Same second lens as "ssc-groups"/"ssc-reptile-groups"/"ssc-fish-groups"
     // above, but architecturally different: invertebrates aren't one Table 1a
-    // CSV group, they're 15 (8 insect groups + arachnids/molluscs/
+    // taxon group, they're 15 (8 insect groups + arachnids/molluscs/
     // crustaceans/corals/other_invertebrates/velvet_worms/horseshoe_crabs),
     // so each child's filter spans however many of those its own remit
-    // touches, instead of a single shared csvGroups value.
+    // touches, instead of a single shared taxonGroups value.
     //
     // Of the 17 real invertebrate SSC/RLA groups, 3 are DELIBERATELY EXCLUDED
     // for the same reason as the fish pilot's Freshwater Fish SG: their own
@@ -1327,12 +1327,12 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     {
       id: "ssc-invertebrate-groups",
       name: "SSC Specialist Groups",
-      filter: { csvGroups: ALL_INVERTEBRATE_GROUPS },
+      filter: { taxonGroups: ALL_INVERTEBRATE_GROUPS },
       children: [
         {
           id: "ssc-mollusc",
           name: "Mollusc Specialist Group",
-          filter: { csvGroups: ["molluscs"] },
+          filter: { taxonGroups: ["molluscs"] },
           // Own materials + its own SSC annual reports list cephalopod,
           // cone-snail, and abalone assessments as the group's own achievements
           // (no separate "Cephalopod RLA"/"Cone Snail RLA" exists as its own
@@ -1349,7 +1349,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-spider-scorpion",
           name: "Spider and Scorpion Specialist Group",
-          filter: { csvGroups: ["arachnids"], orderNames: ["araneae", "scorpiones"] },
+          filter: { taxonGroups: ["arachnids"], orderNames: ["araneae", "scorpiones"] },
           // Own site's mission language aspirationally says "protect all
           // arachnids," but every concrete target in the group's own 2021
           // annual report is exclusively about spiders or scorpions (trap-door
@@ -1369,7 +1369,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-butterfly",
           name: "Butterfly and Moth Specialist Group",
           filter: {
-            csvGroups: ["butterflies_and_moths"],
+            taxonGroups: ["butterflies_and_moths"],
             families: ["papilionidae", "pieridae", "nymphalidae", "lycaenidae", "riodinidae", "hesperiidae", "hedylidae", "saturniidae"],
           },
           // RENAMED by IUCN to "Butterfly and Moth Specialist Group" (our
@@ -1377,7 +1377,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           // mission statement, unchanged since at least 2018, explicitly says
           // "butterflies and moths," which taken literally could mean all of
           // Lepidoptera (moths alone are ~145,000 of the ~160,000 species in
-          // this CSV group). The group's DEMONSTRATED work is overwhelmingly
+          // this taxon group). The group's DEMONSTRATED work is overwhelmingly
           // butterfly-focused (comprehensive Papilionidae/swallowtail
           // assessments, a broader butterfly Red List Index) plus one named
           // moth family as a starting point (Saturniidae, "e.g. emperor
@@ -1407,7 +1407,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-grasshopper",
           name: "Grasshopper Specialist Group",
           filter: {
-            csvGroups: ["grasshoppers_crickets_locusts", "other_insects"],
+            taxonGroups: ["grasshoppers_crickets_locusts", "other_insects"],
             orderNames: ["orthoptera", "phasmida", "mantodea"],
           },
           // Own iucn.org page: "Our aim is to conserve Orthopteroid insects
@@ -1416,7 +1416,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           // species on the IUCN Red List" — explicitly 3 orders, broader than
           // its name suggests (crickets/katydids are already all Orthoptera;
           // mantids/stick insects are separate orders entirely, sourced from
-          // the "other_insects" CSV group rather than "grasshoppers_crickets_
+          // the "other_insects" taxon group rather than "grasshoppers_crickets_
           // locusts"). Locusts are explicitly just a behavioral subset of
           // Acrididae (Orthoptera), not a separate taxon needing its own rule.
           // estimatedDescribed corrected — the prior figure (11,319)
@@ -1429,7 +1429,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-wild-bee",
           name: "Wild Bee Specialist Group",
           filter: {
-            csvGroups: ["bees_wasps_and_ants"],
+            taxonGroups: ["bees_wasps_and_ants"],
             families: ["apidae", "halictidae", "megachilidae", "andrenidae", "colletidae", "melittidae", "stenotritidae"],
           },
           // RENAMED by IUCN to "Wild Bee Specialist Group" (our source DB
@@ -1450,7 +1450,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-mayfly-stonefly-caddisfly",
           name: "Mayfly, Stonefly and Caddisfly Specialist Group",
-          filter: { csvGroups: ["other_insects"], orderNames: ["ephemeroptera", "plecoptera", "trichoptera"] },
+          filter: { taxonGroups: ["other_insects"], orderNames: ["ephemeroptera", "plecoptera", "trichoptera"] },
           // iucn.org: "Mayflies (Ephemeroptera), stoneflies (Plecoptera) and
           // caddisflies (Trichoptera) — EPT for short" — explicit, exactly
           // these 3 orders, no exceptions found.
@@ -1462,18 +1462,18 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-dragonfly",
           name: "Dragonfly Specialist Group",
-          filter: { csvGroups: ["dragonflies_and_damselflies"] },
+          filter: { taxonGroups: ["dragonflies_and_damselflies"] },
           // Own SSC annual report: "increase the knowledge on taxonomy,
           // ecology and biogeography of all Odonata (damselflies and
           // dragonflies)" — the entire order, both suborders (Anisoptera +
-          // Zygoptera), which is exactly this whole Table 1a CSV group (no
+          // Zygoptera), which is exactly this whole Table 1a taxon group (no
           // other order appears in our "dragonflies_and_damselflies" data).
           sourceUrl: "https://worlddragonfly.org/",
         },
         {
           id: "ssc-ant",
           name: "Ant Specialist Group",
-          filter: { csvGroups: ["bees_wasps_and_ants"], families: ["formicidae"] },
+          filter: { taxonGroups: ["bees_wasps_and_ants"], families: ["formicidae"] },
           // Own iucn.org page: "assess and monitor the conservation status of
           // ant species around the world" — family Formicidae in full, no
           // narrower carve-out found (a monotypic mapping — ants ARE
@@ -1486,7 +1486,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-freshwater-crustacean",
           name: "Freshwater Crustacean Specialist Group",
           filter: {
-            csvGroups: ["crustaceans"],
+            taxonGroups: ["crustaceans"],
             families: [
               "astacidae", "cambaridae", "parastacidae", "aeglidae",
               "potamidae", "potamonautidae", "gecarcinucidae", "pseudothelphusidae", "trichodactylidae",
@@ -1615,7 +1615,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-hoverfly",
           name: "Hoverfly Specialist Group",
-          filter: { csvGroups: ["flies_and_mosquitoes"], families: ["syrphidae"] },
+          filter: { taxonGroups: ["flies_and_mosquitoes"], families: ["syrphidae"] },
           // LOWER CONFIDENCE, flagged rather than guessed: the group's own
           // current official mission statement (identical wording on both its
           // iucn.org page and its 2024-2025 SSC annual report) explicitly
@@ -1637,7 +1637,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-coral",
           name: "Coral Specialist Group",
-          filter: { csvGroups: ["corals"], orderNames: ["scleractinia"] },
+          filter: { taxonGroups: ["corals"], orderNames: ["scleractinia"] },
           // Own site (iucncoralsg.org): "maintains and refines the IUCN Red
           // List of Threatened Species for reef-building corals" — narrower
           // than our "Corals & Cnidarians" Table 1a group, which spans all of
@@ -1652,7 +1652,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-firefly",
           name: "Firefly Specialist Group",
-          filter: { csvGroups: ["beetles"], families: ["lampyridae"] },
+          filter: { taxonGroups: ["beetles"], families: ["lampyridae"] },
           // Own site (fireflyersinternational.net/iucn): "Fireflies
           // (Coleoptera: Lampyridae)" — the whole family, no narrower
           // carve-out found.
@@ -1662,7 +1662,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-dung-beetle",
           name: "Dung Beetle Specialist Group",
           filter: {
-            csvGroups: ["beetles"],
+            taxonGroups: ["beetles"],
             // families/genera AND together in this filter engine, so the
             // whole-family Geotrupidae portion is expressed as its own
             // (complete) genus list here rather than via `families`, folded
@@ -1749,21 +1749,21 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-sea-cucumber",
           name: "Sea Cucumber Specialist Group",
-          filter: { csvGroups: ["other_invertebrates"], classNames: ["holothuroidea"] },
+          filter: { taxonGroups: ["other_invertebrates"], classNames: ["holothuroidea"] },
           // Real, active IUCN SSC group missed in the initial pass — clean
           // whole-class mapping, same pattern as Mollusc SG. Class
           // Holothuroidea (sea cucumbers) within the "other_invertebrates"
-          // Table 1a CSV group.
+          // Table 1a taxon group.
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-sea-cucumber-specialist-group",
         },
         {
           id: "ssc-horseshoe-crab",
           name: "Horseshoe Crab Specialist Group",
-          filter: { csvGroups: ["horseshoe_crabs"] },
+          filter: { taxonGroups: ["horseshoe_crabs"] },
           // Own iucn.org page names all 4 living species by name (Limulus
           // polyphemus, Tachypleus tridentatus, T. gigas, Carcinoscorpius
           // rotundicauda) — exactly this whole, already-dedicated Table 1a
-          // CSV group (horseshoe crabs are chelicerates, not true
+          // taxon group (horseshoe crabs are chelicerates, not true
           // crustaceans, despite the common name — already modeled
           // separately in this tree).
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-horseshoe-crab-specialist-group",
@@ -1771,7 +1771,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-earthworm",
           name: "Earthworm Specialist Group",
-          filter: { csvGroups: ["other_invertebrates"], orderNames: ["crassiclitellata", "moniligastrida"] },
+          filter: { taxonGroups: ["other_invertebrates"], orderNames: ["crassiclitellata", "moniligastrida"] },
           // Found missing entirely in a post-review pass — a real group
           // (thin iucn.org page, no formal scope statement, but its name
           // unambiguously maps to the 2 orders taxonomically recognized as
@@ -1787,7 +1787,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-sponge",
           name: "Sponge Specialist Group",
-          filter: { csvGroups: ["other_invertebrates"], classNames: ["demospongiae", "hexactinellida", "calcarea"] },
+          filter: { taxonGroups: ["other_invertebrates"], classNames: ["demospongiae", "hexactinellida", "calcarea"] },
           // Found missing entirely in a post-review pass — a real group
           // (2021-2025 term page, live at a "-2021-2025" URL slug the
           // dashboard's original directory-listing guess missed): mission is
@@ -1802,18 +1802,18 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         // Catch-all: a plain "No SSC Group" remainder (NOT a claim on behalf
         // of Cave Invertebrate SG, Terrestrial and Freshwater Invertebrate
         // RLA, or Marine Invertebrates RLA — see the exclusion note above).
-        // Omits csvGroups claimed in full by a named group above (molluscs,
+        // Omits taxonGroups claimed in full by a named group above (molluscs,
         // horseshoe_crabs, dragonflies_and_damselflies, and
         // grasshoppers_crickets_locusts — the last is 100% order Orthoptera,
         // all of which Grasshopper SG already claims) rather than listing
         // redundant excludes for them. Kept in sync manually — if another
         // invertebrate SSC group is added above, exclude its family/order/
-        // class here too (or omit its csvGroup entirely if fully claimed).
+        // class here too (or omit its taxonGroup entirely if fully claimed).
         {
           id: "ssc-other-invertebrates",
           name: "No / Other SSC Group",
           filter: {
-            csvGroups: [
+            taxonGroups: [
               "beetles", "butterflies_and_moths", "flies_and_mosquitoes", "bees_wasps_and_ants", "true_bugs", "other_insects",
               "arachnids", "crustaceans", "corals", "other_invertebrates", "velvet_worms",
             ],
@@ -1992,8 +1992,8 @@ export const TAXONOMY_TREE: TaxonomyNode = {
 
     // ─── SSC SPECIALIST GROUPS (plants) ─────────────────────────────────
     // Same second lens as the mammal/reptile/fish/invertebrate pilots above.
-    // Like invertebrates, plants aren't one Table 1a CSV group — this spans
-    // the 6 "plantae" CSV groups (flowering_plants, gymnosperms,
+    // Like invertebrates, plants aren't one Table 1a taxon group — this spans
+    // the 6 "plantae" taxon groups (flowering_plants, gymnosperms,
     // ferns_and_allies, mosses, green_algae, red_algae; brown_algae is
     // classified under "Fungi & Protists" in Table 1a, not plants, and none
     // of these groups' remits touch it anyway).
@@ -2012,7 +2012,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     //    growth-form category, not a clade, spanning THREE unrelated algal
     //    lineages (red algae, green algae, AND brown algae/kelp — the last
     //    of which isn't even part of this tree's "plantae" branch at all;
-    //    it's classified under the "fungi" virtual node's csvGroups, per the
+    //    it's classified under the "fungi" virtual node's taxonGroups, per the
     //    comment above). Encoding even the "safe" two-thirds (red + green
     //    algae) would still miss the group's most-emphasized taxon (kelp),
     //    misleadingly implying full coverage — worse than not building it.
@@ -2050,12 +2050,12 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     {
       id: "ssc-plant-groups",
       name: "SSC Specialist Groups",
-      filter: { csvGroups: ALL_PLANT_GROUPS },
+      filter: { taxonGroups: ALL_PLANT_GROUPS },
       children: [
         {
           id: "ssc-orchid",
           name: "Orchid Specialist Group",
-          filter: { csvGroups: ["flowering_plants"], families: ["orchidaceae"] },
+          filter: { taxonGroups: ["flowering_plants"], families: ["orchidaceae"] },
           // Own site + iucn.org: taxonomic base described consistently as
           // "Orchidaceae, one of the largest families of plants" — the whole
           // family, no exceptions found (no page states this as a formal
@@ -2069,22 +2069,22 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-bryophyte",
           name: "Bryophyte Specialist Group",
-          filter: { csvGroups: ["mosses"] },
+          filter: { taxonGroups: ["mosses"] },
           // Own founding action plan is literally titled "Mosses, Liverworts,
           // and Hornworts: Status Survey and Conservation Action Plan for
           // Bryophytes" — all 3 bryophyte divisions. Our "mosses" Table 1a
-          // CSV group already spans all 3 (8 classes: true mosses, 2
+          // taxon group already spans all 3 (8 classes: true mosses, 2
           // liverwort classes, hornworts, etc., confirmed by direct query) —
           // a trivial whole-CSV-group match, no further restriction needed.
                     // estimatedDescribed reconciled with MOSSES_NODE above — both use
-          // the identical csvGroups:["mosses"] filter and should never have
+          // the identical taxonGroups:["mosses"] filter and should never have
           // diverged.
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-bryophyte-specialist-group",
         },
         {
           id: "ssc-cactus-succulent",
           name: "Cactus and Succulent Plants Specialist Group",
-          filter: { csvGroups: ["flowering_plants"], families: ["cactaceae", "didiereaceae"] },
+          filter: { taxonGroups: ["flowering_plants"], families: ["cactaceae", "didiereaceae"] },
           // Own site (iucn-cssg.org) defines "succulent" functionally (water
           // storage in leaves/stems/roots) and explicitly names member
           // families spanning many unrelated lineages beyond Cactaceae —
@@ -2107,7 +2107,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-palm",
           name: "Palm Specialist Group",
-          filter: { csvGroups: ["flowering_plants"], families: ["arecaceae"] },
+          filter: { taxonGroups: ["flowering_plants"], families: ["arecaceae"] },
           // iucn.org: "dedicated to the conservation and sustainable use of
           // palms... assessing the conservation status of palm species
           // throughout the world" — the whole family Arecaceae, no
@@ -2123,7 +2123,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-carnivorous-plant",
           name: "Carnivorous Plant Specialist Group",
           filter: {
-            csvGroups: ["flowering_plants"],
+            taxonGroups: ["flowering_plants"],
             families: ["droseraceae", "nepenthaceae", "sarraceniaceae", "lentibulariaceae", "byblidaceae", "roridulaceae", "cephalotaceae", "drosophyllaceae"],
           },
           // Own site (cached, iucn-cpsg.org unreachable at research time) +
@@ -2141,7 +2141,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-conifer",
           name: "Conifer Specialist Group",
-          filter: { csvGroups: ["gymnosperms"], orderNames: ["pinales"] },
+          filter: { taxonGroups: ["gymnosperms"], orderNames: ["pinales"] },
           // Own dedicated site's species index (threatenedconifers.rbge.
           // ac.uk) lists species across exactly the 7 families of order
           // Pinales (Araucariaceae, Cephalotaxaceae, Cupressaceae, Pinaceae,
@@ -2157,7 +2157,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-cycad",
           name: "Cycad Specialist Group",
-          filter: { csvGroups: ["gymnosperms"], orderNames: ["cycadales"] },
+          filter: { taxonGroups: ["gymnosperms"], orderNames: ["cycadales"] },
           // Own checklist, The World List of Cycads (cycadlist.org): "10
           // accepted genera" across exactly the 2 families of order
           // Cycadales (Cycadaceae, Zamiaceae) — matches our data exactly, no
@@ -2168,7 +2168,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-seagrass",
           name: "Seagrass Species Specialist Group",
           filter: {
-            csvGroups: ["flowering_plants"],
+            taxonGroups: ["flowering_plants"],
             genera: [
               // 4 whole families (confirmed by direct query against our own
               // redlist dataset — no stray genera currently present there):
@@ -2211,7 +2211,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-other-plants",
           name: "No / Other SSC Group",
           filter: {
-            csvGroups: ["flowering_plants", "gymnosperms", "ferns_and_allies", "green_algae", "red_algae"],
+            taxonGroups: ["flowering_plants", "gymnosperms", "ferns_and_allies", "green_algae", "red_algae"],
             excludeFamilies: [
               "cactaceae", "didiereaceae",
               "droseraceae", "nepenthaceae", "sarraceniaceae", "lentibulariaceae", "byblidaceae", "roridulaceae", "cephalotaceae", "drosophyllaceae",
@@ -2238,16 +2238,16 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     // ─── SSC SPECIALIST GROUPS (fungi) ──────────────────────────────────
     // Same second lens as the mammal/reptile/fish/invertebrate/plant pilots
     // above — the final taxon in this pilot. Both of IUCN's 2 taxon-based
-    // fungal SSC groups map onto our "mushrooms" CSV group.
+    // fungal SSC groups map onto our "mushrooms" taxon group.
     {
       id: "ssc-fungi-groups",
       name: "SSC Specialist Groups",
-      filter: { csvGroups: ["mushrooms"] },
+      filter: { taxonGroups: ["mushrooms"] },
       children: [
         {
           id: "ssc-cup-fungus-truffle",
           name: "Cup-fungi, Truffles and Allies Specialist Group",
-          filter: { csvGroups: ["mushrooms"], orderNames: ["pezizales"] },
+          filter: { taxonGroups: ["mushrooms"], orderNames: ["pezizales"] },
           // RENAMED by IUCN to "Cup-fungi, Truffles and Allies Specialist
           // Group" (our source DB still lists the older singular name). Own
           // 2022 SSC report mission statement: "to promote the conservation
@@ -2264,7 +2264,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           // per species isn't possible with our data (some ascomycete
           // classes, e.g. Eurotiomycetes, contain a genuine mix of both),
           // and the full-scope reading would swallow a large fraction of
-          // the entire "mushrooms" CSV group under one group's banner —
+          // the entire "mushrooms" taxon group under one group's banner —
           // exactly the kind of overclaim this pilot has consistently
           // avoided elsewhere.
           sourceUrl: SSC_GROUP_URL_BASE + "iucn-ssc-cup-fungi-truffles-and-allies-specialist-group",
@@ -2272,7 +2272,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-chytrid-zygomycete-downy-mildew-myxomycete",
           name: "Chytrid, Zygomycete, Downy Mildew and Myxomycete Specialist Group",
-          filter: { csvGroups: ["mushrooms"], classNames: ["chytridiomycetes", "mucoromycetes", "zoopagomycetes", "oomycetes", "myxomycetes"] },
+          filter: { taxonGroups: ["mushrooms"], classNames: ["chytridiomycetes", "mucoromycetes", "zoopagomycetes", "oomycetes", "myxomycetes"] },
           // RENAMED by IUCN to "...and Myxomycete Specialist Group" ("Slime
           // Mould" → "Myxomycete"; our source DB still lists the older name).
           // Own 2024-2025 SSC report mission statement, repeated verbatim
@@ -2312,7 +2312,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-lichen",
           name: "Lichen Specialist Group",
-          filter: { csvGroups: ["mushrooms"], classNames: ["lecanoromycetes"] },
+          filter: { taxonGroups: ["mushrooms"], classNames: ["lecanoromycetes"] },
           // No explicit class-level scope statement found in the group's own
           // materials (2021 or 2024-2025 SSC annual reports, iucn.org page,
           // or its associated Red List checklist), but every named target
@@ -2336,7 +2336,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
         {
           id: "ssc-mushroom-bracket-puffball",
           name: "Mushroom, Bracket and Puffball Specialist Group",
-          filter: { csvGroups: ["mushrooms"], classNames: ["agaricomycetes"] },
+          filter: { taxonGroups: ["mushrooms"], classNames: ["agaricomycetes"] },
           // No single explicit "our scope is class X" statement found, but
           // the group's own 2024-2025 SSC report treats the two labels as
           // equivalent in its own reporting ("The 2025.1 Red List update
@@ -2353,7 +2353,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-rust-smut",
           name: "Rusts and Smuts Specialist Group",
           filter: {
-            csvGroups: ["mushrooms"],
+            taxonGroups: ["mushrooms"],
             // orderNames/classNames AND together in this filter engine, so
             // "rusts OR smuts" is expressed as one flat order list: order
             // Pucciniales (rusts) + every order actually present in our data
@@ -2406,7 +2406,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
           id: "ssc-other-fungi",
           name: "No / Other SSC Group",
           filter: {
-            csvGroups: ["mushrooms"],
+            taxonGroups: ["mushrooms"],
             // Rusts and Smuts SG is excluded by order (not class) below, on
             // purpose — it matches by order too (see its filter's comment),
             // so a species with a null order_name under Ustilaginomycetes/
@@ -2430,7 +2430,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     {
       id: "invertebrates",
       name: "Invertebrates",
-      filter: { csvGroups: ALL_INVERTEBRATE_GROUPS },
+      filter: { taxonGroups: ALL_INVERTEBRATE_GROUPS },
       estimatedDescribed: 1_457_195,
       estimatedSource: IUCN_SOURCE,
       estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -2449,7 +2449,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     {
       id: "plantae",
       name: "Plants",
-      filter: { csvGroups: ALL_PLANT_GROUPS },
+      filter: { taxonGroups: ALL_PLANT_GROUPS },
       estimatedDescribed: 424_003,
       estimatedSource: IUCN_SOURCE,
       estimatedSourceUrl: IUCN_SOURCE_URL,
@@ -2466,7 +2466,7 @@ export const TAXONOMY_TREE: TaxonomyNode = {
     {
       id: "fungi",
       name: "Fungi & Protists",
-      filter: { csvGroups: ["mushrooms", "brown_algae"] },
+      filter: { taxonGroups: ["mushrooms", "brown_algae"] },
       estimatedDescribed: 162_752,
       estimatedSource: IUCN_SOURCE,
       estimatedSourceUrl: IUCN_SOURCE_URL,

--- a/app/src/config/taxonomy-tree.ts
+++ b/app/src/config/taxonomy-tree.ts
@@ -109,7 +109,19 @@ const ALL_INSECT_GROUPS = [
 // turned out clean when checked directly) — this comment is about why they
 // never had a STATIC one, not that they're undrillable today.
 
-// All 28 Table 1a taxon groups (Insects split into 8 order-based groups)
+// All 28 Table 1a taxon groups (Insects split into 8 order-based groups).
+//
+// These are also the parquet partition values every node's `taxonGroups` draws
+// from — species/ is hive-partitioned by taxon_group, and a node's filter compiles
+// to `taxon_group IN (…)` (see taxonomy-sql). The two vocabularies coincide because
+// Table 1a is the reporting granularity the partitioning was built for; the field
+// is named taxonGroups after the COLUMN rather than after Table 1a, so it keeps
+// matching the SQL if IUCN ever restructures that table.
+//
+// Deliberately 28 of the 29 partitions on disk: `other` (~119k rows — foraminifera,
+// diatoms and the rest of the CoL universe outside the dashboard's remit) is a real
+// partition that NO node lists, so nothing reads it. That's intentional, not a gap,
+// but it does mean this is a curated subset rather than "every taxon_group value".
 export const ALL_TAXON_GROUPS = [
   "mammals", "birds", "reptiles", "amphibians", "fishes",
   ...ALL_INSECT_GROUPS,

--- a/app/src/hooks/__tests__/filterParams.test.ts
+++ b/app/src/hooks/__tests__/filterParams.test.ts
@@ -961,3 +961,73 @@ describe("OWN_PARAM_NAMES stays in sync with buildQs", () => {
     expect(missing).toEqual([]);
   });
 });
+
+describe("query-string readability (prettifyQs)", () => {
+  // Base off parseParams("") rather than a hand-written literal: it returns a
+  // complete default state by construction, so a field added to buildQs later
+  // can't make these tests fail for an unrelated reason.
+  const stateWith = (over: Record<string, unknown>) =>
+    buildQs({ ...parseParams(""), ...over } as unknown as Parameters<typeof buildQs>[0]);
+
+  // URLSearchParams form-encodes ~ : and , even though RFC 3986 allows them bare in
+  // a query. Leaving them encoded is most of why a drilled-in URL reads badly.
+  it("writes ~ : and , bare rather than percent-encoded", () => {
+    const qs = stateWith({
+      subgroups: new Set(["pl-flowering_plants~order:dioscoreales~family:dioscoreaceae"]),
+      countries: new Set(["BR", "PE"]),
+    });
+    expect(qs).toContain("taxa=flowering_plants~dioscoreales~dioscoreaceae");
+    expect(qs).toContain("countries=BR,PE");
+    expect(qs).not.toContain("%7E");
+    expect(qs).not.toContain("%3A");
+    expect(qs).not.toContain("%2C");
+  });
+
+  // The whole point is that this is cosmetic — every value must survive unchanged.
+  it.each([
+    "a+b",            // literal plus: decoding %2B would silently become a space
+    "a&b=c",          // delimiters must stay encoded
+    "Müller's shrew", // multi-byte UTF-8: per-escape decodeURIComponent would throw
+    "50–60 years",
+    "100%",
+    "a,b:c~d",
+  ])("round-trips the search value %j unchanged", (value) => {
+    const qs = stateWith({ search: value });
+    expect(new URLSearchParams(qs).get("search")).toBe(value);
+  });
+
+  it("is left alone by the browser's own URL parser", () => {
+    const qs = stateWith({
+      subgroups: new Set(["mammals~order:rodentia~family:muridae"]),
+      countries: new Set(["BR", "PE"]),
+    });
+    expect(new URL(`https://x.test/${qs}`).search).toBe(qs);
+  });
+});
+
+describe("view mode inferred from the species key", () => {
+  // A col- key is a Not Evaluated species by construction (assessed rows always key
+  // on sis-), so a link carrying one but no `view` can only have meant the NE list.
+  it("infers new-assessments from a col- species key when view is absent", () => {
+    expect(parseParams("?species=col-35VNR").viewMode).toBe("new-assessments");
+  });
+
+  it("leaves a sis- key in the assessed view", () => {
+    expect(parseParams("?species=sis-15951").viewMode).toBe("reassessments");
+  });
+
+  it("still defaults to reassessments with no species at all", () => {
+    expect(parseParams("?taxa=mammals").viewMode).toBe("reassessments");
+  });
+
+  // `view` is the list's own mode and stays authoritative — it has to work with no
+  // species selected at all, which is the common case.
+  it("lets an explicit view win over the inference", () => {
+    expect(parseParams("?species=col-35VNR&view=reassessments").viewMode).toBe("reassessments");
+    expect(parseParams("?view=new-assessments").viewMode).toBe("new-assessments");
+  });
+
+  it("does not infer from a legacy bare-number species param", () => {
+    expect(parseParams("?species=15951").viewMode).toBe("reassessments");
+  });
+});

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -6,6 +6,7 @@ import { resolveRegions } from "@/lib/regions";
 import { expandTaxaToken, collapseTaxaToTokens, getViewRootForNode, type FilterRank } from "@/lib/taxonomy-utils";
 import { ALL_HABITAT_SEASONS, ALL_HABITAT_IMPORTANCE, ALL_HABITAT_SUITABILITY } from "@/lib/habitat-filter";
 import { parseSpeciesParam } from "@/lib/species-row-key";
+import { prettifyQs } from "@/lib/query-string";
 
 // Both habitat checkbox-dropdowns (Importance, Season) default to "everything
 // checked" (nothing excluded) rather than "nothing checked" — see
@@ -384,31 +385,7 @@ export function buildQs(state: {
   return qs ? `?${qs}` : "";
 }
 
-/**
- * Undo URLSearchParams' over-encoding of characters a query string may carry bare.
- *
- * `toString()` serializes as application/x-www-form-urlencoded, which escapes
- * everything outside `*-._` and alphanumerics. RFC 3986 is looser for the query
- * component — `query = *( pchar / "/" / "?" )` where `pchar` includes `unreserved`
- * (which contains `~`), the sub-delims (which contain `,`) and `:` — so `%7E`/`%3A`/
- * `%2C` are pure noise. Turning `?taxa=pl-flowering_plants%7Eorder%3Adioscoreales`
- * into `?taxa=flowering_plants~dioscoreales` is most of why the URLs read badly.
- *
- * Deliberately a STATIC escape map, never decodeURIComponent per match: `%C3` is
- * half of a multi-byte UTF-8 sequence and decoding it alone throws URIError, so a
- * species named "Müller's shrew" would crash the URL sync. Substituting fixed
- * three-character escapes can't misfire that way.
- *
- * Only these three. `%2B` in particular must stay encoded — a bare `+` in a query
- * string means a space, so decoding it would silently corrupt any value containing
- * a literal plus. `&`, `=` and `#` are delimiters and stay encoded for the same
- * reason. Reading needs no counterpart: URLSearchParams already parses bare `~`,
- * `:` and `,` correctly, so links written before this change are unaffected.
- */
-const QS_BARE_ESCAPES: Record<string, string> = { "%7E": "~", "%3A": ":", "%2C": "," };
-const QS_BARE_ESCAPE_RE = new RegExp(Object.keys(QS_BARE_ESCAPES).join("|"), "gi");
-export const prettifyQs = (qs: string): string =>
-  qs.replace(QS_BARE_ESCAPE_RE, (m) => QS_BARE_ESCAPES[m.toUpperCase()]);
+export { prettifyQs };
 
 // Pure merge: combines this instance's (suffixed) params into whatever's
 // already present in `currentSearch`, rather than replacing the whole query

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -146,8 +146,19 @@ export function parseParams(search: string, suffix: string = "") {
     const root = getViewRootForNode(id);
     if (root) taxaSet.add(root);
   }
+  // A `col-…` species key IS a Not Evaluated species (assessed rows always key on
+  // `sis-…` — see lib/species-row-key), so a link carrying one but no `view` can only
+  // have meant the Not Evaluated list. Without this a hand-written or truncated
+  // `?species=col-…` lands in the assessed list, which never contains that row, and
+  // the panel silently never opens. `view` still wins when present, and is still
+  // required on its own — it is the list's mode, and most URLs carry no species.
+  const speciesKey = parseSpeciesParam(p.get(k("species")));
+  const impliedView: ViewMode | null = speciesKey?.startsWith("col-") ? "new-assessments" : null;
+
   return {
-    viewMode: (viewParam === "new-assessments" ? "new-assessments" : "reassessments") as ViewMode,
+    viewMode: (viewParam === "new-assessments" ? "new-assessments"
+      : viewParam ? "reassessments"
+      : impliedView ?? "reassessments") as ViewMode,
     layoutMode: (layoutParam === "table1a" || layoutParam === "ssc" || layoutParam === "country" ? layoutParam : null) as LayoutMode,
     // Remembers the layout mode a taxon drill-down exited FROM (see
     // exitCountryModeForTaxon) — survives even while layoutMode itself is
@@ -263,7 +274,7 @@ export function parseParams(search: string, suffix: string = "") {
     mapSortDirection: (p.get(k("mapdir")) === "asc" ? "asc" : "desc") as "asc" | "desc",
     // The row key, namespaced (`sis-…`/`col-…`). parseSpeciesParam also accepts the
     // pre-namespace bare-number form so existing links keep working — see its doc.
-    species: parseSpeciesParam(p.get(k("species"))),
+    species: speciesKey,
     tab: (p.get(k("tab")) || null) as "gbif" | "literature" | "redlist" | "wikipedia" | "cites" | "assessors" | "reviewers" | "col" | "eol" | null,
   };
 }
@@ -369,9 +380,35 @@ export function buildQs(state: {
   if (state.mapViewMode === "list") p.set(k("mapview"), "list");
   if (state.mapSortKey && state.mapSortKey !== "species") p.set(k("mapsort"), state.mapSortKey);
   if (state.mapSortDirection === "asc") p.set(k("mapdir"), "asc");
-  const qs = p.toString();
+  const qs = prettifyQs(p.toString());
   return qs ? `?${qs}` : "";
 }
+
+/**
+ * Undo URLSearchParams' over-encoding of characters a query string may carry bare.
+ *
+ * `toString()` serializes as application/x-www-form-urlencoded, which escapes
+ * everything outside `*-._` and alphanumerics. RFC 3986 is looser for the query
+ * component — `query = *( pchar / "/" / "?" )` where `pchar` includes `unreserved`
+ * (which contains `~`), the sub-delims (which contain `,`) and `:` — so `%7E`/`%3A`/
+ * `%2C` are pure noise. Turning `?taxa=pl-flowering_plants%7Eorder%3Adioscoreales`
+ * into `?taxa=flowering_plants~dioscoreales` is most of why the URLs read badly.
+ *
+ * Deliberately a STATIC escape map, never decodeURIComponent per match: `%C3` is
+ * half of a multi-byte UTF-8 sequence and decoding it alone throws URIError, so a
+ * species named "Müller's shrew" would crash the URL sync. Substituting fixed
+ * three-character escapes can't misfire that way.
+ *
+ * Only these three. `%2B` in particular must stay encoded — a bare `+` in a query
+ * string means a space, so decoding it would silently corrupt any value containing
+ * a literal plus. `&`, `=` and `#` are delimiters and stay encoded for the same
+ * reason. Reading needs no counterpart: URLSearchParams already parses bare `~`,
+ * `:` and `,` correctly, so links written before this change are unaffected.
+ */
+const QS_BARE_ESCAPES: Record<string, string> = { "%7E": "~", "%3A": ":", "%2C": "," };
+const QS_BARE_ESCAPE_RE = new RegExp(Object.keys(QS_BARE_ESCAPES).join("|"), "gi");
+export const prettifyQs = (qs: string): string =>
+  qs.replace(QS_BARE_ESCAPE_RE, (m) => QS_BARE_ESCAPES[m.toUpperCase()]);
 
 // Pure merge: combines this instance's (suffixed) params into whatever's
 // already present in `currentSearch`, rather than replacing the whole query
@@ -390,7 +427,7 @@ export function mergeParamsIntoSearch(
   for (const [ownKey, value] of new URLSearchParams(buildQs(newState, suffix))) {
     current.set(ownKey, value);
   }
-  const qs = current.toString();
+  const qs = prettifyQs(current.toString());
   return qs ? `?${qs}` : "";
 }
 

--- a/app/src/lib/__tests__/dashboard-url.test.ts
+++ b/app/src/lib/__tests__/dashboard-url.test.ts
@@ -25,8 +25,9 @@ describe("browseInputToDashboardQuery", () => {
     // The dashboard's parseParams expands these tokens (corals → invertebrates +
     // inv-corals) — see the round-trip below. A dynamic id (fishes' live
     // class-level drilldown — sharks-rays was retired as a static node in
-    // Phase 8) passes through the same way, unexpanded.
-    expect(params({ taxa: ["fishes~class:chondrichthyes"] }).get("taxa")).toBe("fishes~class:chondrichthyes");
+    // Phase 8) is likewise one token, emitted in the short URL form: the rank
+    // labels are recoverable from position, so they aren't written.
+    expect(params({ taxa: ["fishes~class:chondrichthyes"] }).get("taxa")).toBe("fishes~chondrichthyes");
     const p = params({ taxa: ["corals"] });
     expect(p.get("taxa")).toBe("corals");
     expect(p.has("subgroups")).toBe(false);
@@ -118,5 +119,37 @@ describe("browseInputToDashboardQuery → parseParams round-trip", () => {
     const parsed = parseParams(qs);
     expect(parsed.taxa).toEqual(new Set(["invertebrates"]));
     expect(parsed.subgroups).toEqual(new Set(["inv-corals"]));
+  });
+});
+
+describe("browseInputToDashboardQuery emits the short taxon token", () => {
+  // This is the link /browse and /api/mcp hand back to a person or an agent — the
+  // most-shared URL the app produces. resolveTaxa returns INTERNAL node ids, which
+  // spell out the pl-/inv-/fu- prefix and every rank label, so emitting them raw
+  // produced the long form the address bar no longer uses. Both still resolve; this
+  // is about the two staying in step.
+  it.each([
+    [["mammals~order:rodentia"], "mammals~rodentia"],
+    [["mammals~rodentia"], "mammals~rodentia"],
+    [["flowering_plants~dioscoreales~dioscoreaceae"], "flowering_plants~dioscoreales~dioscoreaceae"],
+    [["sharks"], "fishes~chondrichthyes"], // alias that resolves to a dynamic id
+    [["corals"], "corals"],
+  ])("%j -> taxa=%s", (taxa, expected) => {
+    expect(params({ taxa }).get("taxa")).toBe(expected);
+  });
+
+  it("writes ~ and , bare rather than percent-encoded", () => {
+    const qs = browseInputToDashboardQuery({ taxa: ["mammals~order:rodentia"], countries: ["BR", "PE"] });
+    expect(qs).toContain("taxa=mammals~rodentia");
+    expect(qs).toContain("countries=BR,PE");
+    expect(qs).not.toContain("%7E");
+    expect(qs).not.toContain("%3A");
+    expect(qs).not.toContain("%2C");
+  });
+
+  // The point of the short form is that the dashboard reads it back to the same node.
+  it("round-trips through parseParams to the internal id", () => {
+    const qs = browseInputToDashboardQuery({ taxa: ["flowering_plants~dioscoreales~dioscoreaceae"] });
+    expect([...parseParams(qs).subgroups]).toEqual(["pl-flowering_plants~order:dioscoreales~family:dioscoreaceae"]);
   });
 });

--- a/app/src/lib/__tests__/dynamic-taxon.test.ts
+++ b/app/src/lib/__tests__/dynamic-taxon.test.ts
@@ -244,6 +244,36 @@ describe("URL token round-trip for a dynamic id (deep-link support)", () => {
     expect(collapseTaxaToTokens([], ["inv-molluscs~class:gastropoda~order:"])).toEqual(["molluscs~gastropoda~"]);
   });
 
+  // Position is only an INFERENCE, and it's wrong for a link that predates a root's
+  // rank-order change: molluscs/crustaceans/other_invertebrates moved to class-first
+  // on 2026-07-22, so `molluscs~order:stylommatophora` carries an order at the
+  // position that now means class. Inferring there turned ~3,300 land snails into a
+  // classNames filter matching nothing — a shared link silently returning an empty
+  // list, the exact failure this token change is meant to be free of. An explicit
+  // label therefore wins over position.
+  it.each([
+    ["molluscs~order:stylommatophora", "inv-molluscs~order:stylommatophora"],
+    ["crustaceans~order:isopoda", "inv-crustaceans~order:isopoda"],
+    ["other_invertebrates~order:haplotaxida", "inv-other_invertebrates~order:haplotaxida"],
+    ["fishes~order:cypriniformes", "fishes~order:cypriniformes"],
+  ])("keeps the rank an explicit label states, against position: %s", (token, expected) => {
+    expect(expandTaxaToken(token).subgroup).toBe(expected);
+  });
+
+  it("keeps the label on the way back out, so re-serializing can't launder the rank", () => {
+    // Flattening this to `molluscs~stylommatophora` would read back as a CLASS.
+    const id = "inv-molluscs~order:stylommatophora";
+    const [token] = collapseTaxaToTokens([], [id]);
+    expect(token).toBe("molluscs~order:stylommatophora");
+    expect(expandTaxaToken(token).subgroup).toBe(id);
+  });
+
+  it("rejects a label that isn't a rank rather than inventing one", () => {
+    // parseDynamicNodeId returned null for an unknown rank; falling through to
+    // arbitrary-rank handling beats silently calling this an order.
+    expect(expandTaxaToken("mammals~phylum:chordata").subgroup).toBeUndefined();
+  });
+
   // Links shared before the token was shortened carry the prefix and the labels.
   it.each([
     ["pl-flowering_plants~order:dioscoreales", "plantae", "pl-flowering_plants~order:dioscoreales"],

--- a/app/src/lib/__tests__/dynamic-taxon.test.ts
+++ b/app/src/lib/__tests__/dynamic-taxon.test.ts
@@ -102,10 +102,10 @@ describe("nextDynamicRank", () => {
 });
 
 describe("dynamicNodeFilter", () => {
-  it("inherits the root's csvGroups and ANDs in each segment's rank", () => {
+  it("inherits the root's taxonGroups and ANDs in each segment's rank", () => {
     const filter = dynamicNodeFilter("mammals~order:rodentia~family:muridae");
     expect(filter).toEqual({
-      csvGroups: NODE_INDEX.get("mammals")!.filter.csvGroups,
+      taxonGroups: NODE_INDEX.get("mammals")!.filter.taxonGroups,
       orderNames: ["rodentia"],
       families: ["muridae"],
     });
@@ -118,7 +118,7 @@ describe("dynamicNodeFilter", () => {
   it("a class segment (fishes) ANDs in classNames", () => {
     const filter = dynamicNodeFilter("fishes~class:actinopterygii");
     expect(filter).toEqual({
-      csvGroups: NODE_INDEX.get("fishes")!.filter.csvGroups,
+      taxonGroups: NODE_INDEX.get("fishes")!.filter.taxonGroups,
       classNames: ["actinopterygii"],
     });
   });
@@ -152,7 +152,7 @@ describe("speciesMatchesNode with a dynamic node id", () => {
   // speciesMatchesNode used to do `if (!node) return true` for ANY id not in
   // NODE_INDEX, which — before dynamic ids existed — was a safe "don't filter"
   // default. Once dynamic ids became a real, expected input, that default would
-  // silently show every species in the csvGroup regardless of the selected
+  // silently show every species in the taxonGroup regardless of the selected
   // order/family/genus. These tests fail loudly if that regresses.
   const rodent = { taxon_group: "mammals", class_name: "mammalia", order_name: "rodentia", family: "muridae", scientific_name: "Mus musculus" };
   const bat = { taxon_group: "mammals", class_name: "mammalia", order_name: "chiroptera", family: "vespertilionidae", scientific_name: "Myotis myotis" };
@@ -168,7 +168,7 @@ describe("speciesMatchesNode with a dynamic node id", () => {
     expect(speciesMatchesNode(rodent, "mammals~order:rodentia~family:sciuridae")).toBe(false);
   });
 
-  it("still requires csvGroup membership even if rank values happen to match", () => {
+  it("still requires taxonGroup membership even if rank values happen to match", () => {
     expect(speciesMatchesNode(differentGroup, "mammals~order:rodentia")).toBe(false);
   });
 

--- a/app/src/lib/__tests__/dynamic-taxon.test.ts
+++ b/app/src/lib/__tests__/dynamic-taxon.test.ts
@@ -198,10 +198,59 @@ describe("URL token round-trip for a dynamic id (deep-link support)", () => {
     expect(expandTaxaToken(id)).toEqual({ taxa: "mammals", subgroup: id });
   });
 
-  it("collapseTaxaToTokens emits the dynamic id as its own token and drops the redundant root", () => {
-    const id = "mammals~order:rodentia";
-    const tokens = collapseTaxaToTokens(["mammals"], [id]);
-    expect(tokens).toEqual([id]);
+  it("collapseTaxaToTokens emits one token for the dynamic id and drops the redundant root", () => {
+    const tokens = collapseTaxaToTokens(["mammals"], ["mammals~order:rodentia"]);
+    expect(tokens).toEqual(["mammals~rodentia"]);
+  });
+
+  // The rank labels are redundant with position (segments are always a contiguous
+  // prefix of rankOrderFor(root) — see dynamicIdToToken), so the URL omits them.
+  it("drops the per-segment rank labels from the token", () => {
+    const [token] = collapseTaxaToTokens([], ["mammals~order:rodentia~family:muridae"]);
+    expect(token).toBe("mammals~rodentia~muridae");
+  });
+
+  it("drops the virtual-root prefix from the token and restores it on read", () => {
+    const id = "pl-flowering_plants~order:dioscoreales~family:dioscoreaceae";
+    const [token] = collapseTaxaToTokens([], [id]);
+    expect(token).toBe("flowering_plants~dioscoreales~dioscoreaceae");
+    expect(expandTaxaToken(token)).toEqual({ taxa: "plantae", subgroup: id });
+  });
+
+  // "molluscs" is BOTH the flat Table-1a clone (under `all`, not reachable in the
+  // default view) and inv-molluscs under Invertebrates. The token must resolve to
+  // the drillable one — a plain NODE_INDEX lookup would pick the clone.
+  it("resolves an ambiguous root token to the drillable node, not the Table-1a clone", () => {
+    expect(expandTaxaToken("molluscs~gastropoda")).toEqual({
+      taxa: "invertebrates", subgroup: "inv-molluscs~class:gastropoda",
+    });
+  });
+
+  // A class-first root (see ROOT_RANK_ORDER) reads its segments against a different
+  // rank sequence, which is exactly what position-only tokens depend on.
+  it("uses the root's own rank order when rebuilding a class-first token", () => {
+    expect(expandTaxaToken("fishes~teleostei~cypriniformes")).toEqual({
+      taxa: "fishes", subgroup: "fishes~class:teleostei~order:cypriniformes",
+    });
+  });
+
+  // An Unclassified bucket is an empty segment value, so it survives label removal
+  // as an empty token piece — "molluscs~gastropoda~" is Unclassified Order under
+  // Gastropoda, and must not collapse into the Gastropoda node itself.
+  it("keeps an Unclassified bucket distinct from its parent", () => {
+    expect(expandTaxaToken("molluscs~gastropoda~")).toEqual({
+      taxa: "invertebrates", subgroup: "inv-molluscs~class:gastropoda~order:",
+    });
+    expect(collapseTaxaToTokens([], ["inv-molluscs~class:gastropoda~order:"])).toEqual(["molluscs~gastropoda~"]);
+  });
+
+  // Links shared before the token was shortened carry the prefix and the labels.
+  it.each([
+    ["pl-flowering_plants~order:dioscoreales", "plantae", "pl-flowering_plants~order:dioscoreales"],
+    ["mammals~order:rodentia", "mammals", "mammals~order:rodentia"],
+    ["inv-molluscs~class:gastropoda", "invertebrates", "inv-molluscs~class:gastropoda"],
+  ])("still resolves the pre-cleanup token %s", (token, taxa, subgroup) => {
+    expect(expandTaxaToken(token)).toEqual({ taxa, subgroup });
   });
 
   it("round-trips: collapse then expand recovers the original selection", () => {
@@ -210,33 +259,33 @@ describe("URL token round-trip for a dynamic id (deep-link support)", () => {
     expect(expandTaxaToken(token)).toEqual({ taxa: "mammals", subgroup: id });
   });
 
-  // Regression: a dynamic id whose OWN root segment happens to start with one of
-  // the pl-/inv-/fu- virtual-view-group prefixes (reached by drilling into a
-  // virtual-group child like Flowering Plants, Corals, Mushrooms) used to have
-  // that prefix silently stripped by collapseTaxaToTokens' blanket
-  // stripNodePrefix(sg) call — stripNodePrefix is only correct for a STATIC id's
-  // URL-token form (inv-corals -> corals), not for a dynamic id, which round-
-  // trips through the URL as itself. That made the id unstable across any URL
-  // rewrite for an unrelated reason (e.g. toggling the Assessed/Not Evaluated
-  // view mode calls setUrlViewMode, which re-serializes the whole taxa list) —
-  // "pl-flowering_plants~order:malpighiales" silently became
-  // "flowering_plants~order:malpighiales", a DIFFERENT dynamic id as far as
-  // anything keyed on the original root string is concerned (reported: an
-  // ancestor breadcrumb row's cached data went missing after toggling view mode,
-  // since TaxaSummary.tsx's subgroupData cache was keyed by the now-stale prefixed
-  // root and never populated under the new bare one).
-  it("preserves a dynamic id's own pl-/inv-/fu- root prefix through a collapse (does not strip it like a static id's token)", () => {
-    const id = "pl-flowering_plants~order:malpighiales";
-    const tokens = collapseTaxaToTokens(["plantae"], [id]);
-    expect(tokens).toEqual([id]);
-  });
-
-  it("round-trips a prefixed-root dynamic id through repeated collapse+expand cycles unchanged (simulates toggling view mode, which re-serializes the URL)", () => {
-    const id = "pl-flowering_plants~order:malpighiales";
-    const [token1] = collapseTaxaToTokens(["plantae"], [id]);
-    const { taxa, subgroup } = expandTaxaToken(token1);
-    const [token2] = collapseTaxaToTokens([taxa], [subgroup!]);
-    expect(token2).toBe(id);
+  // Regression: a dynamic id whose OWN root segment starts with one of the
+  // pl-/inv-/fu- virtual-view-group prefixes (reached by drilling into a virtual-group
+  // child like Flowering Plants, Corals, Mushrooms) used to have that prefix stripped
+  // by collapseTaxaToTokens' blanket stripNodePrefix(sg) call, WITHOUT anything on the
+  // read side putting it back. "pl-flowering_plants~order:malpighiales" became
+  // "flowering_plants~order:malpighiales" — a different dynamic id as far as anything
+  // keyed on the root string is concerned — silently, on any URL rewrite for an
+  // unrelated reason (toggling the Assessed/Not Evaluated view mode re-serializes the
+  // whole taxa list). Reported as an ancestor breadcrumb row losing its data after a
+  // view-mode toggle, since TaxaSummary's subgroupData cache was keyed by the stale
+  // prefixed root and never populated under the new bare one.
+  //
+  // Dropping the prefix is now the DEFINED token form, with tokenToDynamicId restoring
+  // it on read, so the invariant to protect is no longer "the token equals the id" but
+  // "repeated collapse→expand cycles are stable". That's what actually broke.
+  it.each([
+    "pl-flowering_plants~order:malpighiales",
+    "inv-corals~order:scleractinia",
+    "inv-molluscs~class:gastropoda~order:",
+    "mammals~order:rodentia~family:muridae~genus:mus",
+  ])("is stable across repeated collapse+expand cycles: %s", (id) => {
+    const [token1] = collapseTaxaToTokens([], [id]);
+    const first = expandTaxaToken(token1);
+    expect(first.subgroup).toBe(id);
+    const [token2] = collapseTaxaToTokens([first.taxa], [first.subgroup!]);
+    expect(token2).toBe(token1);
+    expect(expandTaxaToken(token2).subgroup).toBe(id);
   });
 });
 

--- a/app/src/lib/__tests__/filter-vocab.test.ts
+++ b/app/src/lib/__tests__/filter-vocab.test.ts
@@ -54,6 +54,26 @@ describe("resolveTaxa", () => {
     // multi-word / punctuated values aren't taxa (species names go to `search`).
     expect(resolveTaxa(["not a taxon"]).unresolved).toEqual(["not a taxon"]);
   });
+
+  // /browse is what an agent reading /llms.txt calls, and the most natural thing to
+  // hand it is a URL copied out of the dashboard's address bar. That address bar now
+  // shows the short token form, so resolveTaxa has to accept BOTH spellings — it
+  // previously only understood the internal `rank:value` one, so a pasted dashboard
+  // URL came back unresolved with no results and no error.
+  it.each([
+    ["mammals~order:rodentia", "mammals~order:rodentia"],
+    ["mammals~rodentia", "mammals~order:rodentia"],
+    ["pl-flowering_plants~order:dioscoreales", "pl-flowering_plants~order:dioscoreales"],
+    ["flowering_plants~dioscoreales", "pl-flowering_plants~order:dioscoreales"],
+    ["fishes~teleostei~cypriniformes", "fishes~class:teleostei~order:cypriniformes"],
+    ["molluscs~gastropoda~", "inv-molluscs~class:gastropoda~order:"],
+  ])("resolves the dynamic taxon %s to %s", (input, expected) => {
+    expect(resolveTaxa([input]).ids).toEqual([expected]);
+  });
+
+  it("still rejects a ~-shaped value that names nothing", () => {
+    expect(resolveTaxa(["not~a~real~thing"]).unresolved).toEqual(["not~a~real~thing"]);
+  });
 });
 
 describe("resolveCountries", () => {

--- a/app/src/lib/__tests__/taxonomy-sql.test.ts
+++ b/app/src/lib/__tests__/taxonomy-sql.test.ts
@@ -19,13 +19,13 @@ describe("sqlStrList", () => {
 });
 
 describe("filterToSql", () => {
-  it("always scopes to csvGroups", () => {
-    const sql = filterToSql({ csvGroups: ["mammals"] });
+  it("always scopes to taxonGroups", () => {
+    const sql = filterToSql({ taxonGroups: ["mammals"] });
     expect(sql).toContain("taxon_group IN ('mammals')");
   });
 
   it("includes a class filter", () => {
-    const sql = filterToSql({ csvGroups: ["mammals"], classNames: ["mammalia"] });
+    const sql = filterToSql({ taxonGroups: ["mammals"], classNames: ["mammalia"] });
     expect(sql).toContain("coalesce(lower(class_name), '') IN ('mammalia')");
   });
 
@@ -37,7 +37,7 @@ describe("filterToSql", () => {
     // zero rows for every Fishes order once drilled past class level (regression:
     // expandClasses used to REPLACE the canonical name with its aliases instead of
     // adding to it, unlike expandOrders' equivalent split-handling below).
-    const sql = filterToSql({ csvGroups: ["fishes"], classNames: ["actinopterygii"] });
+    const sql = filterToSql({ taxonGroups: ["fishes"], classNames: ["actinopterygii"] });
     expect(sql).toContain("coalesce(lower(class_name), '') IN ('actinopterygii', 'teleostei', 'chondrostei', 'cladistii', 'holostei')");
   });
 
@@ -47,7 +47,7 @@ describe("filterToSql", () => {
     // rows (a plain "chondrichthyes" exclusion would never match anything there),
     // while still keeping "chondrichthyes" itself so an assessed.parquet-scoped
     // query (which only ever uses the coarse label) is excluded correctly too.
-    const sql = filterToSql({ csvGroups: ["fishes"], excludeClasses: ["chondrichthyes"] });
+    const sql = filterToSql({ taxonGroups: ["fishes"], excludeClasses: ["chondrichthyes"] });
     expect(sql).toContain("coalesce(lower(class_name), '') NOT IN ('chondrichthyes', 'elasmobranchii', 'holocephali')");
   });
 
@@ -57,12 +57,12 @@ describe("filterToSql", () => {
     // merger), but CoL XR still keeps "Cetacea" as its own separate, traditional
     // order label — a node filtering orderNames:["artiodactyla"] would otherwise
     // silently miss all 111 CoL-labeled cetaceans.
-    const sql = filterToSql({ csvGroups: ["mammals"], orderNames: ["artiodactyla"] });
+    const sql = filterToSql({ taxonGroups: ["mammals"], orderNames: ["artiodactyla"] });
     expect(sql).toContain("coalesce(lower(order_name), '') IN ('artiodactyla', 'cetacea')");
   });
 
   it("excludes orders, also expanding the artiodactyla/cetacea split", () => {
-    const sql = filterToSql({ csvGroups: ["mammals"], excludeOrders: ["artiodactyla"] });
+    const sql = filterToSql({ taxonGroups: ["mammals"], excludeOrders: ["artiodactyla"] });
     expect(sql).toContain("coalesce(lower(order_name), '') IN ('artiodactyla', 'cetacea')");
   });
 
@@ -70,9 +70,9 @@ describe("filterToSql", () => {
     // Verified against real data (2026-07-21): IUCN's assessed.parquet still uses
     // two old lumped bird orders, while CoL uses the finer modern splits (found
     // once Birds gained live order-level drilldown for the first time).
-    const caprimulgiformes = filterToSql({ csvGroups: ["birds"], orderNames: ["caprimulgiformes"] });
+    const caprimulgiformes = filterToSql({ taxonGroups: ["birds"], orderNames: ["caprimulgiformes"] });
     expect(caprimulgiformes).toContain("coalesce(lower(order_name), '') IN ('caprimulgiformes', 'apodiformes', 'nyctibiiformes', 'steatornithiformes')");
-    const struthioniformes = filterToSql({ csvGroups: ["birds"], orderNames: ["struthioniformes"] });
+    const struthioniformes = filterToSql({ taxonGroups: ["birds"], orderNames: ["struthioniformes"] });
     expect(struthioniformes).toContain("coalesce(lower(order_name), '') IN ('struthioniformes', 'tinamiformes', 'rheiformes', 'casuariiformes', 'apterygiformes')");
   });
 
@@ -80,18 +80,18 @@ describe("filterToSql", () => {
     // Verified against real data (2026-07-21): IUCN's assessed.parquet lumps all
     // conifers under the old "Pinales", while CoL splits Cupressaceae/Taxaceae
     // into "Cupressales" and Podocarpaceae/Araucariaceae into "Araucariales".
-    const sql = filterToSql({ csvGroups: ["gymnosperms"], orderNames: ["pinales"] });
+    const sql = filterToSql({ taxonGroups: ["gymnosperms"], orderNames: ["pinales"] });
     expect(sql).toContain("coalesce(lower(order_name), '') IN ('pinales', 'cupressales', 'araucariales')");
   });
 
   it("an order with no known CoL split is unaffected", () => {
-    const sql = filterToSql({ csvGroups: ["mammals"], orderNames: ["rodentia"] });
+    const sql = filterToSql({ taxonGroups: ["mammals"], orderNames: ["rodentia"] });
     expect(sql).toContain("coalesce(lower(order_name), '') IN ('rodentia')");
     expect(sql).not.toContain("cetacea");
   });
 
   it("falls back to class_name when order_name is empty, matching matchesFilter's GBIF-taxonomy quirk", () => {
-    const filter = { csvGroups: ["mammals"], orderNames: ["primates"] };
+    const filter = { taxonGroups: ["mammals"], orderNames: ["primates"] };
     const sql = filterToSql(filter);
     expect(sql).toContain("(coalesce(lower(order_name), '') IN ('primates') OR (coalesce(lower(order_name), '') = '' AND coalesce(lower(class_name), '') IN ('primates')))");
     // Parity check: a row with empty order_name but class_name matching the order
@@ -100,25 +100,25 @@ describe("filterToSql", () => {
   });
 
   it("derives genus from the first token of scientific_name", () => {
-    const sql = filterToSql({ csvGroups: ["mammals"], genera: ["ursus"] });
+    const sql = filterToSql({ taxonGroups: ["mammals"], genera: ["ursus"] });
     expect(sql).toContain("coalesce(lower(split_part(scientific_name, ' ', 1)), '') IN ('ursus')");
   });
 
   it("always appends the universe-wide COL_EXCLUDE_ALL_NODES exclusion", () => {
-    const sql = filterToSql({ csvGroups: ["mammals"] });
+    const sql = filterToSql({ taxonGroups: ["mammals"] });
     expect(sql).toMatch(/NOT IN \(.*\)$/);
   });
 
-  it("wraps extraSpeciesNames as an OR escape hatch, still scoped to csvGroups", () => {
-    const sql = filterToSql({ csvGroups: ["mammals"], families: ["bovidae"], extraSpeciesNames: ["antilocapra americana"] });
+  it("wraps extraSpeciesNames as an OR escape hatch, still scoped to taxonGroups", () => {
+    const sql = filterToSql({ taxonGroups: ["mammals"], families: ["bovidae"], extraSpeciesNames: ["antilocapra americana"] });
     expect(sql).toMatch(/^\(\(.*\) OR \(.*\)\)$/);
     expect(sql).toContain("antilocapra americana");
   });
 
   it("takes the CoL species-name override branch only when nodeId matches an override, mirroring matchesFilter's comment that this branch never applies to real IUCN-assessed rows", () => {
     // No override configured for an arbitrary nodeId → falls through to the normal clause.
-    const withUnknownNode = filterToSql({ csvGroups: ["mammals"], genera: ["ursus"] }, "not-a-real-node-id");
-    const withoutNode = filterToSql({ csvGroups: ["mammals"], genera: ["ursus"] });
+    const withUnknownNode = filterToSql({ taxonGroups: ["mammals"], genera: ["ursus"] }, "not-a-real-node-id");
+    const withoutNode = filterToSql({ taxonGroups: ["mammals"], genera: ["ursus"] });
     expect(withUnknownNode).toBe(withoutNode);
   });
 });

--- a/app/src/lib/__tests__/taxonomy-utils.describe-filter.test.ts
+++ b/app/src/lib/__tests__/taxonomy-utils.describe-filter.test.ts
@@ -12,20 +12,20 @@ import { describeFilter, breakdownHref } from "../taxonomy-utils";
 // includes every set dimension.
 describe("describeFilter", () => {
   it("includes every set dimension, unconditionally (no hideBreakdownRank escape hatch)", () => {
-    const segs = describeFilter({ csvGroups: ["mammals"], orderNames: ["rodentia"], families: ["heteromyidae"], genera: ["chaetodipus"] });
+    const segs = describeFilter({ taxonGroups: ["mammals"], orderNames: ["rodentia"], families: ["heteromyidae"], genera: ["chaetodipus"] });
     const text = segs.map((s) => s.text).join("");
     expect(text).toBe("Order: Rodentia; Family: Heteromyidae; Genus: Chaetodipus");
   });
 
   it("links a name resolvable in the static COL_TAXON_IDS snapshot", () => {
-    const segs = describeFilter({ csvGroups: ["fishes"], families: ["acipenseridae"] });
+    const segs = describeFilter({ taxonGroups: ["fishes"], families: ["acipenseridae"] });
     const linked = segs.find((s) => s.text === "Acipenseridae");
     expect(linked?.href).toContain("TAXON_ID=KTYZ7");
   });
 
   it("falls back to liveColIds for a name the static snapshot doesn't cover", () => {
     const segs = describeFilter(
-      { csvGroups: ["mammals"], genera: ["chaetodipus"] },
+      { taxonGroups: ["mammals"], genera: ["chaetodipus"] },
       undefined,
       { "genus:chaetodipus": "3LLS" }
     );
@@ -34,7 +34,7 @@ describe("describeFilter", () => {
   });
 
   it("leaves a name unlinked when neither the static snapshot nor liveColIds resolve it", () => {
-    const segs = describeFilter({ csvGroups: ["mammals"], genera: ["nonexistentgenusxyz"] });
+    const segs = describeFilter({ taxonGroups: ["mammals"], genera: ["nonexistentgenusxyz"] });
     const seg = segs.find((s) => s.text === "Nonexistentgenusxyz");
     expect(seg?.href).toBeUndefined();
   });

--- a/app/src/lib/dashboard-url.ts
+++ b/app/src/lib/dashboard-url.ts
@@ -30,6 +30,8 @@ import { applySharedFilters, emitSharedParams } from "@/lib/shared-filters";
 import type { SpeciesFilterCriteria } from "@/lib/species-filter";
 import { resolveTaxa, resolveCountries } from "@/lib/filter-vocab";
 import { resolveRegions } from "@/lib/regions";
+import { taxaUrlToken } from "@/lib/taxonomy-utils";
+import { prettifyQs } from "@/lib/query-string";
 
 const arr = (a?: string[]) => (a ?? []).map((s) => s.trim()).filter(Boolean);
 
@@ -47,8 +49,15 @@ export function browseInputToDashboardQuery(input: BrowseInput): string {
 
   // A single flat `taxa` token list (e.g. corals, felidae); the dashboard's
   // parseParams expands each token to its display-root + sub-group as needed.
+  //
+  // resolveTaxa returns INTERNAL node ids, which for a live-drilldown node spell out
+  // the virtual-root prefix and every rank label (`pl-flowering_plants~order:
+  // dioscoreales~family:dioscoreaceae`). Emitting those raw still resolves — the
+  // reader accepts both spellings — but this is the link /browse and /api/mcp hand
+  // back to a person or an agent, i.e. the most-shared URL the app produces, so it
+  // should be the same short form the address bar shows rather than the long one.
   const taxaIds = resolveTaxa(arr(input.taxa)).ids;
-  if (taxaIds.length) p.set("taxa", taxaIds.join(","));
+  if (taxaIds.length) p.set("taxa", taxaIds.map(taxaUrlToken).join(","));
 
   // Categorical filters (categories, threats, systems, trends, movement,
   // growthForms, endemic) — resolved + emitted by the shared registry,
@@ -79,7 +88,7 @@ export function browseInputToDashboardQuery(input: BrowseInput): string {
   if (input.minDescribedYear != null) p.set("minDescribedYear", String(input.minDescribedYear));
   if (input.maxDescribedYear != null) p.set("maxDescribedYear", String(input.maxDescribedYear));
 
-  const qs = p.toString();
+  const qs = prettifyQs(p.toString());
   return qs ? `?${qs}` : "";
 }
 

--- a/app/src/lib/data/__tests__/country-taxa-summary-duckdb.test.ts
+++ b/app/src/lib/data/__tests__/country-taxa-summary-duckdb.test.ts
@@ -56,17 +56,17 @@ describe("claimEligibleSiblingsSql", () => {
 
   it("returns null when no sibling is claim-eligible", () => {
     const children = [
-      node("a", { csvGroups: ["fishes"], families: ["labridae"] }),
-      node("catchall", { csvGroups: ["fishes"], excludeClasses: ["chondrichthyes"] }),
+      node("a", { taxonGroups: ["fishes"], families: ["labridae"] }),
+      node("catchall", { taxonGroups: ["fishes"], excludeClasses: ["chondrichthyes"] }),
     ];
     expect(claimEligibleSiblingsSql(children, 1)).toBeNull();
   });
 
   it("includes siblings scoped by classNames or orderNames", () => {
     const children = [
-      node("primates", { csvGroups: ["mammals"], orderNames: ["primates"] }),
-      node("rodents", { csvGroups: ["mammals"], classNames: ["mammalia"] }),
-      node("catchall", { csvGroups: ["mammals"], excludeClasses: [] }),
+      node("primates", { taxonGroups: ["mammals"], orderNames: ["primates"] }),
+      node("rodents", { taxonGroups: ["mammals"], classNames: ["mammalia"] }),
+      node("catchall", { taxonGroups: ["mammals"], excludeClasses: [] }),
     ];
     const sql = claimEligibleSiblingsSql(children, 2);
     expect(sql).toContain("primates");
@@ -75,16 +75,16 @@ describe("claimEligibleSiblingsSql", () => {
 
   it("excludes families/genera/speciesNames-scoped siblings from claim eligibility", () => {
     const children = [
-      node("pinnipeds", { csvGroups: ["mammals"], families: ["otariidae"] }),
-      node("catchall", { csvGroups: ["mammals"], excludeClasses: [] }),
+      node("pinnipeds", { taxonGroups: ["mammals"], families: ["otariidae"] }),
+      node("catchall", { taxonGroups: ["mammals"], excludeClasses: [] }),
     ];
     expect(claimEligibleSiblingsSql(children, 1)).toBeNull();
   });
 
   it("excludes the node at excludeIdx itself even if it would otherwise be claim-eligible", () => {
     const children = [
-      node("primates", { csvGroups: ["mammals"], orderNames: ["primates"] }),
-      node("rodents", { csvGroups: ["mammals"], orderNames: ["rodentia"] }),
+      node("primates", { taxonGroups: ["mammals"], orderNames: ["primates"] }),
+      node("rodents", { taxonGroups: ["mammals"], orderNames: ["rodentia"] }),
     ];
     const sql = claimEligibleSiblingsSql(children, 0);
     expect(sql).not.toContain("primates");

--- a/app/src/lib/data/__tests__/species-duckdb.test.ts
+++ b/app/src/lib/data/__tests__/species-duckdb.test.ts
@@ -11,13 +11,13 @@ describe("resolveWhere", () => {
     expect(resolveWhere("all")).toEqual({ clauses: [], params: {} });
   });
 
-  it("filters a taxonomy node by its csvGroups", () => {
+  it("filters a taxonomy node by its taxonGroups", () => {
     const w = resolveWhere("mammals");
     expect(w.clauses).toEqual(["taxon_group = ANY(string_split($g, '|'))"]);
     expect(w.params.g).toBe("mammals");
   });
 
-  it("expands a virtual node to all its csvGroups", () => {
+  it("expands a virtual node to all its taxonGroups", () => {
     const groups = resolveWhere("insecta").params.g.split("|");
     expect(groups).toContain("beetles");
     expect(groups).toContain("other_insects");

--- a/app/src/lib/data/species-duckdb.ts
+++ b/app/src/lib/data/species-duckdb.ts
@@ -12,7 +12,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { DuckDBInstance, type DuckDBConnection } from "@duckdb/node-api";
-import { NODE_INDEX, getCsvGroupsForNode, getAncestors, stripNodePrefix } from "@/lib/taxonomy-utils";
+import { NODE_INDEX, getTaxonGroupsForNode, getAncestors, stripNodePrefix } from "@/lib/taxonomy-utils";
 import { canonicalizeTaxonId, mapTaxonId } from "@/lib/data/taxonomy-constants";
 import { getTaxaSummary } from "@/lib/data/species-store";
 import { isDynamicNodeId, dynamicNodeFilter, buildDynamicNodeId, rankOrderFor, isLiveDrilldownNode, type DynamicSegment } from "@/lib/dynamic-taxon";
@@ -98,7 +98,7 @@ export function ensureNeHelpers(conn: DuckDBConnection): Promise<void> {
 
 // ─── Resolve a taxon identifier to a SQL predicate ──────────────────────────
 //
-// Parity with /api/redlist/species: a taxonomy node filters by its csvGroups
+// Parity with /api/redlist/species: a taxonomy node filters by its taxonGroups
 // ONLY (drill-down sub-filtering — rodents, etc. — is applied client-side). A
 // non-node identifier is the new capability: arbitrary-rank match. Values bind
 // as parameters; the '|'-joined string is split in SQL (DuckDB can't bind a raw
@@ -110,7 +110,7 @@ export function resolveWhere(taxonId: string): WhereParts {
   const id = canonicalizeTaxonId(taxonId);
   if (id === "all") return { clauses: [], params: {} };
   if (NODE_INDEX.has(id)) {
-    const groups = getCsvGroupsForNode(id);
+    const groups = getTaxonGroupsForNode(id);
     return { clauses: ["taxon_group = ANY(string_split($g, '|'))"], params: { g: groups.join("|") } };
   }
   // Dynamic (live taxonomic-drilldown) id — not in NODE_INDEX, but a real,
@@ -273,7 +273,7 @@ export async function querySpecies(opts: {
   // isn't bundled in this function, fall through to the live count below (still correct).
   if (opts.includeNE) {
     try {
-      const groups = getCsvGroupsForNode(canonicalizeTaxonId(opts.taxon));
+      const groups = getTaxonGroupsForNode(canonicalizeTaxonId(opts.taxon));
       const neEstimate = groups.reduce((sum, g) => sum + (neByGroup().get(g) ?? 0), 0);
       if (neEstimate > NE_CAP) {
         return { species: [], truncated, tooLarge: true, neTotal: neEstimate };
@@ -468,7 +468,7 @@ export function nodeIdForSpecies(taxonGroup: string, lineage: Lineage): string |
 
   // Nothing known from the top rank down. Fall back to the group's own node unless it's
   // unlistable, in which case take the deepest known rank with the gaps coalesced.
-  const rootNe = getCsvGroupsForNode(leafRoot).reduce((sum, g) => sum + (neByGroup().get(g) ?? 0), 0);
+  const rootNe = getTaxonGroupsForNode(leafRoot).reduce((sum, g) => sum + (neByGroup().get(g) ?? 0), 0);
   if (rootNe <= NE_CAP) return leafRoot;
   let deepest = -1;
   ranks.forEach((r, i) => { if (valueFor[r]) deepest = i; });
@@ -890,13 +890,13 @@ const RANK_TO_COLUMN: Record<TaxonSuggestion["rank"], string> = {
 
 // Same single-dimension-match search as GROUP_TO_LEAF_NODE above, but prefers a group's
 // "inv-"/"pl-"/"fu-"-prefixed virtual-duplicate id over its bare one when both exist for
-// the same csvGroup (insects/molluscs/crustaceans/etc. — see dynamic-taxon.ts's
+// the same taxonGroup (insects/molluscs/crustaceans/etc. — see dynamic-taxon.ts's
 // DYNAMIC_DRILLDOWN_ROOTS comment). The prefixed id is the one actually nested under
 // invertebrates/plantae/fungi in the default "By Taxon" view that TaxaSummary's
 // ancestor-breadcrumb rendering and this search feature both operate within; the bare id
 // is Table1a mode's separate flat id, whose own ancestor is "all" directly (not
 // invertebrates/plantae/fungi) — a dynamic id built off it resolves to the right species
-// (csvGroups is identical either way) but its ancestor chain doesn't match the id
+// (taxonGroups is identical either way) but its ancestor chain doesn't match the id
 // TaxaSummary's precomputed children-summaries use for that group, so the breadcrumb row
 // fails to find its own data and renders a zeroed placeholder (confirmed via a live repro:
 // searching "isopoda" showed "Crustaceans 0 assessed" instead of the real ~3,410 — the
@@ -906,10 +906,10 @@ const RANK_TO_COLUMN: Record<TaxonSuggestion["rank"], string> = {
 // where the bare Table1a id is exactly right and no breadcrumb is ever attempted.
 //
 // Unlike GROUP_TO_LEAF_NODE, this is a function (not a precomputed map): a group
-// doesn't always have its own single-csvGroup leaf node (Insects has none — its 8
+// doesn't always have its own single-taxonGroup leaf node (Insects has none — its 8
 // Table 1a groups, beetles/butterflies/etc., only ever appear together under one
-// umbrella node with csvGroups: ALL_INSECT_GROUPS; the per-order split is live-only),
-// so this also has to fall back to the smallest umbrella node whose csvGroups
+// umbrella node with taxonGroups: ALL_INSECT_GROUPS; the per-order split is live-only),
+// so this also has to fall back to the smallest umbrella node whose taxonGroups
 // includes the target group. A first-match memo (like GROUP_TO_LEAF_NODE's) would
 // silently return whichever node NODE_INDEX iteration happened to visit first — for
 // Insects that was briefly "ssc-dung-beetle" (an SSC node scoped to just Coleoptera
@@ -926,7 +926,7 @@ function findViewLeafForGroup(taxonGroup: string): string | null {
   for (const [id, node] of NODE_INDEX) {
     if (isSscGroupNode(id)) continue;
     const f = node.filter;
-    if (!f.csvGroups.includes(taxonGroup)) continue;
+    if (!f.taxonGroups.includes(taxonGroup)) continue;
     // Only a node with NO OTHER filter dimension at all qualifies — anything else is
     // a curated sub-split of the group (a static family/order node, or a Specialist
     // Group carved out some other way, e.g. by genera/speciesNames), not the group's
@@ -934,7 +934,7 @@ function findViewLeafForGroup(taxonGroup: string): string | null {
     if (f.classNames || f.orderNames || f.families || f.genera || f.excludeClasses ||
         f.excludeOrders || f.excludeFamilies || f.excludeGenera || f.speciesNames ||
         f.excludeSpeciesNames || f.extraSpeciesNames) continue;
-    const size = f.csvGroups.length;
+    const size = f.taxonGroups.length;
     const prefersOverBest = !best || size < best.size ||
       (size === best.size && stripNodePrefix(id) !== id && stripNodePrefix(best.id) === best.id);
     if (prefersOverBest) best = { id, size };
@@ -946,7 +946,7 @@ function findViewLeafForGroup(taxonGroup: string): string | null {
 
 // Resolves a suggestTaxa match to a real node: a curated by-taxon node if one matches
 // exactly (never an SSC Specialist Group node — see isSscGroupNode), else a dynamic
-// drilldown id built against the CSV group's leaf display node (its "By Taxon"-view
+// drilldown id built against the taxon group's leaf display node (its "By Taxon"-view
 // variant — see findViewLeafForGroup). A dynamic id needs every rank from the root's
 // first live-enumerable level down to the matched one, in order (e.g. Isopoda is an
 // "order" match, but Crustaceans drills class-first, so the id needs a class:<value>

--- a/app/src/lib/data/species-store.ts
+++ b/app/src/lib/data/species-store.ts
@@ -314,7 +314,7 @@ export interface AssessorCountryCandidate {
   latestDate: string;
 }
 
-/** Optional taxonomy filter (orderNames, classNames, etc.) applied on top of csvGroups */
+/** Optional taxonomy filter (orderNames, classNames, etc.) applied on top of taxonGroups */
 interface TaxonomyFilter {
   classNames?: string[];
   orderNames?: string[];

--- a/app/src/lib/data/taxonomy-constants.ts
+++ b/app/src/lib/data/taxonomy-constants.ts
@@ -33,7 +33,7 @@ export const EXCLUDED_DOMESTICATED_GBIF_KEYS = new Set([
 ]);
 
 /**
- * Maps CSV group names (IUCN Table 1a) to display taxon IDs.
+ * Maps taxon group names (IUCN Table 1a) to display taxon IDs.
  * Groups not listed here map to themselves (e.g., "mammals" → "mammals").
  */
 export const DB_GROUP_TO_TAXON_ID: Record<string, string> = {
@@ -63,7 +63,7 @@ export const DB_GROUP_TO_TAXON_ID: Record<string, string> = {
   mushrooms: "fungi",
 };
 
-/** Map a CSV group name to its display taxon ID. */
+/** Map a taxon group name to its display taxon ID. */
 export function mapTaxonId(group: string): string {
   return DB_GROUP_TO_TAXON_ID[group] ?? group;
 }

--- a/app/src/lib/dynamic-taxon.ts
+++ b/app/src/lib/dynamic-taxon.ts
@@ -110,7 +110,7 @@ export function dynamicNodeFilter(id: string): SpeciesFilter | null {
   if (!parsed) return null;
   const root = NODE_INDEX.get(parsed.rootId);
   if (!root) return null;
-  const filter: SpeciesFilter = { csvGroups: root.filter.csvGroups };
+  const filter: SpeciesFilter = { taxonGroups: root.filter.taxonGroups };
   for (const seg of parsed.segments) {
     filter[RANK_TO_FILTER_FIELD[seg.rank]] = [seg.value];
   }

--- a/app/src/lib/dynamic-taxon.ts
+++ b/app/src/lib/dynamic-taxon.ts
@@ -32,6 +32,9 @@ const RANK_TO_FILTER_FIELD: Record<DynamicRank, "classNames" | "orderNames" | "f
 };
 const ALL_RANKS = new Set<DynamicRank>(["class", "order", "family", "genus"]);
 
+/** Is this string one of the four drillable ranks? */
+export const isDynamicRank = (s: string): s is DynamicRank => ALL_RANKS.has(s as DynamicRank);
+
 // Every root drills order -> family -> genus by default. Fishes was the first
 // exception: its static tree already split at CLASS first (Ray-finned vs.
 // Lobe-finned vs. Sharks & Rays — Actinopterygii/Sarcopterygii/Chondrichthyes),

--- a/app/src/lib/filter-vocab.ts
+++ b/app/src/lib/filter-vocab.ts
@@ -8,7 +8,7 @@
  */
 
 import { CATEGORY_NAMES } from "@/config/taxa";
-import { findNode } from "@/lib/taxonomy-utils";
+import { findNode, tokenToDynamicId } from "@/lib/taxonomy-utils";
 import { canonicalizeTaxonId } from "@/lib/data/taxonomy-constants";
 import { resolveCountryToAlpha2, ALPHA2_TO_NAME } from "@/lib/countries";
 import { isDynamicNodeId, dynamicNodeFilter, dynamicNodeDisplayName } from "@/lib/dynamic-taxon";
@@ -227,7 +227,16 @@ export function resolveTaxa(values: string[]): { ids: string[]; unresolved: stri
   const toNode = (c: string): string | null => {
     const canon = canonicalizeTaxonId(c.toLowerCase());
     if (findNode(canon)) return canon;
-    if (isDynamicNodeId(canon) && dynamicNodeFilter(canon)) return canon;
+    if (isDynamicNodeId(canon)) {
+      // Two spellings reach here. The internal id (`mammals~order:rodentia`) is what
+      // dynamicNodeFilter understands directly. The URL token (`mammals~rodentia`) is
+      // what the dashboard's address bar actually shows, so it's what anyone — or any
+      // agent reading /llms.txt — will paste into /browse; it has to resolve to the
+      // same node rather than falling through to "unresolved".
+      if (dynamicNodeFilter(canon)) return canon;
+      const fromToken = tokenToDynamicId(canon);
+      if (fromToken && dynamicNodeFilter(fromToken)) return fromToken;
+    }
     return null;
   };
   for (const raw of values) {

--- a/app/src/lib/gbif.ts
+++ b/app/src/lib/gbif.ts
@@ -102,7 +102,7 @@ export function kingdomCountsPreservedSpecimens(colKingdomKey: string): boolean 
 }
 
 /**
- * The same rule expressed over a Table 1a CSV group (`flowering_plants`,
+ * The same rule expressed over a Table 1a taxon group (`flowering_plants`,
  * `mushrooms`…) or a dashboard taxon id (`plantae`), for the runtime, which
  * knows a species' group rather than its kingdom. Kept in step with
  * kingdomCountsPreservedSpecimens by a test over every group.

--- a/app/src/lib/query-string.ts
+++ b/app/src/lib/query-string.ts
@@ -1,0 +1,30 @@
+/**
+ * Undo URLSearchParams' over-encoding of characters a query string may carry bare.
+ *
+ * `toString()` serializes as application/x-www-form-urlencoded, which escapes
+ * everything outside `*-._` and alphanumerics. RFC 3986 is looser for the query
+ * component — `query = *( pchar / "/" / "?" )` where `pchar` includes `unreserved`
+ * (which contains `~`), the sub-delims (which contain `,`) and `:` — so `%7E`/`%3A`/
+ * `%2C` are pure noise. Turning `?taxa=pl-flowering_plants%7Eorder%3Adioscoreales`
+ * into `?taxa=flowering_plants~dioscoreales` is most of why the URLs read badly.
+ *
+ * Deliberately a STATIC escape map, never decodeURIComponent per match: `%C3` is
+ * half of a multi-byte UTF-8 sequence and decoding it alone throws URIError, so a
+ * species named "Müller's shrew" would crash the URL sync. Substituting fixed
+ * three-character escapes can't misfire that way.
+ *
+ * Only these three. `%2B` in particular must stay encoded — a bare `+` in a query
+ * string means a space, so decoding it would silently corrupt any value containing
+ * a literal plus. `&`, `=` and `#` are delimiters and stay encoded for the same
+ * reason. Reading needs no counterpart: URLSearchParams already parses bare `~`,
+ * `:` and `,` correctly, so links written before this change are unaffected.
+ *
+ * Lives here rather than in useFilterParams because that file is "use client" and
+ * the server-side dashboard-link builder (dashboard-url, behind /browse and
+ * /api/mcp) needs it too.
+ */
+const QS_BARE_ESCAPES: Record<string, string> = { "%7E": "~", "%3A": ":", "%2C": "," };
+const QS_BARE_ESCAPE_RE = new RegExp(Object.keys(QS_BARE_ESCAPES).join("|"), "gi");
+
+export const prettifyQs = (qs: string): string =>
+  qs.replace(QS_BARE_ESCAPE_RE, (m) => QS_BARE_ESCAPES[m.toUpperCase()]);

--- a/app/src/lib/taxonomy-sql.ts
+++ b/app/src/lib/taxonomy-sql.ts
@@ -248,13 +248,13 @@ export function sqlStrList(vals: string[]): string {
 export function filterToSql(filter: NodeFilter, nodeId?: string): string {
   const sciName = "coalesce(lower(scientific_name), '')";
   if (nodeId && COL_SPECIES_NAME_OVERRIDES[nodeId]) {
-    return `taxon_group IN (${sqlStrList(filter.csvGroups)}) AND ${sciName} IN (${sqlStrList(COL_SPECIES_NAME_OVERRIDES[nodeId])})`;
+    return `taxon_group IN (${sqlStrList(filter.taxonGroups)}) AND ${sciName} IN (${sqlStrList(COL_SPECIES_NAME_OVERRIDES[nodeId])})`;
   }
   const cls = "coalesce(lower(class_name), '')";
   const ord = "coalesce(lower(order_name), '')";
   const fam = "coalesce(lower(family), '')";
   const genus = "coalesce(lower(split_part(scientific_name, ' ', 1)), '')";
-  const conds: string[] = [`taxon_group IN (${sqlStrList(filter.csvGroups)})`];
+  const conds: string[] = [`taxon_group IN (${sqlStrList(filter.taxonGroups)})`];
   if (filter.classNames?.length) conds.push(`${cls} IN (${sqlStrList(expandClasses(filter.classNames))})`);
   if (filter.excludeClasses?.length) conds.push(`${cls} NOT IN (${sqlStrList(expandClasses(filter.excludeClasses))})`);
   if (filter.orderNames?.length) {
@@ -281,9 +281,9 @@ export function filterToSql(filter: NodeFilter, nodeId?: string): string {
   const normalClause = conds.join(" AND ");
   // extraSpeciesNames: mirrors matchesFilter's OR escape hatch (taxonomy-utils.ts) —
   // species included regardless of the class/order/family/genus rule above. Still
-  // scoped to this node's csvGroups and the universe-wide exclusions.
+  // scoped to this node's taxonGroups and the universe-wide exclusions.
   if (filter.extraSpeciesNames?.length) {
-    const extraClause = `taxon_group IN (${sqlStrList(filter.csvGroups)}) AND ${sciName} IN (${sqlStrList(filter.extraSpeciesNames)}) AND ${sciName} NOT IN (${sqlStrList(COL_EXCLUDE_ALL_NODES)})`;
+    const extraClause = `taxon_group IN (${sqlStrList(filter.taxonGroups)}) AND ${sciName} IN (${sqlStrList(filter.extraSpeciesNames)}) AND ${sciName} NOT IN (${sqlStrList(COL_EXCLUDE_ALL_NODES)})`;
     return `((${normalClause}) OR (${extraClause}))`;
   }
   return normalClause;

--- a/app/src/lib/taxonomy-utils.ts
+++ b/app/src/lib/taxonomy-utils.ts
@@ -18,7 +18,8 @@ import COL_RELEASE from "@/config/col-release.json";
 // actually runs, both modules have finished initializing.
 import {
   dynamicNodeFilter, isDynamicNodeId, dynamicNodeAncestors,
-  rankOrderFor, parseDynamicNodeId, buildDynamicNodeId,
+  rankOrderFor, parseDynamicNodeId, buildDynamicNodeId, isDynamicRank,
+  type DynamicSegment,
 } from "@/lib/dynamic-taxon";
 
 // ─── Indexes (built once at import) ──────────────────────────────────
@@ -246,7 +247,17 @@ function resolveRootToken(rootToken: string): string | null {
 export function dynamicIdToToken(id: string): string {
   const parsed = parseDynamicNodeId(id);
   if (!parsed) return id;
-  return [stripNodePrefix(parsed.rootId), ...parsed.segments.map((s) => s.value)].join("~");
+  const ranks = rankOrderFor(parsed.rootId);
+  // Position expresses the rank for every id the UI builds. It can't for an id whose
+  // rank doesn't match its position, which a link predating a root's rank-order change
+  // can be (molluscs/crustaceans/other_invertebrates moved to class-first on
+  // 2026-07-22, so `molluscs~order:stylommatophora` has an order at position 0 where
+  // the root now starts at class). Those keep an explicit label rather than being
+  // flattened into a position that would say something else — otherwise re-serializing
+  // such a URL would launder a still-valid order filter into a class filter matching
+  // nothing.
+  const parts = parsed.segments.map((s, i) => (s.rank === ranks[i] ? s.value : `${s.rank}:${s.value}`));
+  return [stripNodePrefix(parsed.rootId), ...parts].join("~");
 }
 
 /**
@@ -255,8 +266,19 @@ export function dynamicIdToToken(id: string): string {
  * treating the token as-is rather than inventing a node.
  *
  * Also accepts the pre-cleanup labelled form (`pl-flowering_plants~order:dioscoreales`)
- * so links shared before this change keep resolving: the label is redundant with
- * position, so it's stripped and position wins.
+ * so links shared before this change keep resolving.
+ *
+ * An explicit label WINS over position when present. Position is only an inference,
+ * and it's wrong for a link that predates a root's rank-order change: molluscs,
+ * crustaceans and other_invertebrates moved to class-first on 2026-07-22, so
+ * `molluscs~order:stylommatophora` carries an order at the position that now means
+ * class. Inferring there would silently turn ~3,300 land snails into a classNames
+ * filter matching nothing — a shared link that quietly returns an empty list, which
+ * is exactly the failure this token change is supposed to be free of.
+ *
+ * A label that isn't one of the four ranks rejects the whole token, matching what
+ * parseDynamicNodeId did before: better to fall through to arbitrary-rank handling
+ * than to invent a rank for it.
  */
 export function tokenToDynamicId(token: string): string | null {
   if (!isDynamicNodeId(token)) return null;
@@ -265,10 +287,17 @@ export function tokenToDynamicId(token: string): string | null {
   if (!rootId) return null;
   const ranks = rankOrderFor(rootId);
   if (rest.length > ranks.length) return null;
-  const segments = rest.map((part, i) => {
+  const segments: DynamicSegment[] = [];
+  for (const [i, part] of rest.entries()) {
     const idx = part.indexOf(":");
-    return { rank: ranks[i], value: idx === -1 ? part : part.slice(idx + 1) };
-  });
+    if (idx === -1) {
+      segments.push({ rank: ranks[i], value: part });
+      continue;
+    }
+    const label = part.slice(0, idx);
+    if (!isDynamicRank(label)) return null;
+    segments.push({ rank: label, value: part.slice(idx + 1) });
+  }
   return buildDynamicNodeId(rootId, segments);
 }
 

--- a/app/src/lib/taxonomy-utils.ts
+++ b/app/src/lib/taxonomy-utils.ts
@@ -83,7 +83,7 @@ const DEFAULT_VIEW_ROOTS = new Set(TAXONOMY_VIEWS.default.roots);
 // (the Table 1a PDF) rather than a third-party citation (MDD, Reptile Database,
 // AmphibiaWeb, Eschmeyer, Zhang 2011, …) or a hand-typed approximation (the SSC
 // pilot groups). That's exactly the 8 default-view summary taxa plus Table 1a's own
-// 21 rows (28 CSV groups, with "insects" as one row) — every node one level deeper
+// 21 rows (28 taxon groups, with "insects" as one row) — every node one level deeper
 // (Rodents, Bats, Beetles, every SSC group, …) cites something else, which — unlike
 // the CoL-derived colDescribed figure — never gets automatically re-verified as the
 // underlying species data changes. Used to pick the "# Described" default per row:
@@ -342,14 +342,14 @@ export function collapseTaxaToTokens(taxa: Iterable<string>, subgroups: Iterable
   return [...tokens];
 }
 
-// ─── CSV group resolution ────────────────────────────────────────────
+// ─── taxon group resolution ────────────────────────────────────────────
 
-/** Get the CSV groups needed to load data for a node. */
-export function getCsvGroupsForNode(nodeId: string): string[] {
+/** Get the taxon groups needed to load data for a node. */
+export function getTaxonGroupsForNode(nodeId: string): string[] {
   const id = canonicalizeTaxonId(nodeId); // map legacy IDs (e.g. mammalia → mammals)
   const node = NODE_INDEX.get(id);
-  if (!node) return [id]; // Fallback: treat as CSV group name
-  return node.filter.csvGroups;
+  if (!node) return [id]; // Fallback: treat as taxon group name
+  return node.filter.taxonGroups;
 }
 
 // ─── Filter matching ─────────────────────────────────────────────────
@@ -359,7 +359,7 @@ export function getCsvGroupsForNode(nodeId: string): string[] {
  *
  * Works both server-side (with RedlistRow/GbifRow) and client-side
  * (with SpeciesRow). Caller must ensure the row comes from one of
- * the filter's csvGroups.
+ * the filter's taxonGroups.
  *
  * Falls back to class_name when order_name is empty (GBIF taxonomy quirk).
  */
@@ -445,7 +445,7 @@ export function matchesFilter(
  * Client-side filter: does a species row match a taxonomy node?
  *
  * Replaces the old `speciesMatchesSubgroup`. Uses the same filter logic
- * but checks CSV group membership first.
+ * but checks taxon group membership first.
  */
 export function speciesMatchesNode(
   species: { taxon_group: string; class_name: string | null; order_name: string | null; family?: string | null; scientific_name?: string | null },
@@ -455,12 +455,12 @@ export function speciesMatchesNode(
   if (!node) {
     // Dynamic (live taxonomic-drilldown) node — not a static tree entry, but a
     // real, filterable rank chain (see dynamic-taxon.ts). Falling through to
-    // "don't filter" here would show every species in the csvGroup regardless
+    // "don't filter" here would show every species in the taxonGroup regardless
     // of the selected order/family/genus — a serious correctness bug, not a
     // graceful degradation, so this is resolved explicitly rather than assumed.
     const dynFilter = dynamicNodeFilter(nodeId);
     if (dynFilter) {
-      if (!dynFilter.csvGroups.includes(species.taxon_group)) return false;
+      if (!dynFilter.taxonGroups.includes(species.taxon_group)) return false;
       return matchesFilter(species, dynFilter);
     }
     return true; // Genuinely unknown, non-dynamic id → don't filter
@@ -468,8 +468,8 @@ export function speciesMatchesNode(
 
   const f = node.filter;
 
-  // Must belong to one of the filter's CSV groups
-  if (!f.csvGroups.includes(species.taxon_group)) return false;
+  // Must belong to one of the filter's taxon groups
+  if (!f.taxonGroups.includes(species.taxon_group)) return false;
 
   // Mirrors filterToSql's COL_SPECIES_NAME_OVERRIDES branch (build-taxa-summary.ts):
   // CoL lumps genus Bison into Bos, so a CoL-sourced row (NE species, named "Bos

--- a/app/src/lib/taxonomy-utils.ts
+++ b/app/src/lib/taxonomy-utils.ts
@@ -16,7 +16,10 @@ import COL_RELEASE from "@/config/col-release.json";
 // circular import, but a safe one: both sides only reference the other inside
 // function bodies (never at module-eval time), so by the time either function
 // actually runs, both modules have finished initializing.
-import { dynamicNodeFilter, isDynamicNodeId, dynamicNodeAncestors } from "@/lib/dynamic-taxon";
+import {
+  dynamicNodeFilter, isDynamicNodeId, dynamicNodeAncestors,
+  rankOrderFor, parseDynamicNodeId, buildDynamicNodeId,
+} from "@/lib/dynamic-taxon";
 
 // ─── Indexes (built once at import) ──────────────────────────────────
 
@@ -202,6 +205,83 @@ for (const id of NODE_INDEX.keys()) {
 }
 
 /**
+ * Resolve the first "~"-separated piece of a dynamic token back to a real node id.
+ *
+ * Deliberately mirrors expandTaxaToken's own resolution order rather than hitting
+ * NODE_INDEX first: `molluscs` exists BOTH as the flat Table-1a clone (under `all`,
+ * not reachable in the default view) and as `inv-molluscs` under Invertebrates.
+ * DEFAULT_VIEW_TOKEN_INDEX excludes the clone, so going through it is what picks
+ * the drillable one — a direct NODE_INDEX lookup would silently pick the clone.
+ */
+function resolveRootToken(rootToken: string): string | null {
+  const id = canonicalizeTaxonId(rootToken.trim());
+  if (DEFAULT_VIEW_ROOTS.has(id)) return id;
+  const viaToken = DEFAULT_VIEW_TOKEN_INDEX.get(id) ?? DEFAULT_VIEW_TOKEN_INDEX.get(stripNodePrefix(id));
+  if (viaToken) return viaToken;
+  return NODE_INDEX.has(id) ? id : null; // explicitly-prefixed legacy token
+}
+
+/**
+ * URL form of a dynamic (live taxonomic-drilldown) node id.
+ *
+ * The internal id spells out everything —
+ * `pl-flowering_plants~order:dioscoreales~family:dioscoreaceae` — but two thirds of
+ * that is recoverable rather than carried:
+ *
+ *   - The `pl-`/`inv-`/`fu-` prefix marks the virtual view group the root was cloned
+ *     into. A STATIC token already drops it and resolves back through
+ *     DEFAULT_VIEW_TOKEN_INDEX (`flowering_plants` → `pl-flowering_plants`); a dynamic
+ *     one can use the identical path for its root piece.
+ *   - The `order:`/`family:` labels are fixed by POSITION. Segments are always a
+ *     contiguous prefix of rankOrderFor(root) and never sparse — nodeIdForSpecies
+ *     fills a lineage gap with "" rather than skipping the rank, precisely because
+ *     "dynamicNodeAncestors/nextDynamicRank read depth positionally" (see its
+ *     comment). So segment i is rankOrderFor(root)[i], always.
+ *
+ * What's left is the root token and the bare values:
+ * `flowering_plants~dioscoreales~dioscoreaceae`. An empty value stays an empty
+ * segment, so the Unclassified buckets remain expressible (`molluscs~gastropoda~`
+ * is Unclassified Order under Gastropoda).
+ */
+export function dynamicIdToToken(id: string): string {
+  const parsed = parseDynamicNodeId(id);
+  if (!parsed) return id;
+  return [stripNodePrefix(parsed.rootId), ...parsed.segments.map((s) => s.value)].join("~");
+}
+
+/**
+ * Inverse of dynamicIdToToken. Null when the root piece names nothing, or when the
+ * token is deeper than the root's rank order — either way the caller falls back to
+ * treating the token as-is rather than inventing a node.
+ *
+ * Also accepts the pre-cleanup labelled form (`pl-flowering_plants~order:dioscoreales`)
+ * so links shared before this change keep resolving: the label is redundant with
+ * position, so it's stripped and position wins.
+ */
+export function tokenToDynamicId(token: string): string | null {
+  if (!isDynamicNodeId(token)) return null;
+  const [rootToken, ...rest] = token.split("~");
+  const rootId = resolveRootToken(rootToken);
+  if (!rootId) return null;
+  const ranks = rankOrderFor(rootId);
+  if (rest.length > ranks.length) return null;
+  const segments = rest.map((part, i) => {
+    const idx = part.indexOf(":");
+    return { rank: ranks[i], value: idx === -1 ? part : part.slice(idx + 1) };
+  });
+  return buildDynamicNodeId(rootId, segments);
+}
+
+/**
+ * The `taxa=` URL token for any node id, static or dynamic — the single place that
+ * knows which of the two token forms applies. Callers building a URL by hand (e.g.
+ * TaxaSummary's popover hrefs) must use this rather than stripNodePrefix, which is
+ * only correct for a static id and mangles a dynamic one.
+ */
+export const taxaUrlToken = (nodeId: string): string =>
+  isDynamicNodeId(nodeId) ? dynamicIdToToken(nodeId) : stripNodePrefix(nodeId);
+
+/**
  * Expand one flat URL token into the internal selection it represents:
  * `{ taxa }` for a display root or an arbitrary scientific rank, or
  * `{ taxa, subgroup }` for a default-view sub-group (corals → invertebrates +
@@ -210,13 +290,14 @@ for (const id of NODE_INDEX.keys()) {
 export function expandTaxaToken(token: string): { taxa: string; subgroup?: string } {
   const id = canonicalizeTaxonId(token.trim());
   if (DEFAULT_VIEW_ROOTS.has(id)) return { taxa: id };
-  // A dynamic (live taxonomic-drilldown) id round-trips through the URL as
-  // itself — no DEFAULT_VIEW_TOKEN_INDEX lookup needed, since its root is
-  // always its own first "~"-separated segment (see dynamic-taxon.ts), and
-  // getViewRootForNode already resolves it correctly via getAncestors.
+  // A dynamic (live taxonomic-drilldown) token carries its root as its own first
+  // "~"-separated piece, so it needs no DEFAULT_VIEW_TOKEN_INDEX lookup for the
+  // WHOLE token — but the root piece itself does (see dynamicIdToToken), which is
+  // what tokenToDynamicId rebuilds before getViewRootForNode resolves the ancestry.
   if (isDynamicNodeId(id)) {
-    const root = getViewRootForNode(id);
-    if (root) return { taxa: root, subgroup: id };
+    const dynamicId = tokenToDynamicId(id) ?? id;
+    const root = getViewRootForNode(dynamicId);
+    if (root) return { taxa: root, subgroup: dynamicId };
   }
   const nodeId = DEFAULT_VIEW_TOKEN_INDEX.get(id) ?? DEFAULT_VIEW_TOKEN_INDEX.get(stripNodePrefix(id));
   if (nodeId) {
@@ -235,21 +316,22 @@ export function collapseTaxaToTokens(taxa: Iterable<string>, subgroups: Iterable
   const tokens = new Set<string>();
   const rootsWithSubgroup = new Set<string>();
   for (const sg of subgroups) {
-    // A dynamic id round-trips through the URL as itself (see expandTaxaToken's own
-    // comment) — stripNodePrefix is only correct for a STATIC node id's token form
-    // (inv-corals -> corals). Applying it unconditionally here was a real bug: a
-    // dynamic id whose OWN root segment happens to start with one of these same
-    // three letters (e.g. "pl-flowering_plants~order:malpighiales", reached by
-    // drilling into a virtual-view-group child like Flowering Plants) had its
-    // prefix silently stripped too, rewriting it to a DIFFERENT dynamic id
-    // ("flowering_plants~order:malpighiales" — a different root identity as far as
-    // isDynamicNodeId/DYNAMIC_DRILLDOWN_ROOTS-based lookups are concerned) every
-    // time the URL was rewritten for an unrelated reason (e.g. toggling the
-    // Assessed/Not Evaluated view mode). TaxaSummary.tsx's subgroupData cache is
-    // keyed by whichever root string first populated it, so this second, bare-
-    // rooted id was a fresh cache miss — its ancestor row silently fell back to a
-    // zeroed placeholder instead of the already-fetched real data.
-    tokens.add(isDynamicNodeId(sg) ? sg : stripNodePrefix(sg));
+    // Both branches drop the pl-/inv-/fu- prefix, but they are NOT interchangeable:
+    // a static id's token is just the bare id, while a dynamic id's token also drops
+    // its per-segment rank labels (see dynamicIdToToken). Applying the static form
+    // blanket-style to a dynamic id was a real bug: "pl-flowering_plants~order:
+    // malpighiales" became "flowering_plants~order:malpighiales", which round-tripped
+    // back as a DIFFERENT dynamic id (a bare root where the prefixed one was meant),
+    // silently, on any URL rewrite — e.g. toggling the Assessed/Not Evaluated view
+    // mode re-serializes the whole taxa list. TaxaSummary's subgroupData cache is
+    // keyed by whichever root string first populated it, so the bare-rooted id was a
+    // fresh miss and its ancestor row fell back to a zeroed placeholder.
+    //
+    // That specific rewrite is now the DEFINED token form rather than an accident, so
+    // the invariant that matters is the round-trip: collapse→expand→collapse must be
+    // stable, which tokenToDynamicId restores the prefix to satisfy. Covered by the
+    // repeated-cycle test in dynamic-taxon.test.ts.
+    tokens.add(taxaUrlToken(sg));
     const root = getViewRootForNode(sg);
     if (root) rootsWithSubgroup.add(root);
   }


### PR DESCRIPTION
## Summary

A drilled-in URL read like this:

```
?taxa=pl-flowering_plants%7Eorder%3Adioscoreales%7Efamily%3Adioscoreaceae&species=col-6CX6F
```

Three things made it that long, and each was carrying information recoverable elsewhere.

```
before   ?taxa=pl-flowering_plants%7Eorder%3Adioscoreales%7Efamily%3Adioscoreaceae
after    ?taxa=flowering_plants~dioscoreales~dioscoreaceae

before   ?taxa=mammals%7Eorder%3Arodentia&countries=BR%2CPE
after    ?taxa=mammals~rodentia&countries=BR,PE
```

Alongside that, two real silent-failure bugs are fixed — one that existed before this branch, one this branch introduced and a review pass caught. Both are described below rather than buried.

### 1. The percent-encoding was gratuitous

`URLSearchParams.toString()` serializes as `application/x-www-form-urlencoded`, which escapes everything outside `*-._`. RFC 3986's query component is looser — `query = *( pchar / "/" / "?" )`, where `pchar` includes `unreserved` (containing `~`), the sub-delims (containing `,`) and `:`. So `%7E`, `%3A` and `%2C` were noise.

`prettifyQs` substitutes them back via a **static escape map**, never `decodeURIComponent` per match: `%C3` is half of a multi-byte UTF-8 sequence and decoding it alone throws `URIError`, which would have crashed the URL sync on a species like *Müller's shrew*. `%2B` deliberately stays encoded — a bare `+` in a query means a space, so decoding it would silently corrupt any value with a literal plus. `&`, `=` and `#` stay encoded for the same reason.

Reading needs no counterpart: `URLSearchParams` already parses bare `~`, `:` and `,`.

It lives in `lib/query-string.ts` rather than `useFilterParams`, which is `"use client"` and therefore unusable from the server-side link builder in §5.

### 2. The rank labels are usually implied by position — but not always

For every id the UI builds, segments are a positional prefix of `rankOrderFor(root)`. Gaps occur but are position-preserving: `nodeIdForSpecies` fills a missing lineage rank with `""` rather than skipping it, precisely because *"dynamicNodeAncestors/nextDynamicRank read depth positionally"* (its own comment). So `order:`/`family:` restate what position already says, and are dropped.

**Position is only an inference, though, and it is wrong for a link that predates a root's rank-order change.** Molluscs, crustaceans and other invertebrates moved to class-first on 2026-07-22, so a URL shared before then carries an order at the position that now means class:

```
?taxa=molluscs~order:stylommatophora
  before this branch   orderNames:["stylommatophora"]   ~3,300 land snails
  first draft of it    classNames:["stylommatophora"]   0 species, silently
  now                  orderNames:["stylommatophora"]   correct
```

So **an explicit label wins over position**, and `dynamicIdToToken` keeps a label for any segment whose rank differs from its positional rank — otherwise re-serializing such a URL would launder a valid order filter into a class filter matching nothing, and `/browse` would hand back a fresh link with the wrong rank baked in. Positional ids (everything the UI builds) still shorten; only ids position cannot express stay long. Both spellings reach a fixed point under repeated collapse→expand.

A label that isn't one of the four ranks now rejects the token rather than being reassigned, matching what `parseDynamicNodeId` did before.

### 3. The `pl-`/`inv-`/`fu-` prefix was recoverable

A *static* token has always dropped it and resolved back through `DEFAULT_VIEW_TOKEN_INDEX` (`flowering_plants` → `pl-flowering_plants`); a dynamic token's root piece now uses the identical path. Resolution deliberately goes through that index rather than `NODE_INDEX`: `molluscs` exists **both** as the flat Table-1a clone (under `all`, unreachable in the default view) and as `inv-molluscs` under Invertebrates, and only the index excludes the clone.

### 4. A `?species=col-…` link with no `view` opened nothing

Pre-existing, unrelated to the URL shortening. A `col-` key is a Not Evaluated species by construction (assessed rows always key on `sis-`, #475). Without `view=new-assessments` such a link landed in the assessed list, which never contains that row, so the panel silently never opened — the same failure mode #475 fixed, reached another way. The view is now inferred when the param is absent.

`view` is otherwise unchanged: an explicit value wins, and it still stands alone — it is the *list's* mode, and most URLs carry no species. Once the app syncs state back it re-writes `view` canonically; the inference is a read-side fallback.

### 5. Every writer had to move together

Shortening what the app *writes* means every consumer and producer of the token has to agree. Three surfaces beyond `useFilterParams` needed updating, two of them found only after the first draft:

- **`/browse`** resolves `?taxa=` through `resolveTaxa`, not `expandTaxaToken`, and only understood the internal `rank:value` spelling. It failed in the worst way — a `~`-bearing value also fails the arbitrary-rank `/^[a-z]+$/` fallback, so a URL pasted straight out of the working dashboard came back "no taxon resolved" rather than erroring.
- **`browseInputToDashboardQuery`** (`dashboard-url.ts`, behind `/browse` and `/api/mcp`) is the link handed back to a person or an agent — the most-shared URL the app produces. It built `taxa` from resolveTaxa's internal ids and never called `prettifyQs`, so it still emitted the long encoded form.
- **`page.tsx` / `compare/page.tsx`** re-serialize the whole query on a view-mode toggle and re-encoded the `~`/`:` that `buildQs` leaves bare. Cosmetic — it parses identically — but it meant the toggle pushed a worse URL than the one it replaced.

`TaxaSummary`'s two href builders were also calling `stripNodePrefix` on a possibly-dynamic node id — the mangling described in §3, from a second site. All of these now go through `taxaUrlToken`, the single place that knows which token form applies.

### Not done, deliberately

- **`?taxon=dioscoreaceae`** (dropping the ancestor path entirely). Needs a 17,801-entry name→node lookup — a new build artifact, a new resync-versioning surface, an ambiguity policy for the 10 names used at more than one rank, and a semantics divergence for the 1,847 families whose leaf-only species set differs from their drill-path one. Added complexity bought with a slightly shorter URL.
- **Deriving `taxonGroups` from the tree.** Exact (verified 139/139) but only removes 65 of 139 declarations, and makes a node's partition scope non-local — you'd walk the tree to see why `ssc-otter` is `[mammals]`. Shipped as a consistency **check** instead.

Root tokens stay English (`flowering_plants`, `fishes`). ~7 roots — `other`, `other_invertebrates`, `other_insects`, `fishes`, `gymnosperms`, `ferns_and_allies`, `invertebrates` — are paraphyletic or residual buckets with no valid taxonomic name at any rank, so a scientific-name scheme would mean inventing names. Everything below the root is already pure taxonomy.

### Other changes

- **`csvGroups` → `taxonGroups`** (22 files, pure rename). It compiles to exactly one thing — `taxon_group IN (…)` in `taxonomy-sql` — and there has been no CSV behind it since the data moved to partitioned parquet. `taxonGroup` was already the name used elsewhere (`OccurrenceMapRow`, `isVascularPlantTaxonGroup`).
- **New guard**: every node's `taxonGroups` must cover the union of its children's. It's the partition predicate, so a parent that under-covers prunes away its own descendants' rows — the child's node lists species the parent's silently omits, surfaced only as wrong counts.
- A comment recording why the field isn't named `table1aTaxonGroups` (the 28 values *are* exactly Table 1a's rows expanded, but `table1a` is already a view id here and the field is used by every view), and that `other` is a 29th partition — ~119k rows of foraminifera and diatoms — that no node lists.

## Compatibility

Links shared before this resolve, including the `pl-`-prefixed and labelled forms, class-first roots, and Unclassified buckets (`molluscs~gastropoda~` → `inv-molluscs~class:gastropoda~order:`). Covered by explicit tests for each.

The one case that did break during development is §2 — a labelled token on a root whose rank order later changed. Fixed, with regression tests; worth knowing it existed because it's the sharpest evidence that this code path deserves care.

One nuance the tests pin but the shortening does not fully canonicalize: `flowering_plants~order:dioscoreales` (unprefixed root, labelled) resolves to the Table-1a clone id `flowering_plants~order:dioscoreales`, while `flowering_plants~dioscoreales` resolves to `pl-flowering_plants~order:dioscoreales`. Two ids, one node — the **filters are identical**, so behaviour matches, but they are not literally the same id.

One test changed meaning rather than moving. The old regression test asserted *"the token equals the id"*, which is no longer the invariant. What actually broke in the original bug was **round-trip stability** across a URL rewrite (toggling view mode re-serializes the whole taxa list, and a mutated token was a fresh cache miss in `TaxaSummary`'s `subgroupData`). That is what it now asserts, over four id shapes.

## Test plan

Typecheck and lint clean. **898/898 tests pass** (+44), covering the token grammar, legacy tokens, label-beats-position, non-positional round-trip stability, the ambiguous `molluscs` root, class-first roots, Unclassified buckets, an invalid rank label, the escape map against adversarial values (`a+b`, `a&b=c`, `Müller's shrew`, `100%`, `50–60 years`), the view inference, and both taxon-token spellings through `/browse` and `dashboard-url`.

Browser drive-through (Playwright, dev server on real data — **13/13**):

- [x] URL written by the app carries no `%7E`/`%3A`
- [x] `?taxa=mammals~rodentia` resolves, and is not rewritten back to the long form
- [x] `?taxa=flowering_plants~dioscoreales~dioscoreaceae` resolves
- [x] `?taxa=fishes~teleostei` resolves (class-first root)
- [x] Legacy `?taxa=pl-flowering_plants%7Eorder%3Adioscoreales%7Efamily%3Adioscoreaceae` still resolves
- [x] `?taxa=molluscs~gastropoda~` opens the Unclassified Order bucket
- [x] `?species=col-…` with no `view` lands in the NE list **and opens the panel**
- [x] Assessed row click still writes `sis-…` and opens
- [x] Token unchanged across a view-mode toggle

Against the running `/browse` endpoint:

- [x] `?taxa=mammals~rodentia` and `?taxa=mammals%7Eorder%3Arodentia` both report `Taxa: Rodentia (Rodents)`
- [x] `?taxa=flowering_plants~dioscoreales~dioscoreaceae` reports `Taxa: Dioscoreaceae (True yams)`
- [x] `?taxa=molluscs~gastropoda~` reports `Taxa: Unclassified Order`

Remaining console noise is environmental: the Sentry tunnel `ETIMEDOUT`s from a sandbox and surfaces as a 500 (no 500 in the server log), plus headless WebGL/maplibre.

## Notes for the reviewer

§2 is the part to read closely. This branch needed **three** follow-up commits for surfaces the first draft missed (`/browse`, `dashboard-url`, then the rank-label regression), the last found by an independent review pass rather than by the tests. The code path has a documented history of silent token bugs — see the long comment in `collapseTaxaToTokens` — and this PR redefines the behaviour that *was* that bug as intended, with the read side restoring what the write side drops. That reasoning is now tested from both directions, but it is the part most worth a second opinion.

**Pre-existing, not fixed here:** `parseBreakdownParam` (`useFilterParams.ts:103`) splits `<nodeId>:<rank>:<name>` on `:`, but a dynamic node id contains `:`. So `bd=mammals~order:rodentia:family:Muridae` parses to `null` and the breakdown is silently dropped — reachable from `TaxaSummary.tsx`'s `fullListHref` on a live-drilldown row, which loses its narrowing and shows the whole node's list. Untouched by this PR (`nodeSpeciesListHref` still embeds the raw internal id), but `taxaUrlToken` is now exactly the colon-free spelling that would fix it. Worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
