### PR TITLE
Show facilitators alongside assessors and reviewers on the assessments tab

### DIFF
--- a/app/src/components/RedListAssessments.tsx
+++ b/app/src/components/RedListAssessments.tsx
@@ -10,6 +10,13 @@ interface PreviousAssessment {
   category: string;
   assessors?: string | null;
   reviewers?: string | null;
+  /**
+   * The individuals behind an organisational assessor — every bird assessment
+   * credits "BirdLife International", so the assessor line names no person and
+   * the facilitator line is the only one that does. Optional because it is
+   * absent from history written before the field existed, not just unset.
+   */
+  facilitators?: string | null;
 }
 
 interface AssessmentDetail {
@@ -572,7 +579,7 @@ function AssessmentDetailView({
   assessment,
 }: {
   detail: AssessmentDetail;
-  assessment: { year: string; assessment_id: number; category: string; assessors?: string | null; reviewers?: string | null };
+  assessment: PreviousAssessment;
 }) {
   const catCode = getCategoryCode(detail.red_list_category) !== "?" ? getCategoryCode(detail.red_list_category) : assessment.category;
   const trendText = getTrendText(detail.population_trend);
@@ -637,11 +644,12 @@ function AssessmentDetailView({
         )}
       </div>
 
-      {/* Assessors & Reviewers */}
-      {(assessment.assessors || assessment.reviewers) && (
+      {/* Assessors, Reviewers & Facilitators */}
+      {(assessment.assessors || assessment.reviewers || assessment.facilitators) && (
         <div className="text-xs text-zinc-500 dark:text-zinc-400 space-y-0.5">
           {assessment.assessors && <div><span className="font-medium">Assessors:</span> {assessment.assessors}</div>}
           {assessment.reviewers && <div><span className="font-medium">Reviewers:</span> {assessment.reviewers}</div>}
+          {assessment.facilitators && <div><span className="font-medium">Facilitators:</span> {assessment.facilitators}</div>}
         </div>
       )}
 

--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -3232,8 +3232,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
   }, [selectedSpeciesKey, paginatedSpecies, speciesDetails]);
 
   // Lazily fetch the full assessment history for the open species (the list
-  // carries only the latest assessors/reviewers; the history array is fetched
-  // here on demand for the Red List Assessments tab).
+  // carries only the latest assessors/reviewers/facilitators; the history array is
+  // fetched here on demand for the Red List Assessments tab).
   useEffect(() => {
     if (!selectedSpeciesKey) return;
     const s = paginatedSpecies.find((sp) => sp.species_key === selectedSpeciesKey);
@@ -6355,7 +6355,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                                 currentAssessmentId={s.assessment_id ?? 0}
                                 currentCategory={s.category}
                                 currentAssessmentDate={s.assessment_date}
-                                previousAssessments={((s.sis_taxon_id ? assessmentHistory[s.sis_taxon_id] : null) ?? s.previous_assessments ?? []).map((a) => ({ year: a.year, assessment_id: a.id, category: a.category, assessors: a.assessors, reviewers: a.reviewers }))}
+                                previousAssessments={((s.sis_taxon_id ? assessmentHistory[s.sis_taxon_id] : null) ?? s.previous_assessments ?? []).map((a) => ({ year: a.year, assessment_id: a.id, category: a.category, assessors: a.assessors, reviewers: a.reviewers, facilitators: a.facilitators }))}
                                 speciesUrl={`https://www.iucnredlist.org/species/${s.sis_taxon_id}/${s.assessment_id}`}
                               />
                             </div>


### PR DESCRIPTION
## Summary

The IUCN Red List Assessments tab showed two credit lines per assessment — **Assessors** and **Reviewers**. Adds a third: **Facilitators**.

This matters most for birds: every bird assessment credits "BirdLife International" as its assessor, so the assessor line names no person and the facilitator line is the only one that does — the same reasoning behind the existing Facilitators chart/filter card.

No new data fetching. The per-assessment history the tab already loads (`/api/redlist/species/history` → `getAssessmentHistory`) has carried `facilitators` all along; it just wasn't passed into the panel or rendered.

- `RedListView.tsx` — include `facilitators` in the `previousAssessments` mapping handed to `RedListAssessments` (and refresh the now-stale comment above the history fetch).
- `RedListAssessments.tsx` — add `facilitators?: string | null` to `PreviousAssessment`, reuse that interface for `AssessmentDetailView`'s `assessment` prop instead of the duplicated inline shape it had drifted from, and render the line conditionally like the other two.

Optional field, per-line conditional: assessments from before IUCN recorded facilitators show Assessors/Reviewers only, with no empty row.

## Test plan

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm test` — 1159 passed, 6 skipped (59 files)
- Browser drive-through (Playwright + Chromium, real dev server): opened a species → **IUCN Red List Assessments** tab, confirmed the credit block renders

  ```
  Assessors: BirdLife International
  Reviewers: Butchart, S.
  Facilitators: Symes, A. & Westrip, J.R.S.
  ```

  then clicked back to an older assessment whose `facilitators` is `null` and confirmed only Assessors/Reviewers render — no stray Facilitators line. No console errors from the app.

**Caveat on the browser check:** this session ran in a remote sandbox with no R2 credentials (so no `app/data/*.parquet` for the species/history routes) and no `RED_LIST_API_KEY` (the assessment-detail route calls the live IUCN API). Those three endpoints were stubbed at the network layer with realistic fixtures; everything above them — routing, `RedListView`, `RedListAssessments` — is the real app rendering in a real browser. Worth one look against production data before merge, since the fixtures, not the app, supplied the credit strings.

No screenshots in the body: uploading to the `pr-assets` R2 bucket per `CLAUDE.md` needs the R2 credentials this sandbox doesn't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaD62u2sit49Gqor56YDX6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaD62u2sit49Gqor56YDX6)_