### PR TITLE
Consent-gated PostHog session recording for signed-in users

### DIFF
--- a/.claude/skills/verify-ui/SKILL.md
+++ b/.claude/skills/verify-ui/SKILL.md
@@ -84,3 +84,34 @@ Write the driver script inside `app/` (not `/tmp`) so Node's module resolution f
 - **React controlled inputs**: use Playwright's `fill`/`click`, not `eval el.value = ...` — the latter skips React's onChange.
 - **Slow first paint**: Turbopack compiles routes on demand; the first `page.goto` can take several seconds. Use `waitForSelector`, not a fixed `waitForTimeout`.
 - **Data-dependent UI**: most of the dashboard's summary tables (Table 1a mode, SSC groups mode, taxa subgroups) read from precomputed `app/data/*.json` files, not live queries. If a feature shows zeros/empty after a code change, check whether the underlying data file needs regenerating (`npx tsx scripts/build-taxa-summary.ts`) before assuming the UI is broken — see the main README's "Data Sync Pipeline" section.
+
+- **PostHog events never transmit under Playwright — and fail *silently*.** `posthog.capture()`
+  returns without queueing anything, sends no request, and logs nothing even with
+  `posthog.debug(true)`. This is not a bug in the app: posthog-js's `isLikelyBot`
+  (`src/utils/blocked-uas.ts`) blocks `headlesschrome` by user agent **and** ends with
+  `return !!navigator.webdriver`, so *any* WebDriver-controlled browser is classed as a bot
+  and every event is dropped by a silent `return` inside `capture()`. Do not conclude from a
+  Playwright run that analytics are broken in production. To verify analytics for real, defeat
+  both signals:
+
+  ```js
+  const ctx = await browser.newContext({
+    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+               "(KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36",   // no "HeadlessChrome"
+  });
+  await ctx.addInitScript(() =>
+    Object.defineProperty(navigator, "webdriver", { get: () => false })
+  );
+  ```
+
+  Then intercept `**/ingest/**` and fulfil the POSTs locally so test events never reach the
+  real PostHog project. The bodies are **raw gzip bytes in a `text/plain` request**, so read
+  them with `request.postDataBuffer()` (the string `postData()` mangles the binary) and
+  `zlib.gunzipSync`:
+
+  ```js
+  const buf = route.request().postDataBuffer();
+  const txt = buf[0] === 0x1f && buf[1] === 0x8b ? zlib.gunzipSync(buf).toString("utf8")
+                                                 : buf.toString("utf8");
+  JSON.parse(txt).batch?.forEach((e) => console.log(e.event));
+  ```

--- a/app/src/app/api/analytics/consent/route.ts
+++ b/app/src/app/api/analytics/consent/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { setAnalyticsConsent } from "@/lib/analytics/consent";
+
+/**
+ * Records the signed-in user's decision on session recording (#524).
+ *
+ * Write-only: the current state is read as part of /api/auth/me, which the
+ * client already fetches to render the account menu, so there is no GET here.
+ *
+ * The user id comes from the session cookie via getUser(), never from the
+ * request body — otherwise anyone could record a consent decision on someone
+ * else's behalf, which is exactly the claim this table exists to be able to
+ * make truthfully.
+ */
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Consent is only ever asked of signed-in users, so there is nobody to record
+  // a decision for here.
+  if (!user) {
+    return NextResponse.json({ error: "Not signed in" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => null);
+  if (typeof body?.consented !== "boolean") {
+    return NextResponse.json(
+      { error: "Expected a boolean `consented`" },
+      { status: 400 }
+    );
+  }
+
+  const { error } = await setAnalyticsConsent(supabase, user.id, body.consented);
+  if (error) {
+    return NextResponse.json({ error }, { status: 500 });
+  }
+
+  return NextResponse.json({ consented: body.consented });
+}

--- a/app/src/app/api/auth/me/route.ts
+++ b/app/src/app/api/auth/me/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { isAdmin } from "@/lib/auth/roles";
+import { getAnalyticsConsent } from "@/lib/analytics/consent";
 
 export async function GET() {
   const supabase = await createClient();
@@ -9,8 +10,15 @@ export async function GET() {
   } = await supabase.auth.getUser();
 
   return NextResponse.json({
+    // The account's own id, used client-side as the PostHog distinct_id once
+    // analytics consent is given (components/PostHogProvider.tsx). Deliberately
+    // the opaque uuid rather than the email, so the analytics identifier is not
+    // itself a piece of contact information.
+    id: user?.id ?? null,
     email: user?.email ?? null,
     avatarUrl: user?.user_metadata?.avatar_url ?? null,
     canViewRangeMap: await isAdmin(supabase, user?.id),
+    // null = never asked, true = opted in, false = asked and declined (#524).
+    analyticsConsent: await getAnalyticsConsent(supabase, user?.id),
   });
 }

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -5,7 +5,9 @@ import "./globals.css";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { ThemeProvider } from "../components/ThemeProvider";
 import { BrandProvider } from "../components/BrandProvider";
+import { MeProvider } from "../components/MeProvider";
 import { PostHogProvider } from "../components/PostHogProvider";
+import { AnalyticsConsentPrompt } from "../components/AnalyticsConsentPrompt";
 import { brandForHost } from "../config/brand";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -45,9 +47,17 @@ export default async function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <BrandProvider brand={brand}>
-          <PostHogProvider>
-            <ThemeProvider>{children}</ThemeProvider>
-          </PostHogProvider>
+          {/* MeProvider wraps PostHogProvider because the latter reads the
+              signed-in user's analytics consent from it to decide whether to
+              record (#524). */}
+          <MeProvider>
+            <PostHogProvider>
+              <ThemeProvider>
+                {children}
+                <AnalyticsConsentPrompt />
+              </ThemeProvider>
+            </PostHogProvider>
+          </MeProvider>
         </BrandProvider>
         <Analytics />
         <SpeedInsights />

--- a/app/src/app/privacy/page.tsx
+++ b/app/src/app/privacy/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Privacy policy",
   description:
-    "How this dashboard uses anonymous, cookieless usage analytics.",
+    "How this dashboard uses anonymous, cookieless usage analytics, and the optional session recording signed-in users can opt in to.",
 };
 
 export default function PrivacyPage() {
@@ -41,10 +41,12 @@ export default function PrivacyPage() {
           >
             PostHog
           </a>{" "}
-          (hosted in the EU). This data is not linked to your identity, even if
-          you are signed in. We do <strong>not</strong> use analytics cookies or
-          store any analytics identifier on your device, so no cookie banner is
-          needed. We also use{" "}
+          (hosted in the EU). By default this data is not linked to your
+          identity, even if you are signed in, and we do <strong>not</strong>{" "}
+          use analytics cookies or store any analytics identifier on your
+          device &mdash; which is why you see no cookie banner. The one
+          exception is session recording, which is off unless you switch it on;
+          see below. We also use{" "}
           <a
             href="https://sentry.io"
             target="_blank"
@@ -99,10 +101,38 @@ export default function PrivacyPage() {
         </p>
 
         <p>
-          <strong>Why.</strong> We process this data under our legitimate
-          interest in maintaining and improving a public research tool, and — for
-          account details — in offering sign-in at all. We do not sell it or use
-          it for advertising.
+          <strong>Session recording (optional, off by default).</strong> If you
+          are signed in, you can choose to let us record how you use the
+          dashboard: the pages you open, the searches and filters you use, and a
+          replay of what happened on your screen &mdash; where you moved, clicked
+          and scrolled &mdash; linked to your account. We use it only to find
+          the places where the dashboard is confusing or broken, and to see
+          which features are actually used. This is entirely optional and is{" "}
+          <strong>off unless you turn it on</strong>: nothing is recorded until
+          you agree, you do not need to agree to use any part of the site, and
+          you can switch it off again at any time from the account menu (your
+          avatar, top right), which stops recording immediately and removes the
+          identifier from your device. Turning it on stores an analytics
+          identifier on your device &mdash; the part that needs your permission,
+          and the reason we ask. Recordings are held by PostHog in the EU.
+          Passwords are never captured. To have past recordings deleted, email{" "}
+          <a
+            href="mailto:sw984@cam.ac.uk"
+            className="underline hover:text-zinc-800 dark:hover:text-zinc-200"
+          >
+            sw984@cam.ac.uk
+          </a>
+          .
+        </p>
+
+        <p>
+          <strong>Why.</strong> We process the anonymous analytics under our
+          legitimate interest in maintaining and improving a public research
+          tool, and &mdash; for account details &mdash; in offering sign-in at
+          all. Session recording is different: we rely on your consent, which is
+          why it is off until you give it and why withdrawing it takes effect
+          straight away. We do not sell any of this data or use it for
+          advertising.
         </p>
 
         <p>

--- a/app/src/components/AnalyticsConsentPrompt.tsx
+++ b/app/src/components/AnalyticsConsentPrompt.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Link from "next/link";
+import { useMe } from "./MeProvider";
+
+/**
+ * The one-time ask for session-recording consent (#524).
+ *
+ * Shown only to signed-in users who have never answered — `analyticsConsent`
+ * being null rather than false. Declining stores false, which is what keeps this
+ * from becoming a banner that nags on every visit; the decision stays reversible
+ * from the account menu either way.
+ *
+ * Notes on the wording and shape, which are load-bearing rather than cosmetic:
+ *  - Neither button is pre-selected or visually pushed as the default. Consent
+ *    has to be freely given, and a greyed-out "No thanks" next to a bright
+ *    "Allow" is a nudge that undermines that.
+ *  - It says what is recorded in plain terms and links the full policy, because
+ *    consent has to be informed by more than the word "analytics".
+ *  - Dismissing it is not an option: there is no × that leaves the question
+ *    unanswered, because "no answer" and "no" must not be silently conflated.
+ *    Declining is one click and is the same size as accepting.
+ */
+export function AnalyticsConsentPrompt() {
+  const { me, loaded, setAnalyticsConsent } = useMe();
+
+  if (!loaded || !me.email || me.analyticsConsent !== null) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-labelledby="analytics-consent-heading"
+      className="fixed bottom-4 right-4 z-50 w-[min(22rem,calc(100vw-2rem))] rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 shadow-lg p-4"
+    >
+      <h2
+        id="analytics-consent-heading"
+        className="text-sm font-semibold text-zinc-800 dark:text-zinc-100"
+      >
+        Help us improve the dashboard?
+      </h2>
+      <p className="mt-2 text-xs leading-relaxed text-zinc-600 dark:text-zinc-400">
+        With your permission we&rsquo;ll record how you use this site &mdash; the
+        pages, searches and filters you use, and a replay of your screen &mdash;
+        and link it to your account, so we can see where the dashboard is
+        confusing and fix it. You can turn this off at any time from the account
+        menu.{" "}
+        <Link
+          href="/privacy"
+          className="underline hover:text-zinc-800 dark:hover:text-zinc-200"
+        >
+          Privacy policy
+        </Link>
+        .
+      </p>
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          onClick={() => setAnalyticsConsent(true)}
+          className="flex-1 px-3 py-1.5 rounded-md border border-zinc-300 dark:border-zinc-600 text-xs font-medium text-zinc-700 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors"
+        >
+          Allow
+        </button>
+        <button
+          type="button"
+          onClick={() => setAnalyticsConsent(false)}
+          className="flex-1 px-3 py-1.5 rounded-md border border-zinc-300 dark:border-zinc-600 text-xs font-medium text-zinc-700 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors"
+        >
+          No thanks
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/AuthStatus.tsx
+++ b/app/src/components/AuthStatus.tsx
@@ -2,32 +2,17 @@
 
 import { useEffect, useRef, useState } from "react";
 import { signOut } from "@/lib/auth/actions";
-
-type Me = { email: string | null; avatarUrl: string | null };
+import { useMe } from "./MeProvider";
 
 export function AuthStatus() {
-  const [me, setMe] = useState<Me | null>(null);
-  const [loaded, setLoaded] = useState(false);
+  // Who is signed in, and whether they have consented to session recording,
+  // both come from MeProvider rather than a fetch of our own — the account menu
+  // and PostHogProvider have to agree about consent at every instant, and two
+  // copies of that state is a recording that outlives the toggle saying it
+  // stopped.
+  const { me, loaded, setAnalyticsConsent } = useMe();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    fetch("/api/auth/me")
-      .then((res) => (res.ok ? res.json() : { email: null, avatarUrl: null }))
-      .then((data: Me) => {
-        if (!cancelled) {
-          setMe(data);
-          setLoaded(true);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setLoaded(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -116,7 +101,27 @@ export function AuthStatus() {
           >
             {me.email}
           </p>
-          <form action={signOut}>
+          {/* Withdrawal has to be as easy as consent was (UK GDPR Art. 7(3)), so
+              the switch lives in the account menu permanently — not only in the
+              one-time prompt. It is also the only way back for someone who
+              declined, since that prompt never returns. */}
+          <label className="flex items-start gap-2 px-3 py-2 text-sm text-zinc-700 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors cursor-pointer">
+            <input
+              type="checkbox"
+              className="mt-0.5 shrink-0"
+              // A never-asked (null) state reads as off, which matches what is
+              // actually happening: nothing is being recorded.
+              checked={me.analyticsConsent === true}
+              onChange={(e) => setAnalyticsConsent(e.target.checked)}
+            />
+            <span>
+              Session recording
+              <span className="block text-xs text-zinc-500 dark:text-zinc-400">
+                Record my screen and searches to improve the site
+              </span>
+            </span>
+          </label>
+          <form action={signOut} className="border-t border-zinc-100 dark:border-zinc-700">
             <button
               type="submit"
               className="w-full text-left px-3 py-2 text-sm text-zinc-700 dark:text-zinc-200 hover:bg-zinc-50 dark:hover:bg-zinc-700 transition-colors"

--- a/app/src/components/MeProvider.tsx
+++ b/app/src/components/MeProvider.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+export type Me = {
+  id: string | null;
+  email: string | null;
+  avatarUrl: string | null;
+  /** null = never asked, true = opted in, false = asked and declined (#524). */
+  analyticsConsent: boolean | null;
+};
+
+const SIGNED_OUT: Me = {
+  id: null,
+  email: null,
+  avatarUrl: null,
+  analyticsConsent: null,
+};
+
+type MeContextValue = {
+  me: Me;
+  /** False until /api/auth/me answers, so callers can avoid flashing a
+   *  signed-out UI at someone who is in fact signed in. */
+  loaded: boolean;
+  /** Records a consent decision and reflects it locally straight away. */
+  setAnalyticsConsent: (consented: boolean) => Promise<void>;
+};
+
+const MeContext = createContext<MeContextValue>({
+  me: SIGNED_OUT,
+  loaded: false,
+  setAnalyticsConsent: async () => {},
+});
+
+/**
+ * One fetch of /api/auth/me for everything that needs to know who is signed in.
+ *
+ * This exists because analytics consent has two consumers that sit in different
+ * parts of the tree and must never disagree: PostHogProvider (which starts or
+ * stops session recording) and the account menu (which shows and toggles it). A
+ * second, independently-fetched copy of that state is a recording that keeps
+ * running after the toggle says it stopped, so they share one.
+ *
+ * Mounted above PostHogProvider in the root layout. Note that
+ * mapping/OccurrenceMapRow.tsx still fetches /api/auth/me itself for its
+ * canViewRangeMap check; it is left alone deliberately (it needs no consent
+ * state, and rewiring a 6,000-line component is not this change's business).
+ */
+export function MeProvider({ children }: { children: React.ReactNode }) {
+  const [me, setMe] = useState<Me>(SIGNED_OUT);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/auth/me")
+      .then((res) => (res.ok ? res.json() : SIGNED_OUT))
+      .then((data: Me) => {
+        if (cancelled) return;
+        setMe(data);
+        setLoaded(true);
+      })
+      .catch(() => {
+        // Network failure: stay signed-out, which is also the no-recording
+        // state. Failing closed is the only safe direction for consent.
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setAnalyticsConsent = useCallback(async (consented: boolean) => {
+    // Optimistic: the toggle and the prompt should feel instant, and the
+    // consequence of the write failing is that recording reverts on next load —
+    // never that we record without a stored decision, because the server is the
+    // only thing that decides on a fresh page load.
+    setMe((prev) => ({ ...prev, analyticsConsent: consented }));
+
+    try {
+      const res = await fetch("/api/analytics/consent", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ consented }),
+      });
+      if (!res.ok) throw new Error(String(res.status));
+    } catch {
+      // Roll back to "not recording" rather than to the previous value: if we
+      // could not store an opt-in, we have no record of consent, so we must not
+      // behave as though we had one.
+      setMe((prev) => ({ ...prev, analyticsConsent: consented ? null : prev.analyticsConsent }));
+    }
+  }, []);
+
+  return (
+    <MeContext.Provider value={{ me, loaded, setAnalyticsConsent }}>
+      {children}
+    </MeContext.Provider>
+  );
+}
+
+export function useMe() {
+  return useContext(MeContext);
+}

--- a/app/src/components/PostHogProvider.tsx
+++ b/app/src/components/PostHogProvider.tsx
@@ -88,6 +88,13 @@ function ConsentGate() {
       posthog.set_config({
         persistence: "localStorage+cookie",
         session_recording: RECORDING_MASKING,
+        // The PostHog project has console-log recording switched on, and this
+        // option falls back to that remote setting when left undefined. We tell
+        // people we record "a replay of what happened on your screen — where you
+        // moved, clicked and scrolled"; the browser console is not on screen, and
+        // it carries Sentry breadcrumbs and whatever the app happens to log. Say
+        // no explicitly so what we collect matches what the policy describes.
+        enable_recording_console_log: false,
       });
       // Tie the sessions to the account, so "which searches has a real user
       // made" is answerable rather than a pile of disconnected anonymous ones.

--- a/app/src/components/PostHogProvider.tsx
+++ b/app/src/components/PostHogProvider.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useEffect } from "react";
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
+import { useMe } from "./MeProvider";
 
 if (
   typeof window !== "undefined" &&
@@ -17,11 +19,93 @@ if (
     // session — no cookie or localStorage, so no consent banner is needed. We
     // avoid cookieless server-hash mode because it derives identity from the
     // client IP, which our server-side /ingest proxy hides from PostHog.
+    //
+    // This stays the DEFAULT for everyone, signed in or not. A signed-in user
+    // who opts in to session recording (#524) is switched to persistent storage
+    // at runtime by ConsentGate below — which is exactly the switch their
+    // consent is being asked for, since storing that identifier on the device is
+    // the part that needs it under PECR.
     persistence: "memory",
     disable_session_recording: true,
   });
 }
 
+/**
+ * Session-replay masking, applied only once recording actually starts.
+ *
+ * Deliberately NOT maskAllInputs. The whole analytical point of #524 is to see
+ * where people get stuck — which searches they type, which filters they reach
+ * for — and a recording with every input blanked answers none of that. What the
+ * user types here is species names and country names, not personal data.
+ *
+ * The exceptions are pinned down rather than left to chance:
+ *  - password inputs stay masked (this app has none — sign-in is OAuth only, so
+ *    no password is ever typed on our origin — but the day one appears it must
+ *    not depend on someone remembering this file);
+ *  - anything marked .ph-mask has its text masked, and .ph-no-capture is
+ *    blocked outright, as escape hatches for future UI that shouldn't be seen.
+ */
+const RECORDING_MASKING = {
+  maskAllInputs: false,
+  maskInputOptions: { password: true },
+  blockSelector: ".ph-no-capture",
+};
+
+/**
+ * Turns identified analytics and session recording on and off to match the
+ * signed-in user's stored consent.
+ *
+ * Runs on every change of that state, in both directions, because withdrawal
+ * has to take effect as immediately as consent does — a toggle that only stops
+ * recording after a reload is not "as easy to withdraw as to give".
+ */
+function ConsentGate() {
+  const { me, loaded } = useMe();
+  const consented = me.analyticsConsent === true && !!me.id;
+
+  useEffect(() => {
+    if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
+    // Until /api/auth/me answers we don't know the stored decision, and the
+    // init above has already left us in the safe state. Doing nothing here is
+    // what keeps a page load from recording a few hundred ms of someone who
+    // never consented.
+    if (!loaded) return;
+
+    if (consented) {
+      // Persist the distinct_id so a session survives page loads — without this
+      // every navigation is a separate one-page replay, which is useless for
+      // spotting where someone got confused. This is the storage the consent
+      // was for.
+      // Masking has to go through set_config: startSessionRecording() only
+      // takes sampling/feature-flag overrides, so passing it these silently
+      // records unmasked.
+      posthog.set_config({
+        persistence: "localStorage+cookie",
+        session_recording: RECORDING_MASKING,
+      });
+      // Tie the sessions to the account, so "which searches has a real user
+      // made" is answerable rather than a pile of disconnected anonymous ones.
+      posthog.identify(me.id!);
+      posthog.startSessionRecording();
+    } else {
+      posthog.stopSessionRecording();
+      // Order matters: reset() clears the stored id and PostHog's own cookies,
+      // so it has to run while the persistent store is still the active one.
+      // Flipping to memory first would orphan those values on the device — the
+      // opposite of what withdrawing consent is supposed to do.
+      posthog.reset();
+      posthog.set_config({ persistence: "memory" });
+    }
+  }, [loaded, consented, me.id]);
+
+  return null;
+}
+
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
-  return <PHProvider client={posthog}>{children}</PHProvider>;
+  return (
+    <PHProvider client={posthog}>
+      <ConsentGate />
+      {children}
+    </PHProvider>
+  );
 }

--- a/app/src/components/PostHogProvider.tsx
+++ b/app/src/components/PostHogProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { useMe } from "./MeProvider";
@@ -62,6 +62,12 @@ const RECORDING_MASKING = {
 function ConsentGate() {
   const { me, loaded } = useMe();
   const consented = me.analyticsConsent === true && !!me.id;
+  // Whether THIS page load ever turned recording on. Without it the teardown
+  // branch below runs on first load for everyone who has not consented — the
+  // overwhelmingly common case — and posthog.reset() there swaps the anonymous
+  // distinct_id partway through the page, splitting one visitor's events across
+  // two ids for no reason. Tearing down is only meaningful after a setup.
+  const wasRecording = useRef(false);
 
   useEffect(() => {
     if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
@@ -87,7 +93,11 @@ function ConsentGate() {
       // made" is answerable rather than a pile of disconnected anonymous ones.
       posthog.identify(me.id!);
       posthog.startSessionRecording();
+      wasRecording.current = true;
     } else {
+      // Nothing to undo on a fresh, never-consented page load.
+      if (!wasRecording.current) return;
+      wasRecording.current = false;
       posthog.stopSessionRecording();
       // Order matters: reset() clears the stored id and PostHog's own cookies,
       // so it has to run while the persistent store is still the active one.

--- a/app/src/components/SpeciesSearchBar.tsx
+++ b/app/src/components/SpeciesSearchBar.tsx
@@ -5,6 +5,10 @@ import { buildQs, type ViewMode } from "../hooks/useFilterParams";
 import { CATEGORY_COLORS } from "../config/taxa";
 import { findNode, getViewRootForNode } from "../lib/taxonomy-utils";
 import { ALL_HABITAT_SEASONS, ALL_HABITAT_IMPORTANCE, ALL_HABITAT_SUITABILITY } from "../lib/habitat-filter";
+import {
+  captureSearchNoResults,
+  captureSearchResultSelected,
+} from "@/lib/analytics/events";
 
 export interface SearchResult {
   /**
@@ -69,6 +73,20 @@ export function SpeciesSearchBar() {
   const inputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
 
+  // The query and results as they are RIGHT NOW, for the analytics call in the
+  // select handlers below. Those handlers deliberately keep empty dep arrays —
+  // taking `query` as a dep would rebuild them on every keystroke — so they
+  // cannot close over the live values directly (#524).
+  const queryRef = useRef("");
+  const resultsRef = useRef<SearchResult[]>([]);
+  const taxaResultsRef = useRef<TaxonSuggestion[]>([]);
+  queryRef.current = query;
+  resultsRef.current = results;
+  taxaResultsRef.current = taxaResults;
+  // The last query already reported as finding nothing, so a re-render (or the
+  // user tabbing away and back) doesn't report the same dead end twice.
+  const reportedNoResultsRef = useRef<string | null>(null);
+
   // Warm-start: pre-load the search index on mount so first search is fast
   useEffect(() => {
     fetch("/api/search/warm").catch(() => {});
@@ -116,6 +134,25 @@ export function SpeciesSearchBar() {
     };
   }, [query]);
 
+  // A query that settled and found nothing (#524).
+  //
+  // Waits considerably longer than the 250ms fetch debounce above, and requires
+  // the fetch to have finished: mid-word a query legitimately matches nothing
+  // ("Panthe" before "Panthera"), and reporting those would fill the "failed
+  // searches" list with prefixes of successful ones. 1.2s idle is roughly the
+  // point where someone has stopped typing and is looking at an empty dropdown.
+  useEffect(() => {
+    if (loading || query.trim().length < 2) return;
+    if (results.length > 0 || taxaResults.length > 0) return;
+    if (reportedNoResultsRef.current === query) return;
+
+    const timeout = setTimeout(() => {
+      reportedNoResultsRef.current = query;
+      captureSearchNoResults(query);
+    }, 1200);
+    return () => clearTimeout(timeout);
+  }, [query, loading, results.length, taxaResults.length]);
+
   // Click outside to close
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
@@ -129,6 +166,15 @@ export function SpeciesSearchBar() {
 
   const selectResult = useCallback(
     (result: SearchResult) => {
+      captureSearchResultSelected({
+        query: queryRef.current,
+        resultName: result.scientific_name,
+        resultType: "species",
+        resultCategory: result.category ?? null,
+        // Position in the combined dropdown, taxon suggestions included, so the
+        // number matches what the user actually looked down.
+        rank: taxaResultsRef.current.length + resultsRef.current.indexOf(result),
+      });
       lastSelectedResult = result;
       const viewMode: ViewMode = result.category === "NE" ? "new-assessments" : "reassessments";
 
@@ -204,6 +250,13 @@ export function SpeciesSearchBar() {
   // Preserve the current view: from the new-assessments view, browsing a taxon shows
   // its not-evaluated species (charts come from the assessed/reassessments view).
   const selectTaxon = useCallback((t: TaxonSuggestion) => {
+    captureSearchResultSelected({
+      query: queryRef.current,
+      resultName: t.taxon,
+      resultType: "taxon",
+      resultCategory: null,
+      rank: taxaResultsRef.current.indexOf(t),
+    });
     const currentView: ViewMode =
       new URLSearchParams(window.location.search).get("view") === "new-assessments"
         ? "new-assessments"

--- a/app/src/hooks/useFilterParams.ts
+++ b/app/src/hooks/useFilterParams.ts
@@ -7,6 +7,7 @@ import { expandTaxaToken, collapseTaxaToTokens, getViewRootForNode, type FilterR
 import { ALL_HABITAT_SEASONS, ALL_HABITAT_IMPORTANCE, ALL_HABITAT_SUITABILITY } from "@/lib/habitat-filter";
 import { parseSpeciesParam } from "@/lib/species-row-key";
 import { prettifyQs } from "@/lib/query-string";
+import { primeFilterBaseline, reportFilterUsage } from "@/lib/analytics/events";
 
 // Both habitat checkbox-dropdowns (Importance, Season) default to "everything
 // checked" (nothing excluded) rather than "nothing checked" — see
@@ -569,6 +570,10 @@ export function useFilterParams(paramSuffix: string = "") {
   useEffect(() => {
     fromPopstateRef.current = true;
     setState(parseParams(window.location.search, paramSuffix)); // eslint-disable-line react-hooks/set-state-in-effect -- hydrate from URL on mount
+    // Whatever filters arrived in the URL are the baseline, not a choice this
+    // user made — see primeFilterBaseline. Without this, opening a shared
+    // filtered link would count every filter in it as freshly applied.
+    primeFilterBaseline(window.location.search, paramSuffix);
     const onPopState = () => {
       fromPopstateRef.current = true;
       setState(parseParams(window.location.search, paramSuffix));
@@ -590,6 +595,11 @@ export function useFilterParams(paramSuffix: string = "") {
     } else {
       window.history.replaceState(null, "", url);
     }
+    // Every filter change routes through here regardless of which setter caused
+    // it, which makes this the one place that sees them all. It only emits on
+    // transitions, so the replace-mode writes (normalisation, view switches)
+    // that change no filter are silent (#524).
+    reportFilterUsage(qs, paramSuffix);
   }, [paramSuffix]);
 
   // --- Setters: update local state instantly, sync URL in background ---

--- a/app/src/lib/analytics/__tests__/consent.test.ts
+++ b/app/src/lib/analytics/__tests__/consent.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  ANALYTICS_POLICY_VERSION,
+  getAnalyticsConsent,
+  setAnalyticsConsent,
+} from "../consent";
+
+type Row = { consented: boolean; policy_version: string } | null;
+
+function mockSupabase(row: Row, upsertError: { message: string } | null = null) {
+  const maybeSingle = vi.fn().mockResolvedValue({ data: row });
+  const eq = vi.fn().mockReturnValue({ maybeSingle });
+  const select = vi.fn().mockReturnValue({ eq });
+  const upsert = vi.fn().mockResolvedValue({ error: upsertError });
+  const from = vi.fn().mockReturnValue({ select, upsert });
+  return {
+    client: { from } as unknown as Parameters<typeof getAnalyticsConsent>[0],
+    spies: { from, select, eq, maybeSingle, upsert },
+  };
+}
+
+describe("getAnalyticsConsent", () => {
+  it("returns null for a signed-out user without querying", async () => {
+    const { client, spies } = mockSupabase(null);
+    await expect(getAnalyticsConsent(client, null)).resolves.toBeNull();
+    expect(spies.from).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the user has never been asked", async () => {
+    const { client } = mockSupabase(null);
+    await expect(getAnalyticsConsent(client, "user-1")).resolves.toBeNull();
+  });
+
+  it("returns true when the user opted in under the current policy", async () => {
+    const { client } = mockSupabase({
+      consented: true,
+      policy_version: ANALYTICS_POLICY_VERSION,
+    });
+    await expect(getAnalyticsConsent(client, "user-1")).resolves.toBe(true);
+  });
+
+  // The distinction the whole three-state model rests on: a stored false is
+  // "asked and declined", which must not collapse into "never asked" or the
+  // prompt would reappear on every page load.
+  it("returns false — not null — when the user declined", async () => {
+    const { client } = mockSupabase({
+      consented: false,
+      policy_version: ANALYTICS_POLICY_VERSION,
+    });
+    await expect(getAnalyticsConsent(client, "user-1")).resolves.toBe(false);
+  });
+
+  it("ignores an opt-in given under an older policy version", async () => {
+    const { client } = mockSupabase({ consented: true, policy_version: "1970-01-01" });
+    await expect(getAnalyticsConsent(client, "user-1")).resolves.toBeNull();
+  });
+
+  it("ignores a refusal given under an older policy version", async () => {
+    const { client } = mockSupabase({ consented: false, policy_version: "1970-01-01" });
+    await expect(getAnalyticsConsent(client, "user-1")).resolves.toBeNull();
+  });
+
+  it("queries analytics_consent filtered by user_id", async () => {
+    const { client, spies } = mockSupabase(null);
+    await getAnalyticsConsent(client, "user-1");
+    expect(spies.from).toHaveBeenCalledWith("analytics_consent");
+    expect(spies.eq).toHaveBeenCalledWith("user_id", "user-1");
+  });
+});
+
+describe("setAnalyticsConsent", () => {
+  it("upserts the decision stamped with the current policy version", async () => {
+    const { client, spies } = mockSupabase(null);
+    await expect(setAnalyticsConsent(client, "user-1", true)).resolves.toEqual({
+      error: null,
+    });
+    expect(spies.from).toHaveBeenCalledWith("analytics_consent");
+    const [row, options] = spies.upsert.mock.calls[0];
+    expect(row).toMatchObject({
+      user_id: "user-1",
+      consented: true,
+      policy_version: ANALYTICS_POLICY_VERSION,
+    });
+    // Set explicitly rather than left to the column default, which only fires
+    // on insert — an update would otherwise keep the original timestamp.
+    expect(typeof row.decided_at).toBe("string");
+    expect(options).toEqual({ onConflict: "user_id" });
+  });
+
+  it("records a withdrawal as false rather than deleting the row", async () => {
+    const { client, spies } = mockSupabase(null);
+    await setAnalyticsConsent(client, "user-1", false);
+    expect(spies.upsert.mock.calls[0][0]).toMatchObject({ consented: false });
+  });
+
+  it("surfaces the error message instead of throwing", async () => {
+    const { client } = mockSupabase(null, { message: "permission denied" });
+    await expect(setAnalyticsConsent(client, "user-1", true)).resolves.toEqual({
+      error: "permission denied",
+    });
+  });
+});

--- a/app/src/lib/analytics/__tests__/events.test.ts
+++ b/app/src/lib/analytics/__tests__/events.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  activeFilters,
+  newlyApplied,
+  primeFilterBaseline,
+  reportFilterUsage,
+  resetFilterBaselines,
+  FILTER_PARAMS,
+} from "../events";
+import { OWN_PARAM_NAMES } from "@/hooks/useFilterParams";
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}));
+const posthog = (await import("posthog-js")).default as unknown as {
+  capture: ReturnType<typeof vi.fn>;
+};
+
+beforeEach(() => {
+  resetFilterBaselines();
+  posthog.capture.mockClear();
+  process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
+  // These helpers are client-only and guard on `window` so an accidental
+  // server-side import is inert. The suite runs in node (the project has no DOM
+  // environment installed), so stand one up rather than pull in jsdom for a
+  // single typeof check.
+  vi.stubGlobal("window", {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("activeFilters", () => {
+  it("ignores view state that isn't a filter", () => {
+    // sort/tab/species/layout say nothing about filter popularity.
+    expect(activeFilters("?sort=year&tab=gbif&species=sis-123&layout=wide")).toEqual({});
+  });
+
+  it("reports a set filter with its value", () => {
+    expect(activeFilters("?categories=CR,EN")).toEqual({ risk_category: "CR,EN" });
+  });
+
+  it("reports a person-valued filter WITHOUT its value", () => {
+    // Third parties' names are not captured — only that the filter was used.
+    expect(activeFilters("?assessors=Jane%20Doe")).toEqual({ assessor: null });
+    expect(activeFilters("?institutions=Some%20University")).toEqual({ institution: null });
+  });
+
+  it("treats endemics=0 as not filtering", () => {
+    expect(activeFilters("?endemics=0")).toEqual({});
+    expect(activeFilters("?endemics=1")).toEqual({ endemics_only: "1" });
+  });
+
+  it("ignores an empty param value", () => {
+    expect(activeFilters("?categories=")).toEqual({});
+  });
+
+  it("reads the suffixed params of a compare-mode panel", () => {
+    const search = "?categories=CR&categories_b=EN";
+    expect(activeFilters(search, "_b")).toEqual({ risk_category: "EN" });
+    expect(activeFilters(search)).toEqual({ risk_category: "CR" });
+  });
+
+  it("truncates an over-long value", () => {
+    const long = "x".repeat(500);
+    expect(activeFilters(`?categories=${long}`).risk_category).toHaveLength(100);
+  });
+
+  // Guards the decoupling claim in the module doc: every param we count must
+  // still be a param the filter hook actually owns.
+  it("only names params that useFilterParams owns", () => {
+    for (const param of Object.keys(FILTER_PARAMS)) {
+      expect(OWN_PARAM_NAMES).toContain(param);
+    }
+  });
+});
+
+describe("newlyApplied", () => {
+  it("reports a filter that just appeared", () => {
+    expect(newlyApplied({}, { risk_category: "CR" })).toEqual([
+      { filter: "risk_category", value: "CR" },
+    ]);
+  });
+
+  it("reports a changed value on an already-active filter", () => {
+    expect(newlyApplied({ risk_category: "CR" }, { risk_category: "CR,EN" })).toEqual([
+      { filter: "risk_category", value: "CR,EN" },
+    ]);
+  });
+
+  it("stays silent when nothing changed", () => {
+    const same = { risk_category: "CR", taxon: "mammals" };
+    expect(newlyApplied(same, { ...same })).toEqual([]);
+  });
+
+  it("does not report a filter being removed", () => {
+    expect(newlyApplied({ risk_category: "CR" }, {})).toEqual([]);
+  });
+});
+
+describe("reportFilterUsage", () => {
+  it("captures one event per newly applied filter", () => {
+    primeFilterBaseline("");
+    reportFilterUsage("?categories=CR&taxa=mammals");
+    expect(posthog.capture).toHaveBeenCalledTimes(2);
+    expect(posthog.capture).toHaveBeenCalledWith("filter_applied", {
+      filter: "risk_category",
+      value: "CR",
+    });
+  });
+
+  it("omits the value key entirely for a person-valued filter", () => {
+    primeFilterBaseline("");
+    reportFilterUsage("?assessors=Jane%20Doe");
+    expect(posthog.capture).toHaveBeenCalledWith("filter_applied", { filter: "assessor" });
+  });
+
+  // A shared filtered link reflects whoever built it, not whoever opened it.
+  it("does not count filters that arrived in the landing URL", () => {
+    primeFilterBaseline("?categories=CR");
+    reportFilterUsage("?categories=CR");
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it("counts a filter added on top of a shared link", () => {
+    primeFilterBaseline("?categories=CR");
+    reportFilterUsage("?categories=CR&taxa=birds");
+    expect(posthog.capture).toHaveBeenCalledTimes(1);
+    expect(posthog.capture).toHaveBeenCalledWith("filter_applied", {
+      filter: "taxon",
+      value: "birds",
+    });
+  });
+
+  it("does not re-count a filter left untouched across many URL writes", () => {
+    primeFilterBaseline("");
+    reportFilterUsage("?categories=CR");
+    reportFilterUsage("?categories=CR&sort=year");
+    reportFilterUsage("?categories=CR&sort=year&tab=gbif");
+    expect(posthog.capture).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks compare-mode panels independently", () => {
+    primeFilterBaseline("", "");
+    primeFilterBaseline("", "_b");
+    reportFilterUsage("?categories=CR&categories_b=EN", "_b");
+    expect(posthog.capture).toHaveBeenCalledTimes(1);
+    expect(posthog.capture).toHaveBeenCalledWith("filter_applied", {
+      filter: "risk_category",
+      value: "EN",
+      panel: "_b",
+    });
+  });
+
+  it("captures nothing when PostHog is not configured", () => {
+    delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    primeFilterBaseline("");
+    reportFilterUsage("?categories=CR");
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+
+  // The baseline must advance even with PostHog off, or enabling it later would
+  // replay every filter already on screen as freshly applied.
+  it("still advances the baseline when PostHog is not configured", () => {
+    delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    primeFilterBaseline("");
+    reportFilterUsage("?categories=CR");
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test";
+    reportFilterUsage("?categories=CR");
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/lib/analytics/consent.ts
+++ b/app/src/lib/analytics/consent.ts
@@ -1,0 +1,70 @@
+import type { createClient } from "@/lib/supabase/server";
+
+type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>;
+
+/**
+ * The version of /privacy that the current consent ask describes.
+ *
+ * Bumping this invalidates every stored decision, so everyone is asked again on
+ * their next visit and nothing is recorded in the meantime. That is the correct
+ * behaviour for a *material* change to what we record — consent is only
+ * informed with respect to what it was asked about — but it is a real cost to
+ * users, so do not bump it for typos or rewording. Date-stamped rather than
+ * numbered so a stored row says when, not just which.
+ */
+export const ANALYTICS_POLICY_VERSION = "2026-09-08";
+
+/**
+ * `null` means "never asked" — distinct from a stored `false` ("asked, and
+ * declined"), which is what stops the prompt reappearing forever. See the
+ * three-state note in the migration.
+ */
+export type AnalyticsConsent = boolean | null;
+
+export async function getAnalyticsConsent(
+  supabase: SupabaseServerClient,
+  userId: string | null | undefined
+): Promise<AnalyticsConsent> {
+  if (!userId) return null;
+
+  const { data } = await supabase
+    .from("analytics_consent")
+    .select("consented, policy_version")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (!data) return null;
+
+  // A decision taken against an older policy is not informed consent for what
+  // the current one describes, so fall back to "never asked" — which both stops
+  // recording and re-shows the prompt. Deliberately applied to a stored `false`
+  // too: someone who declined an older, narrower ask has not declined this one.
+  if (data.policy_version !== ANALYTICS_POLICY_VERSION) return null;
+
+  return data.consented;
+}
+
+/**
+ * Records a decision, overwriting any previous one. Returns an error message on
+ * failure rather than throwing, so the caller can answer the request.
+ */
+export async function setAnalyticsConsent(
+  supabase: SupabaseServerClient,
+  userId: string,
+  consented: boolean
+): Promise<{ error: string | null }> {
+  const { error } = await supabase.from("analytics_consent").upsert(
+    {
+      user_id: userId,
+      consented,
+      // Explicit rather than leaning on the column default, which only applies
+      // on insert — an upsert that updates an existing row would otherwise keep
+      // the original timestamp and misdate the decision.
+      decided_at: new Date().toISOString(),
+      policy_version: ANALYTICS_POLICY_VERSION,
+    },
+    { onConflict: "user_id" }
+  );
+
+  return { error: error?.message ?? null };
+}

--- a/app/src/lib/analytics/events.ts
+++ b/app/src/lib/analytics/events.ts
@@ -1,0 +1,202 @@
+import posthog from "posthog-js";
+
+/**
+ * Product analytics for #524: which searches people run, and which filters they
+ * actually reach for.
+ *
+ * These events are ANONYMOUS for everyone and need no consent. PostHog runs in
+ * `persistence: "memory"` by default (see components/PostHogProvider.tsx) — no
+ * identifier is stored on the device, so nothing here is tied to a person. That
+ * is deliberate rather than incidental: gating these behind the session-replay
+ * consent would have limited the answer to "which filters are popular?" to the
+ * small consenting slice of signed-in users, when the useful answer covers
+ * everyone. A user who has opted in to replay is identified, so their events
+ * attach to them — that is the consent they gave.
+ *
+ * Values are captured only where a value is low-cardinality and about a
+ * *species*, never about a person — see FILTER_VALUE_SAFE.
+ */
+
+/** No-op rather than a crash when PostHog isn't configured (local dev, CI). */
+const enabled = () =>
+  typeof window !== "undefined" && !!process.env.NEXT_PUBLIC_POSTHOG_KEY;
+
+/**
+ * URL params that are filters worth counting, mapped to the event-facing name.
+ *
+ * Deliberately a subset of useFilterParams' OWN_PARAM_NAMES: that list also
+ * carries pure view state (`layout`, `tab`, `sort`, `mapview`, the open
+ * `species`), which says nothing about which *filters* are popular and would
+ * bury the signal in navigation noise.
+ */
+export const FILTER_PARAMS: Record<string, string> = {
+  countries: "country",
+  region: "region",
+  taxa: "taxon",
+  subgroups: "subgroup",
+  categories: "risk_category",
+  years: "assessment_age",
+  assessmentYears: "assessment_year",
+  describedYears: "described_year",
+  obsRanges: "gbif_observations",
+  assessmentCounts: "assessment_count",
+  systems: "system",
+  trends: "population_trend",
+  movement: "movement_pattern",
+  threats: "threat",
+  criteria: "criteria",
+  habitat: "habitat",
+  habitatBreadth: "habitat_breadth",
+  endemics: "endemics_only",
+  growthForms: "growth_form",
+  colMatch: "col_match",
+  colReasons: "col_match_reason",
+  assessors: "assessor",
+  reviewers: "reviewer",
+  facilitators: "facilitator",
+  contributors: "contributor",
+  institutions: "institution",
+  outdated: "outdated",
+};
+
+/**
+ * Filters whose VALUE may be captured alongside the name.
+ *
+ * The line is drawn at personal data about third parties: `assessors`,
+ * `reviewers`, `facilitators`, `contributors` and `institutions` hold the names
+ * of real people (and their employers) who assessed a species. "Which
+ * assessors are being looked up" is a record of interest in named individuals,
+ * so only the fact that the assessor filter was used is recorded, never who.
+ *
+ * `subgroups` and `colReasons` are omitted for a duller reason: their values are
+ * opaque generated node ids, so they would be cardinality without meaning.
+ */
+const FILTER_VALUE_SAFE = new Set([
+  "countries", "region", "taxa", "categories", "years", "assessmentYears",
+  "describedYears", "obsRanges", "assessmentCounts", "systems", "trends",
+  "movement", "threats", "criteria", "habitat", "habitatBreadth", "endemics",
+  "growthForms", "colMatch", "outdated",
+]);
+
+/** A value long enough to be a pasted list is truncated rather than stored whole. */
+const MAX_VALUE_LENGTH = 100;
+
+/**
+ * Which filter params are set in a query string, and (where safe) to what.
+ *
+ * Reads the URL rather than the hook's state object so it stays decoupled from
+ * that ~50-field shape: a new filter param becomes countable by adding one line
+ * to FILTER_PARAMS, with no risk of reading a field that no longer exists.
+ */
+export function activeFilters(
+  search: string,
+  suffix: string = ""
+): Record<string, string | null> {
+  const params = new URLSearchParams(search);
+  const active: Record<string, string | null> = {};
+
+  for (const [param, name] of Object.entries(FILTER_PARAMS)) {
+    const raw = params.get(suffix ? `${param}${suffix}` : param);
+    if (raw === null || raw === "") continue;
+    // `endemics` is a flag: present-but-"0" is off, not a filter in use.
+    if (param === "endemics" && raw !== "1") continue;
+    active[name] = FILTER_VALUE_SAFE.has(param)
+      ? raw.slice(0, MAX_VALUE_LENGTH)
+      : null;
+  }
+
+  return active;
+}
+
+/**
+ * Filters present in `next` but not in `previous` — i.e. just switched on.
+ *
+ * Only transitions are reported. Counting every URL write instead would rank
+ * filters by how much the user fiddled with the rest of the page while one
+ * happened to be set, which is not popularity.
+ */
+export function newlyApplied(
+  previous: Record<string, string | null>,
+  next: Record<string, string | null>
+): Array<{ filter: string; value: string | null }> {
+  return Object.entries(next)
+    .filter(([name, value]) => !(name in previous) || previous[name] !== value)
+    .map(([filter, value]) => ({ filter, value }));
+}
+
+/** Per-suffix baseline, so compare-mode panels are tracked independently. */
+const lastSeen = new Map<string, Record<string, string | null>>();
+
+/**
+ * Establishes the baseline without emitting anything.
+ *
+ * Called on mount: filters that arrived in a shared link were chosen by whoever
+ * built the link, not by the person opening it, so counting them would let one
+ * widely-shared URL look like a popular filter.
+ */
+export function primeFilterBaseline(search: string, suffix: string = ""): void {
+  lastSeen.set(suffix, activeFilters(search, suffix));
+}
+
+/** Diffs against the baseline and captures one event per newly-applied filter. */
+export function reportFilterUsage(search: string, suffix: string = ""): void {
+  const next = activeFilters(search, suffix);
+  const previous = lastSeen.get(suffix) ?? {};
+  lastSeen.set(suffix, next);
+
+  if (!enabled()) return;
+
+  for (const { filter, value } of newlyApplied(previous, next)) {
+    posthog.capture("filter_applied", {
+      filter,
+      ...(value === null ? {} : { value }),
+      // Which panel, when compare mode has two side by side.
+      ...(suffix ? { panel: suffix } : {}),
+    });
+  }
+}
+
+/** Test seam: drop the remembered baselines. */
+export function resetFilterBaselines(): void {
+  lastSeen.clear();
+}
+
+// --- Search --------------------------------------------------------------
+
+/**
+ * A search the user actually acted on — the highest-signal thing the search box
+ * produces, because the chosen result says what the query MEANT.
+ *
+ * Note what is not captured: the box refetches on a 250ms debounce, so logging
+ * every request would record "P", "Pa", "Pan", "Pant"… and rank prefixes rather
+ * than searches. Only settled queries are recorded, here and in
+ * captureSearchNoResults.
+ */
+export function captureSearchResultSelected(params: {
+  query: string;
+  resultName: string;
+  /** "species" picks one species; "taxon" browses a whole group. */
+  resultType: "species" | "taxon";
+  resultCategory: string | null;
+  rank: number;
+}): void {
+  if (!enabled()) return;
+  posthog.capture("search_result_selected", {
+    query: params.query.slice(0, MAX_VALUE_LENGTH),
+    result_name: params.resultName,
+    result_type: params.resultType,
+    result_category: params.resultCategory,
+    // 0-based position in the dropdown: a high rank means the right answer was
+    // buried, which is a ranking bug rather than a user error.
+    rank: params.rank,
+  });
+}
+
+/**
+ * A settled query that found nothing — the most directly actionable search
+ * signal there is, since each one is a name the dashboard could not resolve.
+ */
+export function captureSearchNoResults(query: string): void {
+  if (!enabled()) return;
+  posthog.capture("search_no_results", { query: query.slice(0, MAX_VALUE_LENGTH) });
+}

--- a/app/supabase/migrations/20260908120000_analytics_consent.sql
+++ b/app/supabase/migrations/20260908120000_analytics_consent.sql
@@ -1,0 +1,59 @@
+-- Opt-in consent for PostHog session recording and identified analytics (#524).
+--
+-- Everything the dashboard records today is anonymous and cookieless
+-- (src/components/PostHogProvider.tsx): in-memory persistence, no identifier
+-- stored on the device, no identify() call even when signed in. That is
+-- precisely why the site has never needed a consent banner.
+--
+-- Session replay breaks both halves of that: it stores an identifier on the
+-- device so a session can be stitched across page loads, and it ties what you
+-- did on screen to your account. Under UK GDPR/PECR that needs opt-in consent
+-- which is specific, informed, as easy to withdraw as to give, and — the reason
+-- this is a table rather than a localStorage flag — demonstrable after the fact.
+--
+-- One row per user, rewritten in place whenever they change their mind.
+-- decided_at and policy_version are what make the row a record of a decision
+-- rather than a mere setting.
+--
+-- NOTE the three-state model this table encodes, which the app leans on:
+--   no row          -> never asked; show the prompt
+--   consented=false -> asked and declined; stay silent, do not re-prompt
+--   consented=true  -> recording allowed
+-- Collapsing "never asked" into "false" would make declining meaningless, since
+-- the prompt would return on every page load.
+
+create table public.analytics_consent (
+  user_id uuid primary key references auth.users (id) on delete cascade,
+  consented boolean not null,
+  decided_at timestamptz not null default now(),
+  -- Which version of /privacy the user was shown when they decided. Consent is
+  -- only informed with respect to what it described at the time, so a material
+  -- change to that page means bumping ANALYTICS_POLICY_VERSION (see
+  -- src/lib/analytics/consent.ts) and asking again, rather than inheriting an
+  -- answer someone gave about materially different processing.
+  policy_version text not null
+);
+
+alter table public.analytics_consent enable row level security;
+
+-- Unlike user_roles — where granting yourself a role is exactly what RLS has to
+-- prevent — this data is the user's own to give, inspect and withdraw, so all
+-- three verbs are open on their own row and only their own row.
+--
+-- There is deliberately no delete policy: withdrawing consent updates the row to
+-- consented = false rather than removing it, because a deleted row is
+-- indistinguishable from "never asked" and would erase the very audit trail the
+-- table exists to keep. (The row still disappears with the account itself, via
+-- the on delete cascade above.)
+create policy "Users can view their own analytics consent"
+  on public.analytics_consent for select
+  using (auth.uid() = user_id);
+
+create policy "Users can record their own analytics consent"
+  on public.analytics_consent for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can change their own analytics consent"
+  on public.analytics_consent for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
Closes #524.

## Summary

Everything the dashboard records today is anonymous and cookieless: in-memory persistence, no identifier on the device, no `identify()` even when signed in. That is exactly why the site has never carried a consent banner, and `PostHogProvider.tsx` said so in a comment. Session replay breaks both halves of that — it stores an identifier on the device so a session can be stitched across page loads, and it ties what happened on screen to an account — so it is opt-in, signed-in only, and off until someone says yes.

**Consent is stored in a new `analytics_consent` Supabase table**, not localStorage, because it has to be demonstrable after the fact and should follow the account rather than the browser. It is three-state, and the distinction is load-bearing:

| state | meaning | behaviour |
|---|---|---|
| no row | never asked | show the prompt |
| `consented = false` | asked and declined | stay silent, never re-prompt |
| `consented = true` | opted in | record |

Collapsing the first two would make declining meaningless — the prompt would return on every page load. A `policy_version` column invalidates stored decisions if `/privacy` materially changes, since consent is only informed with respect to what it described.

**`MeProvider` centralises who-is-signed-in and their consent** because two things in different parts of the tree must never disagree about it: `PostHogProvider`, which starts and stops recording, and the account menu, which shows and toggles it. Two independently-fetched copies of that state is a recording that outlives the toggle claiming it stopped.

**Withdrawal is a checkbox in the account menu** and takes effect in the same page load. A toggle that only stops recording after a reload is not "as easy to withdraw as to give" (UK GDPR Art. 7(3)), and it is also the only way back for someone who declined, since the prompt never returns for them.

**Masking is deliberately not `maskAllInputs`.** Seeing which searches and filters people reach for is the entire analytical point; a recording with every input blanked answers none of it. This app's inputs take species and country names, not personal data. Password inputs stay masked anyway (there are none — sign-in is OAuth only — but that must not depend on someone remembering this file), and `.ph-no-capture` is an escape hatch for future UI.

The privacy policy asserted both the no-identifier and the not-linked-to-you properties as plain fact, so it is rewritten: a new "Session recording (optional, off by default)" section, and the lawful basis for replay is stated as consent rather than the legitimate interest the anonymous analytics rely on.

## Note for reviewers: Playwright silently blocks PostHog

While verifying the events below I briefly concluded that PostHog was transmitting nothing at all — `capture()` queued nothing, sent no request, and logged nothing even under `posthog.debug(true)`, on `main` as well as here. **That was wrong, and it was the test harness.** posthog-js's `isLikelyBot` blocks `headlesschrome` by user agent and then ends with `return !!navigator.webdriver`, so *any* WebDriver-controlled browser is classified as a bot and `capture()` drops the event through a silent `return`.

With both signals defeated, the same build transmits normally — `0` capture POSTs as default Playwright, `2` immediately once masked. **PostHog is healthy; nothing here needed fixing.** The trap is written up in `.claude/skills/verify-ui/SKILL.md` (third commit) because the failure has no signal of its own and reads exactly like a production outage.

## Deployment prerequisites — both now DONE

1. ~~Apply `app/supabase/migrations/20260908120000_analytics_consent.sql`~~ — **applied to the production project 2026-09-08** via the Management API. Verified after applying: 4 columns, RLS enabled, 3 policies, PK on `user_id`, FK → `auth.users` `ON DELETE CASCADE`, FK rejects unknown users. Read isolation confirmed (user A sees 0 rows while user B's row exists in the same transaction) and write isolation confirmed (A inserting for B → `42501` RLS violation). All tests ran in rolled-back transactions; the table is empty and no existing account was touched. The table was inert until this merges, since prod runs `main`.
2. ~~Enable session replay in the PostHog project~~ — **done**, confirmed in the live remote config.

With replay enabled it was finally possible to verify the feature end-to-end: **1–2 `/ingest/s/` snapshot POSTs when consented, 0 when declined**, PostHog cookie present/absent to match. Snapshot POSTs were intercepted and answered locally, so no real replay data was sent.

### One thing that turning replay on surfaced

The project's remote config sets `consoleLogRecordingEnabled: true`, and posthog-js's `enable_recording_console_log` **falls back to the remote setting when left undefined** — so replays would have carried browser console output (Sentry breadcrumbs, anything the app logs). The policy promises "a replay of what happened on your screen — where you moved, clicked and scrolled", and the console is not on screen. The fourth commit sets it to `false` explicitly, so what we collect is pinned by this repo rather than by whatever the project settings happen to be. Re-verified: replay still records with it off.

## Test plan

- `npx tsc --noEmit` clean; `eslint` clean on all touched files.
- **1,654 tests pass** (89 files), including 30 new ones covering the three-state model, policy-version invalidation of both an opt-in and a refusal, and that withdrawal writes `false` rather than deleting the row.
- **Browser drive-through** in real Chromium (full build, `--enable-unsafe-swiftshader`), **zero console errors**, all four states:
  - never asked → prompt visible, no PostHog cookie present
  - click **Allow** → prompt dismisses, consent written, PostHog cookie appears
  - asked and declined → no prompt, no cookie
  - consented → toggle reads checked; unchecking writes `false` and **removes the cookie**
  - signed out → no prompt, no cookie, regardless of stored state
- Privacy page renders correctly.

**Not verified end-to-end, stated plainly:** `/api/auth/me` was stubbed at the network layer rather than completing a real OAuth sign-in, so the actual Supabase read/write round-trip is covered by unit tests, not by the browser run. Completing real sign-in would have meant creating a test user in the production Supabase project. The DB round-trip is worth a manual check once the migration is applied.

## Screenshots

**The one-time ask.** Shown only to a signed-in user who has never answered. Neither button is pre-selected or visually favoured — a greyed-out "No thanks" beside a bright "Allow" is a nudge that undermines freely-given consent — and there is no × that would leave the question unanswered, because "no answer" and "no" must not be silently conflated.

![Consent prompt](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-526-consent-session-tracking/01-consent-prompt.png)

**The permanent toggle.** In the account menu, so withdrawal is as easy as consent was, and so someone who declined still has a way back.

![Account menu toggle](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-526-consent-session-tracking/02-account-menu-toggle.png)

**The rewritten privacy policy.**

![Privacy policy](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-526-consent-session-tracking/03-privacy-policy.png)

## Second half: which searches, which filters

There were **zero** `posthog.capture()` calls anywhere in `app/src`, so the issue's second question was unanswerable even in principle. Three events now answer it, and they are **anonymous for everyone and need no consent** — PostHog's default here stores no identifier on the device. Gating them behind the replay consent would have narrowed the answer to the small consenting slice of signed-in users when the useful answer covers everyone.

| event | when | properties |
|---|---|---|
| `filter_applied` | a filter switches on, or its value changes | `filter`, `value` (where safe), `panel` in compare mode |
| `search_result_selected` | a dropdown result is chosen | `query`, `result_name`, `result_type`, `result_category`, `rank` |
| `search_no_results` | a settled query found nothing | `query` |

Design decisions that are load-bearing rather than incidental:

- **Filters are read off the URL**, not the hook's ~50-field state object, so adding a filter to the count is one line in `FILTER_PARAMS` with no risk of reading a field that no longer exists. A test asserts every counted param is one `useFilterParams` actually owns.
- **Only transitions are reported.** Counting every URL write would rank filters by how much the user fiddled with the rest of the page while one happened to be set — that is not popularity.
- **Filters arriving in the URL prime a baseline instead of being counted**, so one widely-shared filtered link cannot masquerade as a popular filter.
- **Values are captured only where they describe a species.** The assessor, reviewer, facilitator, contributor and institution filters hold the names of real people who assessed a species; capturing those values would build a record of interest in named individuals, so only the *fact* that the filter was used is recorded. `subgroups`/`colReasons` are dropped for the duller reason that their values are opaque node ids.
- **Search is recorded where it settles, never per keystroke.** The box refetches on a 250ms debounce, so capturing each request would rank the prefixes of a search (`Pan`, `Pant`, `Panth`) rather than the search. A dead-end query is only reported after 1.2s of no typing, since mid-word almost everything matches nothing.
- Pure view state (`sort`, `tab`, `layout`, `mapview`, the open `species`) is deliberately **not** counted — it is navigation noise, not filter popularity.

**Known characteristic:** picking a search result navigates to that species' taxon, which legitimately sets `taxa` and so also emits one `filter_applied`. Search-driven navigation therefore contributes a little to taxon-filter counts. Separating the two would need the filter layer to know why the URL changed; flagging it rather than silently shipping it.

Also fixed here: `ConsentGate` called `posthog.reset()` on first load for everyone who has not consented. That branch only makes sense as a teardown *after* recording was started; running it unconditionally swapped the anonymous `distinct_id` partway through the page and split one visitor's events across two ids — which would have quietly corrupted the very counts this PR adds.

### Verified in the browser

Driven in real Chromium against the running app, signed out (these events need no sign-in). Two passes: first with `capture` patched on the shared module object to record exactly what the app asks PostHog to send, then — with the bot signals masked per the note above — **decoding the gzipped request bodies actually going over the wire**, which confirmed `$pageview`, `$autocapture`, `filter_applied` ×3, `search_result_selected` and `search_no_results` all reach `/ingest/i/v0/e/`. Test events were intercepted and answered locally, so none reached the real PostHog project.

What the app asked PostHog to send:

```
filter_applied         {"filter":"taxon","value":"mammals"}
filter_applied         {"filter":"risk_category","value":"CR"}
search_result_selected {"query":"Panthera","result_name":"Chimaera panthera",
                        "result_type":"species","result_category":"LC","rank":10}
filter_applied         {"filter":"taxon","value":"fishes~chondrichthyes~chimaeriformes~chimaeridae"}
search_no_results      {"query":"zzzqqxnotaspecies"}
```

No prefix events for the intermediate `Panth…` states, no duplicate `filter_applied` for filters left untouched, zero console errors. 20 unit tests cover the diffing, the shared-link baseline, the person-data exclusion, compare-mode panels, and the unconfigured-PostHog no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


