### PR TITLE
Shift+drag a filter chart to select a range of bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the IUCN Red List Assessments Dashboard.
 
 ## [Unreleased]
 
+- Added Shift+drag range selection to the filter charts — drag across Conservation Status, Years Since Assessed, Year of Latest Assessment, GBIF Records, Year Described, Number of Assessments or the Assessors/Reviewers/Facilitators chart to select every bar swept over, holding Cmd/Ctrl to add to the existing selection rather than replace it. The Year view's from/to number inputs are gone — a drag across the bars does the same job in one gesture (the `minAssessmentYear`/`maxAssessmentYear` URL params still work for shared links, /browse and MCP)
 - Fixed GBIF counts for plants and fungi excluding preserved specimens. Herbarium and fungarium sheets are the primary — often the only — georeferenced record of a plant or fungus, so counting field observations alone showed *Parkinsonia peruviana* (CR) as having 1 record when it has 31. The sync now counts preserved specimens for Plantae, Fungi and Chromista, matching what the occurrence map has defaulted to for those kingdoms all along; animals are unchanged
 
 ## [v2.19.0] — 2026-07-24 – 2026-07-30 — Sign-in, Compare Mode & Filter Charts

--- a/app/src/components/redlist/FilterBarChart.tsx
+++ b/app/src/components/redlist/FilterBarChart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import {
   BarChart,
   Bar,
@@ -37,6 +38,12 @@ interface FilterBarChartProps {
   highlightedItems?: Set<string>;
   /** Truncate Y axis labels to this many characters */
   yAxisTickMaxLength?: number;
+  /**
+   * Shift+drag across the chart to select every bar swept over. Receives the
+   * bars' keys (code, falling back to range — the same key `selectedItems`
+   * holds) in chart order. Omit to leave the chart click-only.
+   */
+  onRangeSelect?: (keys: string[], event: MouseEvent | React.MouseEvent) => void;
 }
 
 export default function FilterBarChart({
@@ -52,24 +59,109 @@ export default function FilterBarChart({
   xAxisMax,
   highlightedItems,
   yAxisTickMaxLength,
+  onRangeSelect,
 }: FilterBarChartProps) {
-  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (data.length === 0) return;
+  // Which bar row the cursor is over, from its Y position within the plot area
+  // (rows are evenly spaced, so this is pure arithmetic — no recharts state).
+  const rowIndexAt = (event: React.MouseEvent<HTMLDivElement>, clamp = false): number | null => {
+    if (data.length === 0) return null;
     const rect = event.currentTarget.getBoundingClientRect();
     const plotHeight = rect.height - CHART_TOP_MARGIN - CHART_BOTTOM_MARGIN;
-    if (plotHeight <= 0) return;
+    if (plotHeight <= 0) return null;
     const relativeY = event.clientY - rect.top - CHART_TOP_MARGIN;
     const index = Math.floor((relativeY / plotHeight) * data.length);
-    if (index < 0 || index >= data.length) return;
+    if (clamp) return Math.min(data.length - 1, Math.max(0, index));
+    if (index < 0 || index >= data.length) return null;
+    return index;
+  };
+
+  // Shift+drag range selection. `drag` holds the anchor row and the row under
+  // the cursor; the band between them is previewed as an overlay and committed
+  // on mouse-up (on window, so releasing outside the chart still lands).
+  const [drag, setDrag] = useState<{ start: number; end: number } | null>(null);
+  // A drag ends with a click event on the wrapper — suppress it so the release
+  // row doesn't also get single-selected on top of the range.
+  const justDragged = useRef(false);
+
+  const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!onRangeSelect || !event.shiftKey) return;
+    const index = rowIndexAt(event);
+    if (index == null) return;
+    // Shift+drag otherwise starts a text selection, which fights the drag
+    event.preventDefault();
+    setDrag({ start: index, end: index });
+  };
+
+  const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!drag) return;
+    const index = rowIndexAt(event, true);
+    if (index == null || index === drag.end) return;
+    setDrag({ start: drag.start, end: index });
+  };
+
+  useEffect(() => {
+    if (!drag) return;
+    const commit = (event: MouseEvent) => {
+      setDrag(null);
+      // The click that closes the drag fires synchronously after this mouseup,
+      // so clearing on the next tick both suppresses it and guarantees the flag
+      // can't leak into a later click (a mouseup outside the chart fires no
+      // click here at all, and would otherwise leave the flag stuck on).
+      justDragged.current = true;
+      setTimeout(() => { justDragged.current = false; }, 0);
+      const from = Math.min(drag.start, drag.end);
+      const to = Math.max(drag.start, drag.end);
+      const keys = data.slice(from, to + 1).map(d => d.code || d.range || "").filter(Boolean);
+      if (keys.length > 0) onRangeSelect?.(keys, event);
+    };
+    window.addEventListener("mouseup", commit);
+    return () => window.removeEventListener("mouseup", commit);
+  }, [drag, data, onRangeSelect]);
+
+  const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (justDragged.current) return;
+    // Shift is the range-drag modifier, not a select-this-bar click
+    if (onRangeSelect && event.shiftKey) return;
+    const index = rowIndexAt(event);
+    if (index == null) return;
     const entry = data[index];
     onBarClick({ payload: { code: entry.code, range: entry.range } }, event);
   };
+
+  // Percentage-based band geometry mirrors how rowIndexAt splits the plot area,
+  // so the preview lines up with the rows without measuring the DOM.
+  const dragBand = drag && data.length > 0 ? {
+    from: Math.min(drag.start, drag.end),
+    span: Math.abs(drag.end - drag.start) + 1,
+  } : null;
+  const insetPx = CHART_TOP_MARGIN + CHART_BOTTOM_MARGIN;
 
   // Wrap in a div with a single click handler so the whole row is a hit target
   // (bar, y-axis label, count label, empty space) — not just the visible bar,
   // which is hard to click when counts are small.
   return (
-    <div onClick={handleClick} style={{ width: "100%", height: "100%", cursor: "pointer" }}>
+    <div
+      onClick={handleClick}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      style={{ width: "100%", height: "100%", cursor: "pointer", position: "relative", userSelect: drag ? "none" : undefined }}
+    >
+      {dragBand && (
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: `calc(${CHART_TOP_MARGIN}px + (100% - ${insetPx}px) * ${dragBand.from / data.length})`,
+            height: `calc((100% - ${insetPx}px) * ${dragBand.span / data.length})`,
+            backgroundColor: "rgba(59, 130, 246, 0.18)",
+            border: "1px solid rgba(59, 130, 246, 0.6)",
+            borderRadius: 4,
+            pointerEvents: "none",
+            zIndex: 1,
+          }}
+        />
+      )}
       <ResponsiveContainer width="100%" height="100%">
         <BarChart
           data={data}
@@ -91,6 +183,9 @@ export default function FilterBarChart({
             : undefined}
           />
           <Tooltip
+            // Held off during a drag — it otherwise sits on top of the band
+            // being dragged out, hiding exactly what the drag is selecting
+            active={drag ? false : undefined}
             formatter={(value: number) => [value.toLocaleString(), "Species"]}
             labelFormatter={labelFormatter}
             contentStyle={{

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -1433,10 +1433,10 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   const [yearsChartMode, setYearsChartMode] = useState<"range" | "year">(
     () => (selectedAssessmentYears.size > 0 ? "year" : "range")
   );
-  // If the URL hydrates with specific years — or an explicit year range — after
-  // mount, surface the year view. The range case matters for shared links: the
-  // from/to inputs live in this view, so a link carrying a range would otherwise
-  // open with its own filter's control hidden.
+  // If the URL hydrates with specific years — or an explicit min/max year range
+  // (still accepted from /browse, the MCP server and hand-built links, though
+  // the UI now selects years by shift+dragging the chart) — surface the year
+  // view, so a shared link opens on the chart its filter applies to.
   useEffect(() => {
     if (selectedAssessmentYears.size > 0
       || exactFilters.minAssessmentYear != null
@@ -3008,6 +3008,23 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   // handlers are parameterised by which selection setter they target.
   type SetSelection = React.Dispatch<React.SetStateAction<Set<string>>>;
 
+  // Shift+drag across a chart selects every bar the drag swept over (see
+  // FilterBarChart/YearBarChart's onRangeSelect). Plain shift+drag replaces the
+  // selection; holding Cmd/Ctrl as well adds to it, which is how a range wider
+  // than what's on screen gets built — e.g. the by-year chart pages 10 years at
+  // a time, so 2005-2020 is one drag per page.
+  const makeRangeSelect = useCallback((setter: SetSelection) =>
+    (keys: string[], event: MouseEvent | React.MouseEvent) => {
+      const isAdditive = event.metaKey || event.ctrlKey;
+      setter(prev => isAdditive ? new Set([...prev, ...keys]) : new Set(keys));
+    }, []);
+  const rangeSelectCategories = useMemo(() => makeRangeSelect(setSelectedCategories), [makeRangeSelect, setSelectedCategories]);
+  const rangeSelectYearRanges = useMemo(() => makeRangeSelect(setSelectedYearRanges), [makeRangeSelect, setSelectedYearRanges]);
+  const rangeSelectAssessmentYears = useMemo(() => makeRangeSelect(setSelectedAssessmentYears), [makeRangeSelect, setSelectedAssessmentYears]);
+  const rangeSelectObsRanges = useMemo(() => makeRangeSelect(setSelectedObsRanges), [makeRangeSelect, setSelectedObsRanges]);
+  const rangeSelectDescribedYears = useMemo(() => makeRangeSelect(setSelectedDescribedYears), [makeRangeSelect, setSelectedDescribedYears]);
+  const rangeSelectAssessmentCounts = useMemo(() => makeRangeSelect(setSelectedAssessmentCounts), [makeRangeSelect, setSelectedAssessmentCounts]);
+
   // Toggle a single assessor/reviewer in/out of selection (used by search list)
   const makeAssessorToggle = useCallback((setter: SetSelection) => (code: string) => {
     setter(prev => {
@@ -4069,6 +4086,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                     dataKey="code"
                     selectedItems={selectedCategories}
                     onBarClick={handleCategoryClick}
+                    onRangeSelect={rangeSelectCategories}
                     yAxisWidth={26}
                     rightMargin={55}
                     labelFormatter={(code) => ({
@@ -4161,47 +4179,6 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                   )}
                 </div>
               </div>
-              {/* Explicit year range. The chart itself only offers whole years
-                  (cmd-click to pick several); a range like 2017–2019 was
-                  previously reachable only by hand-editing minAssessmentYear /
-                  maxAssessmentYear into the URL. Same two params, so a range
-                  set here still shows up as the existing chips and still
-                  round-trips through a shared link. */}
-              {!(isSingleSpecies && singleSpecies) && yearsChartMode === "year" && (
-                <div className="flex items-center gap-1.5 mb-1 text-xs text-zinc-500 dark:text-zinc-400">
-                  <span>Range</span>
-                  <input
-                    type="number"
-                    inputMode="numeric"
-                    placeholder="from"
-                    value={exactFilters.minAssessmentYear ?? ""}
-                    onChange={(e) => setExactFilters({ minAssessmentYear: e.target.value === "" ? null : Number(e.target.value) })}
-                    aria-label="Assessed from year"
-                    className="w-16 rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-1.5 py-0.5 text-xs tabular-nums text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                  />
-                  <span>–</span>
-                  <input
-                    type="number"
-                    inputMode="numeric"
-                    placeholder="to"
-                    value={exactFilters.maxAssessmentYear ?? ""}
-                    onChange={(e) => setExactFilters({ maxAssessmentYear: e.target.value === "" ? null : Number(e.target.value) })}
-                    aria-label="Assessed to year"
-                    className="w-16 rounded border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-1.5 py-0.5 text-xs tabular-nums text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                  />
-                  {(exactFilters.minAssessmentYear != null || exactFilters.maxAssessmentYear != null) && (
-                    <button
-                      type="button"
-                      onClick={() => setExactFilters({ minAssessmentYear: null, maxAssessmentYear: null })}
-                      className="ml-0.5 px-1 rounded hover:bg-zinc-100 dark:hover:bg-zinc-800"
-                      aria-label="Clear year range"
-                      title="Clear year range"
-                    >
-                      ×
-                    </button>
-                  )}
-                </div>
-              )}
               <div className="flex-1 min-h-[150px] flex flex-col">
                 {speciesLoading && assessedSpecies.length === 0 ? (
                   <div className="flex-1 flex items-center justify-center"><Spinner /></div>
@@ -4230,6 +4207,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                         dataKey="shortRange"
                         selectedItems={yearRangeSelectedItems}
                         onBarClick={handleYearClick}
+                        onRangeSelect={rangeSelectYearRanges}
                         barColor="#3b82f6"
                         yAxisWidth={36}
                         rightMargin={85}
@@ -4242,6 +4220,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                       data={paginatedAssessmentYearsData}
                       selectedItems={assessmentYearSelectedItems}
                       onBarClick={handleAssessmentYearClick}
+                      onRangeSelect={rangeSelectAssessmentYears}
                       barColor="#3b82f6"
                       yMax={yearsGlobalMax}
                     />
@@ -4276,6 +4255,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                     dataKey="shortRange"
                     selectedItems={selectedObsRanges}
                     onBarClick={handleObsClick}
+                    onRangeSelect={rangeSelectObsRanges}
                     barColor="#10b981"
                     yAxisWidth={42}
                     rightMargin={85}
@@ -4318,6 +4298,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                     dataKey="shortRange"
                     selectedItems={selectedDescribedYears}
                     onBarClick={handleDescribedYearClick}
+                    onRangeSelect={rangeSelectDescribedYears}
                     barColor="#3b82f6"
                     yAxisWidth={64}
                     rightMargin={85}
@@ -4342,6 +4323,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                     dataKey="shortRange"
                     selectedItems={selectedObsRanges}
                     onBarClick={handleObsClick}
+                    onRangeSelect={rangeSelectObsRanges}
                     barColor="#10b981"
                     yAxisWidth={42}
                     rightMargin={85}
@@ -4514,6 +4496,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                             dataKey="shortRange"
                             selectedItems={selectedAssessmentCounts}
                             onBarClick={handleAssessmentCountClick}
+                            onRangeSelect={rangeSelectAssessmentCounts}
                             barColor="#8b5cf6"
                             yAxisWidth={42}
                             rightMargin={85}
@@ -4668,6 +4651,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                       onViewModeChange={changeCreditChartMode}
                       selectedItems={creditSelection[assessorReviewerMode].selected}
                       onBarClick={makeAssessorClick(creditSelection[assessorReviewerMode].setter)}
+                      onRangeSelect={makeRangeSelect(creditSelection[assessorReviewerMode].setter)}
                       onItemToggle={makeAssessorToggle(creditSelection[assessorReviewerMode].setter)}
                       loading={speciesLoading && assessedSpecies.length === 0}
                     />

--- a/app/src/components/redlist/ReviewerChart.tsx
+++ b/app/src/components/redlist/ReviewerChart.tsx
@@ -27,6 +27,8 @@ interface AssessorChartProps {
   /** The selected items for the currently active tab */
   selectedItems: Set<string>;
   onBarClick: (data: { payload?: { code?: string } }, event: React.MouseEvent) => void;
+  /** Shift+drag across the bars to select everyone swept over */
+  onRangeSelect?: (codes: string[], event: MouseEvent | React.MouseEvent) => void;
   onItemToggle: (code: string) => void;
   loading?: boolean;
   viewMode: ViewMode;
@@ -45,6 +47,7 @@ export default function AssessorChart({
   allFacilitators,
   selectedItems,
   onBarClick,
+  onRangeSelect,
   onItemToggle,
   loading,
   viewMode,
@@ -198,6 +201,7 @@ export default function AssessorChart({
             dataKey="code"
             selectedItems={selectedItems}
             onBarClick={onBarClick}
+            onRangeSelect={onRangeSelect}
             barColor={activeColor}
             yAxisWidth={150}
             leftMargin={-30}

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -3210,7 +3210,7 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
     {perTaxa.length > 0 && selectedTaxa.size === 0 && (
       <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 mt-1.5">
         <span className="hidden sm:inline pl-3 md:pl-4 text-sm text-zinc-400 dark:text-zinc-500">
-          {countryMode ? "Click a country to view its species, Cmd/Ctrl+click to multi-select." : "Click to filter, use charts and search to explore species. Cmd/Ctrl+click to multi-select."}
+          {countryMode ? "Click a country to view its species, Cmd/Ctrl+click to multi-select." : "Click to filter, use charts and search to explore species. Cmd/Ctrl+click to multi-select, Shift+drag across a chart to select a range."}
         </span>
         <span className="inline-flex items-center gap-1.5 ml-auto pr-3 sm:pr-0">
           {/* Assessed/Not Evaluated toggle used to be paired here too, but it's

--- a/app/src/components/redlist/YearBarChart.tsx
+++ b/app/src/components/redlist/YearBarChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   BarChart,
   Bar,
@@ -10,6 +10,17 @@ import {
   ResponsiveContainer,
   Cell,
 } from "recharts";
+
+// Plot-area insets, mirroring the margins and axis sizes set on the chart
+// below. Kept in sync by hand so the drag band can be positioned in CSS
+// without measuring the SVG.
+const CHART_MARGIN = { top: 8, right: 8, left: 4, bottom: 4 };
+const Y_AXIS_WIDTH = 40;
+const X_AXIS_HEIGHT = 40;
+const PLOT_LEFT = CHART_MARGIN.left + Y_AXIS_WIDTH;
+const PLOT_RIGHT = CHART_MARGIN.right;
+const PLOT_TOP = CHART_MARGIN.top;
+const PLOT_BOTTOM = CHART_MARGIN.bottom + X_AXIS_HEIGHT;
 
 interface YearBarChartProps {
   /** Data sorted ascending by year (chronological left-to-right) */
@@ -23,6 +34,11 @@ interface YearBarChartProps {
   barColor?: string;
   /** Fixed Y-axis max so the scale stays stable across pagination */
   yMax?: number;
+  /**
+   * Shift+drag across the chart to select every year swept over, in chart
+   * order. Omit to leave the chart click-only.
+   */
+  onRangeSelect?: (codes: string[], event: MouseEvent | React.MouseEvent) => void;
 }
 
 // Recharts' BarChart onClick handler state carries the hovered category + payload
@@ -37,6 +53,7 @@ export default function YearBarChart({
   onBarClick,
   barColor = "#3b82f6",
   yMax,
+  onRangeSelect,
 }: YearBarChartProps) {
   // Capture the mouse event alongside recharts' synthetic state so multi-select
   // (Cmd/Ctrl+click) still works when clicks are handled at the chart level.
@@ -47,81 +64,163 @@ export default function YearBarChart({
     if (value >= 1_000) return `${(value / 1_000).toFixed(value % 1_000 === 0 ? 0 : 1)}k`;
     return String(value);
   };
+  // Shift+drag range selection: `drag` holds the anchor year and the year under
+  // the cursor. The band between them is previewed as a ReferenceArea and
+  // committed on mouse-up (bound to the window, so releasing outside the chart
+  // still lands).
+  const [drag, setDrag] = useState<{ start: string; end: string } | null>(null);
+  // A drag also ends in a click — suppress it so the release year doesn't get
+  // single-selected on top of the range.
+  const justDragged = useRef(false);
+  const codeFrom = (state: BarChartClickState): string | undefined =>
+    state?.activePayload?.[0]?.payload?.code ?? (state?.activeLabel != null ? String(state.activeLabel) : undefined);
+
   const handleChartClick = (nextState: unknown) => {
+    if (justDragged.current) return;
     const state = nextState as BarChartClickState;
     const event = lastEventRef.current;
     if (!event) return;
-    const code = state?.activePayload?.[0]?.payload?.code ?? (state?.activeLabel != null ? String(state.activeLabel) : undefined);
+    // Shift is the range-drag modifier, not a select-this-bar click
+    if (onRangeSelect && event.shiftKey) return;
+    const code = codeFrom(state);
     if (!code) return;
     onBarClick({ payload: { code } }, event);
   };
-  const handleChartMouseDown = (_nextState: unknown, event: React.SyntheticEvent) => {
-    lastEventRef.current = event as React.MouseEvent;
+  const handleChartMouseDown = (nextState: unknown, event: React.SyntheticEvent) => {
+    const mouseEvent = event as React.MouseEvent;
+    lastEventRef.current = mouseEvent;
+    if (!onRangeSelect || !mouseEvent.shiftKey) return;
+    const code = codeFrom(nextState as BarChartClickState);
+    if (!code) return;
+    // Shift+drag otherwise starts a text selection, which fights the drag
+    mouseEvent.preventDefault();
+    setDrag({ start: code, end: code });
   };
+  const handleChartMouseMove = (nextState: unknown) => {
+    if (!drag) return;
+    const code = codeFrom(nextState as BarChartClickState);
+    if (!code || code === drag.end) return;
+    setDrag({ start: drag.start, end: code });
+  };
+
+  useEffect(() => {
+    if (!drag) return;
+    const commit = (event: MouseEvent) => {
+      setDrag(null);
+      // The click that closes the drag fires synchronously after this mouseup,
+      // so clearing on the next tick both suppresses it and guarantees the flag
+      // can't leak into a later click (a mouseup outside the chart fires no
+      // click here at all, and would otherwise leave the flag stuck on).
+      justDragged.current = true;
+      setTimeout(() => { justDragged.current = false; }, 0);
+      const a = data.findIndex(d => d.code === drag.start);
+      const b = data.findIndex(d => d.code === drag.end);
+      if (a < 0 || b < 0) return;
+      const codes = data.slice(Math.min(a, b), Math.max(a, b) + 1).map(d => d.code);
+      if (codes.length > 0) onRangeSelect?.(codes, event);
+    };
+    window.addEventListener("mouseup", commit);
+    return () => window.removeEventListener("mouseup", commit);
+  }, [drag, data, onRangeSelect]);
+  // The band is drawn as an overlay rather than a <ReferenceArea>, which can
+  // only anchor to category centres — it would cut the first and last bar of
+  // the drag in half. Categories divide the plot area evenly, so plain
+  // percentages land on the band edges exactly.
+  const dragBand = (() => {
+    if (!drag || data.length === 0) return null;
+    const a = data.findIndex(d => d.code === drag.start);
+    const b = data.findIndex(d => d.code === drag.end);
+    if (a < 0 || b < 0) return null;
+    return { from: Math.min(a, b), span: Math.abs(b - a) + 1 };
+  })();
+  const insetX = PLOT_LEFT + PLOT_RIGHT;
+
   return (
-    <ResponsiveContainer width="100%" height="100%">
-      <BarChart
-        data={data}
-        margin={{ top: 8, right: 8, left: 4, bottom: 4 }}
-        barCategoryGap={2}
-        onClick={handleChartClick}
-        onMouseDown={handleChartMouseDown}
-        style={{ cursor: "pointer" }}
-      >
-        <XAxis
-          dataKey="code"
-          type="category"
-          tick={{ fontSize: 10, fill: "#a1a1aa" }}
-          tickLine={false}
-          axisLine={{ stroke: "#3f3f46" }}
-          interval={0}
-          angle={-45}
-          textAnchor="end"
-          height={40}
-        />
-        <YAxis
-          type="number"
-          tick={{ fontSize: 10, fill: "#a1a1aa" }}
-          tickLine={false}
-          axisLine={false}
-          width={40}
-          allowDecimals={false}
-          domain={yMax != null ? [0, yMax] : undefined}
-          tickFormatter={formatTick}
-        />
-        <Tooltip
-          formatter={(value: number, _name, props: { payload?: { label?: string } }) => [
-            // Prefer the precomputed "count (pct%)" label if present, otherwise fall back to raw count
-            props?.payload?.label ?? value.toLocaleString(),
-            "Species",
-          ]}
-          labelFormatter={(year: string) => `Assessed ${year}`}
-          contentStyle={{
-            backgroundColor: "#18181b",
-            border: "1px solid #3f3f46",
-            borderRadius: "8px",
+    <div style={{ width: "100%", height: "100%", position: "relative" }}>
+      {dragBand && (
+        <div
+          style={{
+            position: "absolute",
+            top: PLOT_TOP,
+            bottom: PLOT_BOTTOM,
+            left: `calc(${PLOT_LEFT}px + (100% - ${insetX}px) * ${dragBand.from / data.length})`,
+            width: `calc((100% - ${insetX}px) * ${dragBand.span / data.length})`,
+            backgroundColor: "rgba(59, 130, 246, 0.18)",
+            border: "1px solid rgba(59, 130, 246, 0.6)",
+            borderRadius: 4,
+            pointerEvents: "none",
+            zIndex: 1,
           }}
-          itemStyle={{ color: "#fff" }}
-          labelStyle={{ color: "#a1a1aa" }}
-          cursor={{ fill: "#3f3f46", opacity: 0.2 }}
         />
-        <Bar
-          dataKey="count"
-          radius={[3, 3, 0, 0]}
-          minPointSize={2}
+      )}
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          data={data}
+          margin={CHART_MARGIN}
+          barCategoryGap={2}
+          onClick={handleChartClick}
+          onMouseDown={handleChartMouseDown}
+          onMouseMove={handleChartMouseMove}
+          style={{ cursor: "pointer", userSelect: drag ? "none" : undefined }}
         >
-          {data.map((entry, index) => {
-            const isDimmed = selectedItems.size > 0 && !selectedItems.has(entry.code);
-            return (
-              <Cell
-                key={`cell-${index}`}
-                fill={barColor}
-                opacity={isDimmed ? 0.3 : 1}
-              />
-            );
-          })}
-        </Bar>
-      </BarChart>
-    </ResponsiveContainer>
+          <XAxis
+            dataKey="code"
+            type="category"
+            tick={{ fontSize: 10, fill: "#a1a1aa" }}
+            tickLine={false}
+            axisLine={{ stroke: "#3f3f46" }}
+            interval={0}
+            angle={-45}
+            textAnchor="end"
+            height={X_AXIS_HEIGHT}
+          />
+          <YAxis
+            type="number"
+            tick={{ fontSize: 10, fill: "#a1a1aa" }}
+            tickLine={false}
+            axisLine={false}
+            width={Y_AXIS_WIDTH}
+            allowDecimals={false}
+            domain={yMax != null ? [0, yMax] : undefined}
+            tickFormatter={formatTick}
+          />
+          <Tooltip
+            // Held off during a drag — it otherwise sits on top of the band
+            // being dragged out, hiding exactly what the drag is selecting
+            active={drag ? false : undefined}
+            formatter={(value: number, _name, props: { payload?: { label?: string } }) => [
+              // Prefer the precomputed "count (pct%)" label if present, otherwise fall back to raw count
+              props?.payload?.label ?? value.toLocaleString(),
+              "Species",
+            ]}
+            labelFormatter={(year: string) => `Assessed ${year}`}
+            contentStyle={{
+              backgroundColor: "#18181b",
+              border: "1px solid #3f3f46",
+              borderRadius: "8px",
+            }}
+            itemStyle={{ color: "#fff" }}
+            labelStyle={{ color: "#a1a1aa" }}
+            cursor={{ fill: "#3f3f46", opacity: 0.2 }}
+          />
+          <Bar
+            dataKey="count"
+            radius={[3, 3, 0, 0]}
+            minPointSize={2}
+          >
+            {data.map((entry, index) => {
+              const isDimmed = selectedItems.size > 0 && !selectedItems.has(entry.code);
+              return (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={barColor}
+                  opacity={isDimmed ? 0.3 : 1}
+                />
+              );
+            })}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Shift+drag across a filter chart to select a run of bars, and drop the Year view's from/to number inputs in favour of it.

**Drag selection.** Holding Shift and dragging across a chart selects every bar the drag sweeps over. A translucent band previews the range while the mouse is down (the recharts tooltip is held off during a drag so it can't sit on top of it), and mouse-up applies the selection:

- **Shift+drag** replaces the current selection with the swept bars
- **Cmd/Ctrl+Shift+drag** adds them to the existing selection instead — which is how a range wider than what's on screen gets built (the by-year chart pages 10 years at a time, so 2005–2020 is one drag per page)
- Releasing outside the chart still applies the range; the click that closes a drag no longer also single-selects the bar under the cursor

Wired into every chart where a click is purely a selection: **Conservation Status**, **Years Since Assessed**, **Year of Latest Assessment**, **GBIF Records**, **Year Described**, **Number of Assessments**, and the **Assessors/Reviewers/Facilitators** chart. The three hierarchical drill-down charts (Threats, Criteria, Habitat) are deliberately left click-only — a click there doubles as an expand/collapse toggle, so sweeping a range would expand every category it touched.

**Year from/to inputs removed.** The `Range [from]–[to]` number inputs above the Year view are gone; a drag across the bars does the same job in one gesture. The `minAssessmentYear`/`maxAssessmentYear` URL params they wrote are untouched — `/browse`, the MCP server and existing shared links still set a year range that way, it still shows the same chips, and a link carrying one still opens the Year view.

The landing hint line now reads "… Cmd/Ctrl+click to multi-select, Shift+drag across a chart to select a range."

### Dragging EN → LC on Conservation Status, and the result

![drag in progress](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-485-chart-drag-select/01-drag-in-progress.png)

![selection applied](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-485-chart-drag-select/02-selection-applied.png)

### Dragging 2021 → 2024 on the Year view (note: no from/to inputs any more)

![year drag](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-485-chart-drag-select/03-year-drag.png)

![year selection applied](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-485-chart-drag-select/04-year-applied.png)

## Test plan

- `npx tsc --noEmit` and `eslint` clean; `npm run test` — 935 tests across 50 files pass
- Browser drive-through (Playwright, Chromium, light **and** dark), Mammals view, checking the URL after each gesture:
  - Conservation Status, EN → LC ⇒ `categories=EN,VU,NT,LC`, chips + species count update (6,054 → 4,947)
  - Year view, 2021 → 2024 ⇒ `assessmentYears=2021,2022,2023,2024`; band aligns to the full width of the first and last bar
  - Page back to 1996–2018, Cmd+Shift+drag ⇒ `assessmentYears=2021,2022,2023,2024,2015,2016,2017` (additive across pages)
  - A plain click straight after a drag still replaces the selection (`assessmentYears=1996`) — no stuck drag state
  - GBIF Records, 101-1K → 10K+ ⇒ `obsRanges=101-1K,1K-10K,10K+`
  - Years Since Assessed, 1-5y → 10-20y ⇒ `years=1-5 years,5-10 years,10-20 years`
  - More Filters: Number of Assessments 2 → 4 ⇒ `assessmentCounts=2,3,4`; Assessors, 3 adjacent names ⇒ `assessors=Kennerley, R.|Helgen, K.|Aplin, K.`
  - No text selection dragged out across the page, and no console errors in any run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
