### PR TITLE
Open the map on every basis of record but living and fossil specimens, and no coordinate cleaning

### DIFF
--- a/app/src/components/mapping/OccurrenceMapRow.tsx
+++ b/app/src/components/mapping/OccurrenceMapRow.tsx
@@ -6,7 +6,6 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import type { MapRef, ViewStateChangeEvent, MapLayerMouseEvent } from "react-map-gl/maplibre";
 import type maplibregl from "maplibre-gl";
-import { taxonGroupCountsPreservedSpecimens } from "@/lib/gbif";
 import { InatObservation, getThumbUrl, InatPhotoWithPreview } from "@/components/InatPhotoCard";
 import { QualityFlag, QUALITY_FLAG_LABELS, QUALITY_FLAG_DESCRIPTIONS, QUALITY_FLAG_SOURCES } from "@/lib/mapping/coordinate-cleaning";
 import { fetchInstitutionName, knownInstitutionName } from "@/lib/mapping/grscicoll";
@@ -630,54 +629,46 @@ interface OccurrenceMapRowProps {
 }
 
 /**
- * Plants & fungi rely heavily on herbarium/fungarium specimens in GBIF, so
- * preserved specimens are ON by default for those kingdoms — the same rule the
- * counts behind this map are now fetched under, so the checkbox a species opens
- * with matches the number that got the user here. Re-exported rather than
- * redefined so the two cannot drift.
- */
-export const isPlantOrFungiTaxonGroup = taxonGroupCountsPreservedSpecimens;
-
-/**
  * Which record types are selected when the viewer opens.
  *
- * Plants and fungi start with every one of them, because for these kingdoms
- * the herbarium or fungarium sheet is often the only record there is, and a
- * default that quietly drops record types hides the very evidence an
- * assessment gets written from. Animals keep the narrower set: field
- * observations, with specimens and literature citations off until asked for.
+ * Every kingdom now starts with every record type but two, rather than only
+ * plants and fungi: a herbarium sheet, a museum skin or a literature citation
+ * is evidence of where the species was, and a default that quietly drops
+ * record types hides the very evidence an assessment gets written from.
+ *
+ * The two exceptions are the ones that say where an individual *ended up*
+ * rather than where the species lives: a living specimen is a zoo or botanic
+ * garden animal or plant, and a fossil specimen is a range from a different
+ * epoch. Both are off until asked for.
  */
-export function defaultCheckedTypes(taxonGroup: string | undefined) {
-  const everything = isPlantOrFungiTaxonGroup(taxonGroup);
+export function defaultCheckedTypes() {
   return {
     humanObservation: true,
     machineObservation: true,
-    observation: everything,
-    preservedSpecimen: everything,
-    fossilSpecimen: everything,
-    livingSpecimen: everything,
+    observation: true,
+    preservedSpecimen: true,
+    fossilSpecimen: false,
+    livingSpecimen: false,
     materialSample: true,
-    materialCitation: everything,
-    occurrence: everything,
+    materialCitation: true,
+    occurrence: true,
   };
 }
 
 /**
  * Which coordinate-cleaning checks are applied when the viewer opens.
  *
- * None at all for plants and fungi — same reasoning: these checks are
- * plausibility heuristics with real false-positive rates, and a herbarium
- * record trimmed by one is a record an assessor never sees. Everything else
- * starts with the two that flag coordinates nothing can defend: null island,
- * and exact duplicates.
+ * None at all, for any kingdom — the rule that used to apply only to plants
+ * and fungi. These checks are plausibility heuristics with real false-positive
+ * rates, and a record trimmed by one is a record an assessor never sees. The
+ * viewer opens on everything GBIF holds; the cleaning is opt-in from there.
  */
-export function defaultAppliedChecks(taxonGroup: string | undefined): Record<QualityFlag, boolean> {
-  const clean = !isPlantOrFungiTaxonGroup(taxonGroup);
+export function defaultAppliedChecks(): Record<QualityFlag, boolean> {
   return {
-    ZERO_COORDINATE: clean,
+    ZERO_COORDINATE: false,
     EQUAL_COORDINATES: false,
     GBIF_HEADQUARTERS: false,
-    DUPLICATE: clean,
+    DUPLICATE: false,
     NEAR_CAPITAL: false,
     NEAR_CENTROID: false,
     NEAR_INSTITUTION: false,
@@ -828,7 +819,7 @@ export default function OccurrenceMapRow({
   const [loadingOccurrences, setLoadingOccurrences] = useState(true);
   const [loadingBreakdown, setLoadingBreakdown] = useState(true);
 
-  const [checkedTypes, setCheckedTypes] = useState(() => defaultCheckedTypes(taxonGroup));
+  const [checkedTypes, setCheckedTypes] = useState(() => defaultCheckedTypes());
 
   // Advanced filter state
   const [maxUncertainty, setMaxUncertainty] = useState<number | null>(null);
@@ -845,13 +836,11 @@ export default function OccurrenceMapRow({
   // src/lib/coordinate-cleaning.ts), individually toggleable. Default all off —
   // opt-in, since these are plausibility heuristics with real false-positive risk
   // (documented per-check), not the same as GBIF's own hasGeospatialIssue=false
-  // parsing-error filter, which stays on unconditionally upstream of this. Two
-  // exceptions default on: zero/null-island coordinates (no plausible reading of
-  // (0,0) or an axis-zero point as a real location), and repeated coordinates
-  // (an exact duplicate of another record adds nothing on the map and is a very
-  // common GBIF artifact — only the repeat is hidden, the first stays visible).
+  // parsing-error filter, which stays on unconditionally upstream of this. No
+  // exceptions: not even null island or exact duplicates are trimmed before the
+  // assessor asks, so the viewer opens on everything GBIF holds for the species.
   const [appliedChecks, setAppliedChecks] = useState<Record<QualityFlag, boolean>>(() =>
-    defaultAppliedChecks(taxonGroup)
+    defaultAppliedChecks()
   );
   // Native range only — hide occurrences reported in a country outside this
   // species' native range. Off by default (folded into the Coordinate cleaning
@@ -1543,9 +1532,9 @@ export default function OccurrenceMapRow({
   // Records GBIF flags are always fetched now: they have coordinates, so they
   // belong with the rest and are hidden (or not) by a coordinate-cleaning check
   // like any other suspect point, rather than by a separate opt-in.
-  // Off for plants and fungi, on for everything else — the same rule the other
-  // cleaning checks follow, since this is now one of them.
-  const [hideGbifFlagged, setHideGbifFlagged] = useState(() => !isPlantOrFungiTaxonGroup(taxonGroup));
+  // Off by default — the same rule the other cleaning checks follow, since
+  // this is now one of them.
+  const [hideGbifFlagged, setHideGbifFlagged] = useState(false);
   const [recordSetTotals, setRecordSetTotals] = useState<{ mapped: number; issue: number; missing: number } | null>(null);
 
   /**

--- a/app/src/components/mapping/__tests__/occurrenceDefaults.test.ts
+++ b/app/src/components/mapping/__tests__/occurrenceDefaults.test.ts
@@ -1,46 +1,43 @@
 /**
  * What the occurrence viewer shows before anyone touches a filter.
  *
- * These defaults decide what an assessor sees first, and for plants and fungi
- * the old ones hid most of the evidence: specimens off, and cleaning checks
- * trimming points on plausibility heuristics. Worth pinning down.
+ * These defaults decide what an assessor sees first, and the old ones hid most
+ * of the evidence for everything but plants and fungi: specimens and citations
+ * off, and cleaning checks trimming points on plausibility heuristics. The
+ * viewer now opens on everything GBIF holds, for every kingdom, bar the two
+ * record types that describe where an individual ended up rather than where the
+ * species lives. Worth pinning down.
  */
 import { describe, it, expect } from "vitest";
 import { defaultCheckedTypes, defaultAppliedChecks } from "../OccurrenceMapRow";
 
-const PLANT_AND_FUNGI_GROUPS = ["flowering_plants", "gymnosperms", "ferns_and_allies", "mushrooms"];
-const ANIMAL_GROUPS = ["mammals", "birds", "reptiles", "amphibians", "fishes"];
-
 describe("defaultCheckedTypes", () => {
-  it.each(PLANT_AND_FUNGI_GROUPS)("selects every record type for %s", (group) => {
-    expect(Object.values(defaultCheckedTypes(group)).every(Boolean)).toBe(true);
+  it("selects every record type but living and fossil specimens", () => {
+    const types = defaultCheckedTypes();
+    expect(types.livingSpecimen).toBe(false);
+    expect(types.fossilSpecimen).toBe(false);
+    const { livingSpecimen: _l, fossilSpecimen: _f, ...rest } = types;
+    expect(Object.values(rest).every(Boolean)).toBe(true);
   });
 
-  it.each(ANIMAL_GROUPS)("keeps specimens and citations off for %s", (group) => {
-    const types = defaultCheckedTypes(group);
-    expect(types.preservedSpecimen).toBe(false);
-    expect(types.fossilSpecimen).toBe(false);
-    expect(types.materialCitation).toBe(false);
-    // Field observations stay on, which is what these counts have always meant.
+  it("keeps specimens, citations and field observations on", () => {
+    const types = defaultCheckedTypes();
+    expect(types.preservedSpecimen).toBe(true);
+    expect(types.materialCitation).toBe(true);
     expect(types.humanObservation).toBe(true);
     expect(types.machineObservation).toBe(true);
-  });
-
-  it("falls back to the narrower set when the taxon group is unknown", () => {
-    expect(defaultCheckedTypes(undefined).preservedSpecimen).toBe(false);
   });
 });
 
 describe("defaultAppliedChecks", () => {
-  it.each(PLANT_AND_FUNGI_GROUPS)("applies no cleaning check for %s", (group) => {
-    expect(Object.values(defaultAppliedChecks(group)).some(Boolean)).toBe(false);
+  it("applies no cleaning check at all", () => {
+    expect(Object.values(defaultAppliedChecks()).some(Boolean)).toBe(false);
   });
 
-  it.each(ANIMAL_GROUPS)("still drops null island and duplicates for %s", (group) => {
-    const checks = defaultAppliedChecks(group);
-    expect(checks.ZERO_COORDINATE).toBe(true);
-    expect(checks.DUPLICATE).toBe(true);
-    // Everything else is opt-in: these are heuristics with false positives.
+  it("leaves even null island and duplicates opt-in", () => {
+    const checks = defaultAppliedChecks();
+    expect(checks.ZERO_COORDINATE).toBe(false);
+    expect(checks.DUPLICATE).toBe(false);
     expect(checks.NEAR_CAPITAL).toBe(false);
     expect(checks.URBAN_AREA).toBe(false);
     expect(checks.OUTSIDE_REPORTED_COUNTRY).toBe(false);

--- a/app/src/lib/__tests__/taxonGroupCountsPreservedSpecimens.test.ts
+++ b/app/src/lib/__tests__/taxonGroupCountsPreservedSpecimens.test.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { isPlantOrFungiTaxonGroup } from "../OccurrenceMapRow";
+import { taxonGroupCountsPreservedSpecimens } from "../gbif";
 import { ALL_TAXON_GROUPS } from "@/config/taxonomy-tree";
 
 // ---------------------------------------------------------------------------
-// isPlantOrFungiTaxonGroup — decides whether PRESERVED_SPECIMEN should default
-// to ON for a given species' CSV taxon group. Plants & fungi rely heavily on
-// herbarium/fungarium records, so they default ON; all other kingdoms default
-// OFF (matching the historical behavior for animals).
+// taxonGroupCountsPreservedSpecimens — decides whether PRESERVED_SPECIMEN is
+// counted for a given species' CSV taxon group. Plants & fungi rely heavily on
+// herbarium/fungarium records, so they count in; all other kingdoms don't.
+// (The occurrence map no longer asks this — its checkboxes default the same way
+// for every kingdom — but the dashboard's GBIF counts still do.)
 // ---------------------------------------------------------------------------
-describe("isPlantOrFungiTaxonGroup", () => {
+describe("taxonGroupCountsPreservedSpecimens", () => {
   it.each([
     "flowering_plants",
     "gymnosperms",
@@ -17,14 +18,14 @@ describe("isPlantOrFungiTaxonGroup", () => {
     "green_algae",
     "red_algae",
   ])("returns true for plant group %s", (group) => {
-    expect(isPlantOrFungiTaxonGroup(group)).toBe(true);
+    expect(taxonGroupCountsPreservedSpecimens(group)).toBe(true);
   });
 
   it.each([
     "mushrooms",
     "brown_algae",
   ])("returns true for fungi group %s", (group) => {
-    expect(isPlantOrFungiTaxonGroup(group)).toBe(true);
+    expect(taxonGroupCountsPreservedSpecimens(group)).toBe(true);
   });
 
   it.each([
@@ -43,15 +44,15 @@ describe("isPlantOrFungiTaxonGroup", () => {
     "velvet_worms",
     "horseshoe_crabs",
   ])("returns false for animal group %s", (group) => {
-    expect(isPlantOrFungiTaxonGroup(group)).toBe(false);
+    expect(taxonGroupCountsPreservedSpecimens(group)).toBe(false);
   });
 
   it("returns false when taxonGroup is undefined", () => {
-    expect(isPlantOrFungiTaxonGroup(undefined)).toBe(false);
+    expect(taxonGroupCountsPreservedSpecimens(undefined)).toBe(false);
   });
 
   it("returns false for an unknown taxon group", () => {
-    expect(isPlantOrFungiTaxonGroup("not_a_real_group")).toBe(false);
+    expect(taxonGroupCountsPreservedSpecimens("not_a_real_group")).toBe(false);
   });
 
   // Guards against forgetting to add newly-introduced taxon groups to the
@@ -59,7 +60,7 @@ describe("isPlantOrFungiTaxonGroup", () => {
   // should classify deterministically as plant/fungi-or-not.
   it("covers every Table 1a taxon group", () => {
     for (const group of ALL_TAXON_GROUPS) {
-      const result = isPlantOrFungiTaxonGroup(group);
+      const result = taxonGroupCountsPreservedSpecimens(group);
       expect(typeof result).toBe("boolean");
     }
   });


### PR DESCRIPTION
## Summary

The occurrence viewer's defaults were split by kingdom. Plants and fungi opened with every record type checked and no cleaning; everything else opened with only field observations and material samples — preserved specimens, literature citations and bare "occurrence" records off until asked for — plus three coordinate-cleaning filters already trimming points (null island, exact duplicates, and GBIF's own geospatial flag).

This makes the defaults the same for every kingdom:

**Basis of Record — everything on, except two.** A museum skin, a herbarium sheet and a literature record are evidence of where a species was regardless of its kingdom, and a default that quietly drops them hides the very evidence an assessment gets written from. The two that stay off are the ones that say where an individual *ended up* rather than where the species lives:

| Record type | Before (animals) | Before (plants/fungi) | Now |
|---|---|---|---|
| Human observation | on | on | **on** |
| Machine observation | on | on | **on** |
| Observation | off | on | **on** |
| Preserved specimen | off | on | **on** |
| Material sample | on | on | **on** |
| Material citation | off | on | **on** |
| Occurrence | off | on | **on** |
| Fossil specimen | off | on | **off** |
| Living specimen | off | on | **off** |

Note this flips fossil and living specimens *off* for plants and fungi, which previously had them on — a botanic-garden accession and a Miocene leaf impression are no more a statement about the current range than a zoo animal is.

**Coordinate cleaning — nothing applied.** The rule plants and fungi already had, now for everything. These checks are plausibility heuristics with real false-positive rates, so the viewer opens on everything GBIF holds and the trimming is opt-in from there. That includes the "Flagged by GBIF" row, which already sits with the cleaning checks in the dropdown and now follows the same default.

**Incidental cleanup.** `defaultCheckedTypes` and `defaultAppliedChecks` no longer branch on taxon group, so they lose their parameter. That left the `isPlantOrFungiTaxonGroup` alias in `OccurrenceMapRow` dead, with a doc comment describing a rule that no longer exists, so it's removed; its tests move onto `taxonGroupCountsPreservedSpecimens`, the live function underneath it that the dashboard's GBIF *counts* still use. Those counts are deliberately untouched — this PR changes what the map opens with, not what the dashboard totals mean.

## Test plan

- `npx vitest run` — 1466 passed, 8 skipped (79 files). `occurrenceDefaults.test.ts` rewritten for the new defaults; the retargeted `taxonGroupCountsPreservedSpecimens.test.ts` keeps its full Table-1a-group coverage.
- `npx tsc --noEmit` — clean.
- `npx eslint` on the changed files — clean.
- **Browser drive-through** (Playwright, Chromium, `/mapping` fullscreen view on *Panthera leo*, a mammal — the case the old animal defaults applied to, and one with real preserved, fossil and material-citation records in GBIF):
  - Toolbar reads **"Basis of Record · Selected 7 of 9"** and **"Coordinate cleaning · Applied 0 of 12"**.
  - Basis dropdown: Human observation, Machine observation, Observation, Preserved specimen (194 loaded), Material sample, Material citation, Occurrence all checked; **Fossil specimen and Living specimen unchecked** — the only two.
  - Cleaning dropdown: all 12 rows unchecked, including "Flagged by GBIF" (which offers to hide 127 records rather than having hidden them).
  - No page errors; map canvas and record list render, 730 records listed.

Screenshots aren't attached: this sandbox has no R2 credentials to upload them under the repo's `pr-assets` convention, and its network policy blocks the basemap tile host, so a capture would show the points over a blank basemap rather than the real map. The interactive verification above was done against live GBIF data in a real browser — the checkbox states and toolbar counts are read from the running app, not inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QD6H8uDpspS4WXJLkqKs1k

---
_Generated by [Claude Code](https://claude.ai/code/session_01QD6H8uDpspS4WXJLkqKs1k)_