### PR TITLE
Reword 10+ year old assessments as "needs updating"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The dashboard answers questions like:
 ## Features
 
 ### Taxa summary and drill-down
-The landing table shows every taxonomic group with species counts, assessment coverage, outdated-assessment percentages, described-species totals from the Catalogue of Life, and GBIF occurrence totals. Click a row to drill into that group and down through the taxonomic tree. Includes a Red List vs GBIF focus-mode toggle and column visibility controls.
+The landing table shows every taxonomic group with species counts, assessment coverage, percentages of assessments needing updating, described-species totals from the Catalogue of Life, and GBIF occurrence totals. Click a row to drill into that group and down through the taxonomic tree. Includes a Red List vs GBIF focus-mode toggle and column visibility controls.
 
 ### Filter charts
 Clickable charts cross-filter the species table and each other:

--- a/app/src/app/api/mcp/route.ts
+++ b/app/src/app/api/mcp/route.ts
@@ -68,7 +68,7 @@ const handler = createMcpHandler(
       {
         title: "Browse a taxon",
         description:
-          "List/aggregate IUCN Red List species under a taxon, with GBIF + Catalogue of Life data. `taxa` works at ANY rank: a curated group (birds, corals), a sub-group (sharks-rays, flatworms), or a scientific class/order/family name (felidae, odonata). Returns total + by-category breakdown + an `outdated`/`stats` block (use it for percentage questions like '% of mammals outdated') + a capped species list. Combine optional filters (AND across filters; OR within a list).",
+          "List/aggregate IUCN Red List species under a taxon, with GBIF + Catalogue of Life data. `taxa` works at ANY rank: a curated group (birds, corals), a sub-group (sharks-rays, flatworms), or a scientific class/order/family name (felidae, odonata). Returns total + by-category breakdown + an `outdated`/`stats` block (use it for percentage questions like '% of mammals needing updating') + a capped species list. Combine optional filters (AND across filters; OR within a list).",
         inputSchema: { taxa: z.string().describe("A taxonomic group, sub-group, or scientific name (any rank)."), ...FILTERS },
       },
       async (args) => {

--- a/app/src/app/browse/route.ts
+++ b/app/src/app/browse/route.ts
@@ -160,7 +160,7 @@ function resultsHtml(r: BrowseResult): string {
     summary = `<p class="summary"><strong>${r.total.toLocaleString()}</strong> species match — ${filterDesc}.${r.total > r.shown ? ` Showing the first ${r.shown}.` : ""}</p>`;
     if (breakdownStr) summary += `<p>By category: ${breakdownStr}</p>`;
     if (r.stats.assessed > 0 && r.stats.outdated_pct != null) {
-      summary += `<p>Assessments outdated (>10 yrs old): <strong>${r.stats.outdated.toLocaleString()}</strong> of ${r.stats.assessed.toLocaleString()} (<strong>${r.stats.outdated_pct}%</strong>).</p>`;
+      summary += `<p>Assessments needing updating (>10 yrs old): <strong>${r.stats.outdated.toLocaleString()}</strong> of ${r.stats.assessed.toLocaleString()} (<strong>${r.stats.outdated_pct}%</strong>).</p>`;
     }
   }
 
@@ -184,7 +184,7 @@ function resultsHtml(r: BrowseResult): string {
 
 const EXAMPLES: { url: string; desc: string }[] = [
   { url: `${BASE}?taxa=corals&threats=climate-change`, desc: "Coral species threatened by climate change" },
-  { url: `${BASE}?taxa=mammals`, desc: "All mammals — read stats.outdated_pct for % of outdated assessments" },
+  { url: `${BASE}?taxa=mammals`, desc: "All mammals — read stats.outdated_pct for % of assessments needing updating" },
   { url: `${BASE}?taxa=felidae&categories=threatened`, desc: "Threatened cats (arbitrary rank: a family name)" },
   { url: `${BASE}?taxa=amphibians&region=Sub-Saharan+Africa&categories=threatened`, desc: "Threatened amphibians in Sub-Saharan Africa (IUCN region)" },
   { url: `${BASE}?search=tiger`, desc: "Look up a species by name" },
@@ -224,7 +224,7 @@ ${unresolvedBlock(unresolved)}
 ${filterLines}
 <p><strong>region</strong> (IUCN): ${vocab.region.map((r) => `<code>${esc(r)}</code>`).join(", ")}.</p>
 <p>${paramLines}</p>
-<p>Every response leads with a total, a by-category breakdown, and an outdated count + %, so percentage questions are answered in one request.</p>
+<p>Every response leads with a total, a by-category breakdown, and a needs-updating count + % (<code>stats.outdated</code> / <code>stats.outdated_pct</code>), so percentage questions are answered in one request.</p>
 <h2>Examples</h2><ul>${examples}</ul>
 ${PAGE_FOOT}`;
 }

--- a/app/src/app/llms.txt/route.ts
+++ b/app/src/app/llms.txt/route.ts
@@ -89,7 +89,7 @@ minDescribedYear / maxDescribedYear: year-described bounds (NE species)
 - ${base}/browse?taxa=corals&threats=climate-change
     Coral species threatened by climate change
 - ${base}/browse?taxa=mammals
-    All mammals — read stats.outdated_pct for % of outdated assessments
+    All mammals — read stats.outdated_pct for % of assessments needing updating
 - ${base}/browse?taxa=felidae&categories=threatened
     Threatened cats (arbitrary rank: a family name)
 - ${base}/browse?taxa=amphibians&region=Sub-Saharan+Africa&categories=threatened

--- a/app/src/components/CountryStatsList.tsx
+++ b/app/src/components/CountryStatsList.tsx
@@ -302,7 +302,7 @@ export default function CountryStatsList({
               />
               {showOutdatedMode && (
                 <SortHeader
-                  label="# Outdated"
+                  label="# Needs Updating"
                   active={sortKey === "outdated"}
                   dir={sortDir}
                   widthClass="w-[22%]"
@@ -318,7 +318,7 @@ export default function CountryStatsList({
               )}
               {showOutdatedMode && (
                 <SortHeader
-                  label="% Outdated"
+                  label="% Needs Updating"
                   active={sortKey === "percentOutdated"}
                   dir={sortDir}
                   widthClass="w-[22%]"

--- a/app/src/components/WorldMap.tsx
+++ b/app/src/components/WorldMap.tsx
@@ -145,11 +145,11 @@ interface WorldMapProps {
   footer?: React.ReactNode;
   // Whether to show the Species/GBIF color mode toggle (only accurate for top-level taxa)
   showGbifToggle?: boolean;
-  // Whether the "% Outdated" color mode is meaningful (false for unassessed/NE species views,
+  // Whether the "% Needs Updating" color mode is meaningful (false for unassessed/NE species views,
   // where every species has no assessment date rather than an outdated one)
   showOutdatedMode?: boolean;
   // Whether to show the color-mode <select> at all (species/outdated/GBIF) — false
-  // for new-assessments/NE views, where it's not just missing its "% Outdated"
+  // for new-assessments/NE views, where it's not just missing its "% Needs Updating"
   // option but pointless outright: color-coding a map of species that are all,
   // definitionally, unassessed conveys nothing. Independent of showGbifToggle/
   // showOutdatedMode (which only control which OPTIONS appear once shown).
@@ -511,7 +511,7 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
               className="text-[10px] bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-md px-1.5 py-0.5 text-zinc-700 dark:text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
             >
               <option value="species">{speciesLabel}</option>
-              {showOutdatedMode && <option value="outdated">% Outdated</option>}
+              {showOutdatedMode && <option value="outdated">% Needs Updating</option>}
               {showGbifToggle && <option value="occurrences"># GBIF Obs</option>}
             </select>
           )}
@@ -602,13 +602,13 @@ function WorldMap({ selectedCountries, onCountrySelect, selectedTaxon, precomput
               {showOutdatedMode && hoveredSpeciesStats && hoveredSpeciesStats.species > 0 && (
                 <>
                   <div className="flex justify-between gap-4 text-xs">
-                    <span className="text-zinc-500"># Outdated</span>
+                    <span className="text-zinc-500"># Needs Updating</span>
                     <span className="font-medium text-zinc-700 dark:text-zinc-300 tabular-nums">
                       {formatNumber(hoveredSpeciesStats.outdated || 0)}
                     </span>
                   </div>
                   <div className="flex justify-between gap-4 text-xs">
-                    <span className="text-zinc-500">% Outdated</span>
+                    <span className="text-zinc-500">% Needs Updating</span>
                     <span className="font-medium text-zinc-700 dark:text-zinc-300 tabular-nums">
                       {(((hoveredSpeciesStats.outdated || 0) / hoveredSpeciesStats.species) * 100).toFixed(1)}%
                     </span>

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -2077,8 +2077,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
 
   // True per-country totals — taxon/subgroup selection only, no other filters —
   // so the Country map tooltip can show "142 of 3,847 total" instead of just
-  // "142" when a filter (e.g. Outdated, a category) narrows the country's
-  // species count. Without this, e.g. "% Outdated: 100%" while the Outdated
+  // "142" when a filter (e.g. Needs Updating, a category) narrows the country's
+  // species count. Without this, e.g. "% Needs Updating: 100%" while the Needs Updating
   // toggle is on reads as a fact about the country instead of a tautology.
   const countryStatsForMapTotal = useMemo(() => {
     const counts: Record<string, number> = {};
@@ -4127,7 +4127,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                       aria-pressed={isOutdatedSelected}
                       title={`Filter to species last assessed before ${outdatedCutoffDate(dataAsOf).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })}`}
                     >
-                      Outdated
+                      Needs Updating
                     </button>
                   )}
                   {/* Pagination controls (year view only, and only when multiple pages) */}
@@ -5028,7 +5028,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             {(() => {
               const ef = exactFilters;
               const chips: { key: keyof typeof ef; label: string }[] = [];
-              if (ef.outdated) chips.push({ key: "outdated", label: ef.outdated === "yes" ? "Outdated (>10 yrs)" : "Current (≤10 yrs)" });
+              if (ef.outdated) chips.push({ key: "outdated", label: ef.outdated === "yes" ? "Needs updating (>10 yrs)" : "Current (≤10 yrs)" });
               if (ef.minObs != null) chips.push({ key: "minObs", label: `≥ ${ef.minObs.toLocaleString()} obs` });
               if (ef.maxObs != null) chips.push({ key: "maxObs", label: `≤ ${ef.maxObs.toLocaleString()} obs` });
               if (ef.minAssessmentYear != null) chips.push({ key: "minAssessmentYear", label: `Assessed ≥ ${ef.minAssessmentYear}` });

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -190,7 +190,7 @@ const getAssessedBarColor = (percent: number) =>
 const getOutdatedBarColor = (percent: number) =>
   percent < 20 ? "#22c55e" : percent <= 50 ? "#f97316" : "#ef4444";
 
-// Info icon for the "# Outdated" header. This column's counts come from the
+// Info icon for the "# Needs Updating" header. This column's counts come from the
 // static data/taxa-summary.json build artifact (see README § Data Sync
 // Pipeline), computed as of the last data sync — not live, unlike the rest
 // of the dashboard — so the tooltip states that sync date directly rather
@@ -234,7 +234,7 @@ const flexTdClasses = `${cellPad} ${colDivider} whitespace-nowrap w-0`;
 const flexThClasses = `${cellPad} ${colDivider} text-left text-sm font-bold text-zinc-600 dark:text-zinc-300 whitespace-nowrap w-0`;
 // Bar-column headers (Assessed / Outdated / Unassessed / Not Evaluated) are allowed
 // to wrap: their cells already carry a bar min-width, so a long single-line header
-// (e.g. "# Outdated (>10 yrs old)") would otherwise force the column wider than
+// (e.g. "# Needs Updating (>10 yrs old)") would otherwise force the column wider than
 // it needs to be and push the table into horizontal overflow.
 const centeredThClasses = `${cellPad} ${colDivider} text-center text-sm font-bold text-zinc-600 dark:text-zinc-300 w-0`;
 // "# Described Species" is the widest single-line header after the taxon name
@@ -260,7 +260,7 @@ const COLUMN_LABELS: Record<ColumnId, string> = {
   described: "# Described Species",
   colDescribed: "# Described Species (CoL)",
   assessed: "# Red List Assessed",
-  outdated: "# Outdated (>10 yrs old)",
+  outdated: "# Needs Updating (>10 yrs old)",
   breakdown: "Conservation Status Breakdown",
   gbifUnassessed: "# Unassessed, 1+ GBIF Obs",
   colNe: "# Not Evaluated",
@@ -2602,14 +2602,14 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
                 (inline-flex forces it to stay unwrapped) — shortened here,
                 same info still available via the plain-mode header. */}
             {countryStyleColumns ? (
-              "# Outdated"
+              "# Needs Updating"
             ) : (
-              <span className="inline-flex items-center gap-1"># Outdated (&gt;10 yrs old) <OutdatedInfoIcon /></span>
+              <span className="inline-flex items-center gap-1"># Needs Updating (&gt;10 yrs old) <OutdatedInfoIcon /></span>
             )}
           </th>
         )}
         {countryStyleColumns && (
-          <th className={numericThNoDividerClasses}>% Outdated</th>
+          <th className={numericThNoDividerClasses}>% Needs Updating</th>
         )}
         {isVisible("gbifUnassessed") && (
           <th className={centeredThClasses}># Unassessed, 1+ GBIF Obs</th>

--- a/app/src/lib/browse-query.ts
+++ b/app/src/lib/browse-query.ts
@@ -211,7 +211,7 @@ export async function runBrowseQuery(input: BrowseInput): Promise<BrowseResult> 
   if (maxAssessmentYear != null) interpreted.push(`Assessed in or before ${maxAssessmentYear}`);
   if (minDescribedYear != null) interpreted.push(`Described in or after ${minDescribedYear}`);
   if (maxDescribedYear != null) interpreted.push(`Described in or before ${maxDescribedYear}`);
-  if (outdated) interpreted.push(outdated === "yes" ? "Outdated assessments (>10 yrs old)" : "Current assessments (≤10 yrs old)");
+  if (outdated) interpreted.push(outdated === "yes" ? "Assessments needing updating (>10 yrs old)" : "Current assessments (≤10 yrs old)");
 
   return {
     interpreted, unresolved, tooLarge, noSelector: false,


### PR DESCRIPTION
## Summary

Replaces the user-facing **"Outdated"** wording for 10+ year old assessments with **"Needs Updating"**, across the dashboard UI, the agent-facing `/browse` and `llms.txt` surfaces, and the README. "Outdated" reads as a judgement on the assessment; "needs updating" describes the action it implies.

### Display strings changed

| Surface | Before | After |
| --- | --- | --- |
| Taxa summary header + column-picker | `# Outdated (>10 yrs old)` | `# Needs Updating (>10 yrs old)` |
| Taxa summary, Country View | `# Outdated` / `% Outdated` | `# Needs Updating` / `% Needs Updating` |
| Country stats list sort headers | `# Outdated` / `% Outdated` | `# Needs Updating` / `% Needs Updating` |
| World map colour-mode option | `% Outdated` | `% Needs Updating` |
| World map hover tooltip | `# Outdated` / `% Outdated` | `# Needs Updating` / `% Needs Updating` |
| Species dashboard filter button | `Outdated` | `Needs Updating` |
| Species dashboard filter chip | `Outdated (>10 yrs)` | `Needs updating (>10 yrs)` |
| `/browse` result summary | `Assessments outdated (>10 yrs old):` | `Assessments needing updating (>10 yrs old):` |
| `/browse` docs + examples, `llms.txt`, MCP tool description | `% of outdated assessments` | `% of assessments needing updating` |

Comments that quoted the old header text verbatim were updated to match.

### Deliberately unchanged

Internal identifiers keep their names, so nothing that already works breaks:

- the **`outdated` URL parameter** — existing shared dashboard links (`?outdated=yes`) keep working; verified the button still produces that URL
- the **`outdated` / `outdated_pct` API and JSON data fields** — `/browse`, the MCP tool and `app/data/*.json` contracts are untouched, so no data regeneration is needed
- `isOutdated()` / `outdatedCutoffDate()` and the surrounding variable names

The `/browse` docs line now names the `stats.outdated` / `stats.outdated_pct` fields explicitly, so an agent reading the new prose can still map it to the actual field names.

## Test plan

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm test` — 981 passed, 6 skipped (52 files)
- Browser drive-through (Playwright + Chromium, 1500×1100):
  - **Landing table** — renders `# Needs Updating (>10 yrs old)` with its info icon, no overflow
  - **Column-picker menu** — shows the new label
  - **By Country → List** — `# Needs Updating` / `% Needs Updating` sort headers render with real data (Brazil 3,522 / 17.9%, USA 6,820 / 56.8%)
  - **Map colour-mode dropdown** — `% Needs Updating` option present and selectable
  - **SSC Specialist Group, Table 1a, Comparison Mode** — all show the new header
  - **Species dashboard** — the `Needs Updating` toggle flips `aria-pressed` false→true, keeps its `Filter to species last assessed before 25 Aug 2016` tooltip, drives the URL to `?taxa=mammals&outdated=yes`, and renders the `Needs updating (>10 yrs)` chip
  - `Outdated` no longer appears in the rendered text of any page checked
  - **Layout A/B** — measured table `scrollWidth` vs container width on the landing page and in Comparison Mode, with the new label and with the old one stashed: identical (landing 1022/1022; Comparison 943/684). The longer label causes no layout change — the bar-column header wraps as designed, and Comparison Mode's horizontal scroll is pre-existing.
- `curl` against `/llms.txt` and `/browse` — both render the new wording

### Verification caveats

Two things could not be exercised in this sandbox, both for environment reasons rather than anything in this diff:

- **Map hover tooltip** (`# / % Needs Updating`) — map tiles are blocked by the sandbox proxy, so the map renders blank and hover can't be triggered. The strings are a straight substitution in the same tooltip block; worth a quick hover on a real environment.
- **Species table rows** — `app/data/redlist/` is populated from the private R2 bucket, and no R2 credentials are available here. I verified the species dashboard against a small locally-generated CSV fixture (gitignored, not committed) so the filter button and chip could be driven for real; the DuckDB-backed species list itself stayed empty.

No screenshots are attached: uploading to the `pr-assets` R2 bucket per `CLAUDE.md` needs `R2_*` credentials, which this environment doesn't have.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeEHJwemiVXxJhg9DD6383)_