### PR TITLE
Hide the Wikipedia tab

### DIFF
--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -44,6 +44,10 @@ type LegacyDetailTab = DetailTab | "assessors" | "reviewers";
 // /api/eol routes are all still here — flip this back to true to bring it back.
 const SHOW_EOL_TAB = false;
 
+// Wikipedia tab is hidden for now. The tab, its panel and the WikipediaSummary
+// component are all still here — flip this back to true to bring it back.
+const SHOW_WIKIPEDIA_TAB = false;
+
 // A ?tab=eol link (or a stale one) shouldn't strand the user on a tab with no
 // button in the bar, so fall back to the default tab while EoL is hidden.
 function visibleTab(tab: LegacyDetailTab | null | undefined): DetailTab {
@@ -53,6 +57,7 @@ function visibleTab(tab: LegacyDetailTab | null | undefined): DetailTab {
   // roleFromLegacyTab).
   if (tab === "assessors" || tab === "reviewers") return "candidates";
   if (tab === "eol" && !SHOW_EOL_TAB) return "gbif";
+  if (tab === "wikipedia" && !SHOW_WIKIPEDIA_TAB) return "gbif";
   return tab;
 }
 
@@ -6466,12 +6471,14 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                                     Encyclopedia of Life
                                   </button>
                                 )}
-                                <button
-                                  className={`shrink-0 px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "wikipedia" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
-                                  onClick={() => setActiveDetailTab("wikipedia")}
-                                >
-                                  Wikipedia
-                                </button>
+                                {SHOW_WIKIPEDIA_TAB && (
+                                  <button
+                                    className={`shrink-0 px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "wikipedia" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
+                                    onClick={() => setActiveDetailTab("wikipedia")}
+                                  >
+                                    Wikipedia
+                                  </button>
+                                )}
                                 {s.category === "NE" && (
                                   <button
                                     className={`shrink-0 px-2 sm:px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors ${activeDetailTab === "candidates" ? "text-blue-600 dark:text-blue-400 border-b-2 border-blue-600 dark:border-blue-400" : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300"}`}
@@ -6581,7 +6588,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                               />
                             </div>
                           )}
-                          {(visitedTabs.has("wikipedia")) && (
+                          {SHOW_WIKIPEDIA_TAB && (visitedTabs.has("wikipedia")) && (
                           <div style={{ display: activeDetailTab === "wikipedia" ? undefined : "none" }}>
                             <WikipediaSummary scientificName={s.scientific_name} />
                           </div>


### PR DESCRIPTION
## Summary

Hides the **Wikipedia** tab from the species detail panel, using the same pattern already in place for the hidden Encyclopedia of Life tab:

- New `SHOW_WIKIPEDIA_TAB = false` constant in `RedListView.tsx`, sitting next to `SHOW_EOL_TAB`.
- The tab button and its panel (`WikipediaSummary`) are both gated on it.
- `visibleTab()` maps `?tab=wikipedia` back to the default GBIF tab, so an existing shared link doesn't strand the user on a tab that has no button in the bar.

Nothing is deleted — the tab, its panel and `WikipediaSummary` all stay in the tree. Flipping the flag back to `true` brings the tab back exactly as it was (verified, see below).

The detail tab bar now reads: **GBIF · Literature · IUCN Red List Assessments · CITES · Catalogue of Life** (plus Suggested Experts on NE rows).

## Test plan

- `npx tsc --noEmit` — clean.
- `npm run lint` — clean.
- `npx vitest run src/hooks/__tests__/filterParams.test.ts` — 130 passed (the only test file touching the `tab` param).
- **Browser drive-through** (Playwright against `npm run dev`, species row expanded):
  - Tab bar renders `["GBIF","Literature","IUCN Red List Assessments","CITES","Catalogue of Life"]`; zero buttons named "Wikipedia".
  - Legacy deep link `?tab=wikipedia&species=sis-22823` opens the row on the **GBIF** tab (active tab confirmed), no dead tab state.
  - Flipping `SHOW_WIKIPEDIA_TAB` to `true` temporarily: the Wikipedia button reappears in the bar and the same legacy link lands on it — then reverted.
  - No new console errors attributable to this change (only sandbox egress failures for GBIF/Sentry/tiles).

Two caveats on how that verification ran, for transparency:
- This session's container has no R2 credentials, so `app/data/` has no species parquet and the real species query can't run locally. The species list response was stubbed with one synthetic row (`Panthera leo`) via Playwright request interception — the UI code under test is unmodified and rendered for real.
- No screenshots attached: uploading to the `pr-assets` R2 bucket (per CLAUDE.md) needs credentials this container doesn't have, and committing images to the repo isn't allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKBXQhNUY4dA5wfDQx4UZo

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKBXQhNUY4dA5wfDQx4UZo)_