### PR TITLE
Label the years-chart outdated filter "10+ yrs old"

### DIFF
--- a/app/src/components/redlist/RedListView.tsx
+++ b/app/src/components/redlist/RedListView.tsx
@@ -4821,8 +4821,8 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
             {/* Years Since Assessed / Year of Latest Assessment */}
             <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl p-3 flex flex-col">
               {/* The charts row is a fixed-width 3-up grid, so this header always has
-                  ~305px to work with, whatever the viewport. Title + Needs Updating +
-                  the view select came to ~341px, which wrapped the two controls onto
+                  ~305px to work with, whatever the viewport. Title + the "10+ yrs old"
+                  button + the view select came to ~341px, which wrapped the two controls onto
                   a row of their own; the sizes below (and on both controls) are what
                   fits them beside the title instead. It still wraps rather than
                   overflowing if a platform's text runs wider than the ~6px to spare. */}
@@ -4846,7 +4846,7 @@ export default function RedListView({ viewMode = "reassessments", onViewModeChan
                       aria-pressed={isOutdatedSelected}
                       title={`Filter to species last assessed before ${outdatedCutoffDate(dataAsOf).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })}`}
                     >
-                      Needs Updating
+                      10+ yrs old
                     </button>
                   )}
                   {/* Pagination controls (year view only, and only when multiple pages) */}

--- a/app/src/components/redlist/TaxaSummary.tsx
+++ b/app/src/components/redlist/TaxaSummary.tsx
@@ -231,7 +231,7 @@ const flexTdClasses = `${cellPad} ${colDivider} whitespace-nowrap w-0`;
 const flexThClasses = `${cellPad} ${colDivider} text-left text-sm font-bold text-zinc-600 dark:text-zinc-300 whitespace-nowrap w-0`;
 // Bar-column headers (Assessed / Outdated / Unassessed / Not Evaluated) are allowed
 // to wrap: their cells already carry a bar min-width, so a long single-line header
-// (e.g. "# Needs Updating (>10 yrs old)") would otherwise force the column wider than
+// (e.g. "# Needs Updating (10+ yrs old)") would otherwise force the column wider than
 // it needs to be and push the table into horizontal overflow.
 const centeredThClasses = `${cellPad} ${colDivider} text-center text-sm font-bold text-zinc-600 dark:text-zinc-300 w-0`;
 // "# Described Species" is the widest single-line header after the taxon name
@@ -257,7 +257,7 @@ const COLUMN_LABELS: Record<ColumnId, string> = {
   described: "# Described Species",
   colDescribed: "# Described Species (CoL)",
   assessed: "# Red List Assessed",
-  outdated: "# Needs Updating (>10 yrs old)",
+  outdated: "# Needs Updating (10+ yrs old)",
   breakdown: "Conservation Status Breakdown",
   gbifUnassessed: "# Unassessed, 1+ GBIF Obs",
   colNe: "# Not Evaluated",
@@ -2607,13 +2607,13 @@ export default function TaxaSummary({ onToggleTaxon, selectedTaxa, selectedSubgr
         {isVisible("outdated") && (
           <th className={countryStyleColumns ? numericThNoDividerClasses : centeredThClasses}>
             {/* Country View's half-width column has no room for the full
-                "(>10 yrs old)" qualifier + info icon on one non-wrapping line
+                "(10+ yrs old)" qualifier + info icon on one non-wrapping line
                 (inline-flex forces it to stay unwrapped) — shortened here,
                 same info still available via the plain-mode header. */}
             {countryStyleColumns ? (
               "# Needs Updating"
             ) : (
-              <span className="inline-flex items-center gap-1"># Needs Updating (&gt;10 yrs old) <OutdatedInfoIcon /></span>
+              <span className="inline-flex items-center gap-1"># Needs Updating (10+ yrs old) <OutdatedInfoIcon /></span>
             )}
           </th>
         )}


### PR DESCRIPTION
## Summary

Label-only change to how the ">10 years since assessment" cutoff is worded in the UI. The underlying threshold (`isOutdated`, strictly more than 10 years) is unchanged — no logic, data, or filter behaviour touched.

- **Years Since Assessed chart** (`RedListView.tsx`): the outdated shortcut button now reads **"10+ yrs old"** instead of "Needs Updating". Its tooltip still names the exact cutoff date ("Filter to species last assessed before 2 Sept 2016").
- **Needs Updating column header** (`TaxaSummary.tsx`): qualifier changed from "(>10 yrs old)" to **"(10+ yrs old)"**, in both the rendered header and the `COLUMN_LABELS` entry used by the column-toggle menu. The Country View's shortened "# Needs Updating" header is unaffected (it never carried the qualifier).

Not changed (out of scope, flagged for a follow-up if wanted): the active-filter chip still reads "Needs updating (>10 yrs)".

## Test plan

- `npx tsc --noEmit` — clean.
- `npm run lint` — clean.
- **Browser drive-through** (dev server + Playwright, per `.claude/skills/verify-ui/`):
  - Landing table header renders `# Needs Updating (10+ yrs old)`, info icon still inline, column width unchanged.
  - Drilled into Mammals → Years Since Assessed card shows the button reading "10+ yrs old", sitting on one line beside the title and the Range select (no wrap).
  - Clicked it: `aria-pressed` → `true` with the red active styling; clicked again: → `false`, back to the muted style.

**Caveat on the drive-through:** species-level data could not load in this sandbox — the DuckDB `httpfs` extension host (`extensions.duckdb.org`) is blocked by the environment's egress policy and no R2 credentials are present, so the charts render at zero behind a "Failed to load Red List data" banner. That's environmental and unrelated to this diff; the label text, layout/no-wrap, and both toggle states were all still directly observable. For the same reason (no R2 credentials) no screenshots were uploaded to the `pr-assets` bucket — happy to add them from a machine with data + creds if you'd like them in the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015naDcpaq8iD351euGxe1Sx

---
_Generated by [Claude Code](https://claude.ai/code/session_015naDcpaq8iD351euGxe1Sx)_