### PR TITLE
Parse bd= from the right so a dynamic node id survives

### DIFF
--- a/app/src/hooks/__tests__/filterParams.test.ts
+++ b/app/src/hooks/__tests__/filterParams.test.ts
@@ -1031,3 +1031,56 @@ describe("view mode inferred from the species key", () => {
     expect(parseParams("?species=15951").viewMode).toBe("reassessments");
   });
 });
+
+describe("bd= breakdown param", () => {
+  const bd = (v: string) => parseParams(`?bd=${encodeURIComponent(v)}`).breakdown;
+
+  it("parses a static node id", () => {
+    expect(bd("ssc-small-mammal:order:rodentia")).toEqual({
+      nodeId: "ssc-small-mammal", rank: "order", name: "rodentia",
+    });
+  });
+
+  // A live-drilldown node id contains the delimiter, so splitting left-to-right made
+  // nodeId="mammals~order" and rank="rodentia" — not a rank, so the whole param was
+  // rejected and the breakdown narrowing silently vanished, showing the full node
+  // list instead of the one row that was clicked.
+  it.each([
+    ["mammals~order:rodentia:family:Muridae", "mammals~order:rodentia", "family", "Muridae"],
+    ["inv-molluscs~class:gastropoda~order:stylommatophora:family:Helicidae",
+     "inv-molluscs~class:gastropoda~order:stylommatophora", "family", "Helicidae"],
+  ])("parses a dynamic node id whose own id contains colons: %s", (raw, nodeId, rank, name) => {
+    expect(bd(raw)).toEqual({ nodeId, rank, name });
+  });
+
+  it.each([
+    ["ssc-small-mammal:order:rodentia:only:1,2,3", { nodeId: "ssc-small-mammal", rank: "order", name: "rodentia", onlyIds: [1, 2, 3] }],
+    ["mammals~order:rodentia:family:Muridae:excl:4,5", { nodeId: "mammals~order:rodentia", rank: "family", name: "Muridae", excludeIds: [4, 5] }],
+  ])("keeps the only/excl id-list suffix: %s", (raw, expected) => {
+    expect(bd(raw)).toEqual(expected);
+  });
+
+  it.each([
+    "mammals~order:rodentia:notarank:Muridae",
+    "justonefield",
+    "nodeid:order",
+  ])("rejects a malformed value rather than half-applying it: %s", (raw) => {
+    expect(bd(raw)).toBeNull();
+  });
+
+  // The three-field form must not mistake its own rank for an only/excl mode.
+  it("does not treat a 3-field value's rank as a mode", () => {
+    expect(bd("ssc-small-mammal:order:only")).toEqual({
+      nodeId: "ssc-small-mammal", rank: "order", name: "only",
+    });
+  });
+
+  it.each([
+    { nodeId: "ssc-small-mammal", rank: "order" as const, name: "rodentia" },
+    { nodeId: "mammals~order:rodentia", rank: "family" as const, name: "Muridae" },
+    { nodeId: "mammals~order:rodentia", rank: "family" as const, name: "Muridae", onlyIds: [7, 8] },
+  ])("round-trips through buildQs: %j", (breakdown) => {
+    const qs = buildQs({ ...parseParams(""), breakdown } as unknown as Parameters<typeof buildQs>[0]);
+    expect(parseParams(qs).breakdown).toEqual(breakdown);
+  });
+});

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -101,13 +101,43 @@ export interface BreakdownParam {
   onlyIds?: number[];
   excludeIds?: number[];
 }
+/**
+ * Parsed from the RIGHT, because the nodeId is the one field that can itself contain
+ * the delimiter: a live-drilldown node id is `mammals~order:rodentia`, so
+ * `bd=mammals~order:rodentia:family:Muridae` split left-to-right yields
+ * nodeId="mammals~order", rank="rodentia" — not a rank, so the whole param was
+ * rejected and the breakdown narrowing silently vanished, leaving the full node list.
+ * (Static ids like `ssc-small-mammal` have no colon and always parsed fine, which is
+ * why this survived: every curated breakdown row worked, only live-drilldown ones
+ * didn't.)
+ *
+ * The tail is fixed-arity, so it can be peeled off unambiguously: an optional
+ * `only|excl:<ids>` pair, then name, then rank — and whatever remains, colons and
+ * all, is the nodeId. Deliberately fixed here rather than by making the writer emit
+ * a colon-free node id: RedListView gates this filter on
+ * `selectedSubgroups.has(breakdownFilter.nodeId)`, and selectedSubgroups holds
+ * INTERNAL ids, so rewriting the nodeId to its URL-token form would make the filter
+ * silently inert instead — the same failure with extra steps.
+ */
 const parseBreakdownParam = (p: URLSearchParams, key: string): BreakdownParam | null => {
   const raw = p.get(key);
   if (!raw) return null;
-  const [nodeId, rank, name, mode, idsCsv] = raw.split(":");
+  const parts = raw.split(":");
+  let mode: string | undefined;
+  let idsCsv: string | undefined;
+  // `:only:1,2` / `:excl:1,2` only exists alongside a nodeId+rank+name, so there are
+  // at least 5 fields when present — which also stops a 3-field `nodeId:rank:name`
+  // from mistaking its own rank for a mode.
+  if (parts.length >= 5 && (parts[parts.length - 2] === "only" || parts[parts.length - 2] === "excl")) {
+    idsCsv = parts.pop();
+    mode = parts.pop();
+  }
+  const name = parts.pop();
+  const rank = parts.pop();
+  const nodeId = parts.join(":");
   if (!nodeId || !name || !FILTER_RANKS.includes(rank as FilterRank)) return null;
   const result: BreakdownParam = { nodeId, rank: rank as FilterRank, name };
-  if ((mode === "only" || mode === "excl") && idsCsv) {
+  if (mode && idsCsv) {
     const ids = idsCsv.split(",").map(Number).filter((n) => !Number.isNaN(n));
     if (ids.length > 0) {
       if (mode === "only") result.onlyIds = ids;


### PR DESCRIPTION
## Summary

Clicking a breakdown row in a **live-drilldown** node's "# Described Species" popover landed on the full node list instead of the row you clicked. The narrowing was silently dropped — no error, just more species than asked for.

`bd=<nodeId>:<rank>:<name>` was split left-to-right, but the nodeId is the one field that can itself contain the delimiter. A live-drilldown node id *is* `mammals~order:rodentia`:

```
bd=mammals~order:rodentia:family:muridae
  split(":")  -> ["mammals~order", "rodentia", "family", "muridae"]
              -> nodeId="mammals~order", rank="rodentia"
```

`"rodentia"` isn't in `FILTER_RANKS`, so `parseBreakdownParam` returned `null` and the filter never applied. Confirmed against the pre-fix logic:

```
ssc-small-mammal:order:rodentia         -> {nodeId:"ssc-small-mammal", rank:"order", name:"rodentia"}
mammals~order:rodentia:family:muridae   -> null
```

Static node ids (`ssc-small-mammal`, `inv-corals`) have no colon and always parsed, which is why this survived: every curated SSC breakdown row worked, only live-drilldown ones didn't.

## Fix

Parse from the right. The tail is fixed-arity, so it peels off unambiguously: an optional `only|excl:<ids>` pair, then `name`, then `rank` — and whatever remains, colons and all, is the nodeId. The `parts.length >= 5` guard stops a three-field value from mistaking its own rank for a mode.

**Read-side only, deliberately.** The obvious-looking fix is to make the writer emit a colon-free node id via `taxaUrlToken` (added in #476). That would have made things worse: `RedListView.tsx:1198` gates this filter on `selectedSubgroups.has(breakdownFilter.nodeId)`, and `selectedSubgroups` holds **internal** ids — so a URL-token nodeId would never match, and the filter would go silently inert. Same failure, extra steps.

No URL format change, so every existing `bd=` link keeps working.

## Test plan

Typecheck and lint clean. **910/910 tests pass** (+12), covering static ids, dynamic ids (including the deeply nested `inv-molluscs~class:gastropoda~order:stylommatophora:family:Helicidae`), both `only`/`excl` suffix forms, malformed values, the three-field-vs-mode ambiguity, and a `buildQs` → `parseParams` round-trip.

Browser drive-through (Playwright, dev server on real data — **3/3**), on Rodentia:

- [x] `?taxa=mammals~rodentia` alone → **2,388 species**
- [x] `+ bd=mammals~order:rodentia:family:muridae` → **800 species**, with a removable `Muridae ×` pill
- [x] A stale `bd=` naming an unselected node stays **inert** (still 2,388) rather than emptying the list

Found during review of #476; noted in that PR's body as pre-existing and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
