### PR TITLE
Link Sentry issues to PostHog people and replays

### DIFF
--- a/app/src/app/privacy/page.tsx
+++ b/app/src/app/privacy/page.tsx
@@ -55,7 +55,12 @@ export default function PrivacyPage() {
           >
             Sentry
           </a>{" "}
-          to record technical error reports so we can fix problems.
+          to record technical error reports so we can fix problems. If you have
+          turned session recording on (see below), those error reports are
+          linked to your account and to the recording of what you were doing
+          when the error happened, so we can see what caused it; if you
+          have not, they carry only a temporary id that exists for that
+          one visit and identifies nobody.
         </p>
 
         <p>

--- a/app/src/instrumentation-client.ts
+++ b/app/src/instrumentation-client.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import posthog from "posthog-js";
 
 Sentry.init({
   dsn: "https://3321a937f74313b1ff02b1ba4e884e27@o4511047063633920.ingest.de.sentry.io/4511047064420432",
@@ -12,6 +13,37 @@ Sentry.init({
   // Enable logs to be sent to Sentry
   enableLogs: true,
 
+  integrations: [
+    // Ties the two tools together in both directions: each Sentry issue gains a
+    // "PostHog Person URL" tag, plus a "PostHog Recording URL" tag when a replay
+    // is actually running, and the error is mirrored into PostHog as an
+    // $exception event.
+    //
+    // The recording tag is consent-gated for free: the integration only adds it
+    // when posthog.sessionRecordingStarted() is true, which only happens for a
+    // signed-in user who opted in. Everyone else's issues carry just the person
+    // URL, built from the throwaway in-memory distinct_id that lasts one page
+    // visit and identifies nobody.
+    //
+    // This is what we get instead of recording the browser console into replays.
+    // posthog-js's enable_recording_console_log is all-or-nothing — no level
+    // filtering — so switching it on would vacuum up every log line from every
+    // dependency, including whatever `.catch(console.error)` prints on a failed
+    // fetch of assessor/reviewer names. Sentry already captures errors properly,
+    // with stack traces and source maps; this link is the missing half, and it
+    // collects nothing we haven't chosen (see components/PostHogProvider.tsx).
+    //
+    // NOTE the functional form. PostHog's own docstring still shows
+    // `new posthog.SentryIntegration(posthog)`, which is the Sentry v7 class
+    // shape; @sentry/nextjs is on v10, where integrations are plain objects.
+    posthog.sentryIntegration({
+      organization: "shane-weisz",
+      // The NUMERIC project id, from the DSN's path above — not the
+      // "redlist-dashboard" slug used by withSentryConfig in next.config.ts.
+      // Only used to build the PostHog -> Sentry deep link.
+      projectId: 4511047064420432,
+    }),
+  ],
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;


### PR DESCRIPTION
Follow-up to #526. This is the alternative to recording the browser console into session replays.

## Why not just record the console

`posthog-js`'s `enable_recording_console_log` is a plain boolean — **no level filtering, no truncation**. There is no "errors only". Turning it on captures every `log`/`warn`/`error`/`info`/`debug` from our code *and every dependency*, which in practice is mostly Next.js preload warnings and MapLibre noise.

The specific hazard is not hypothetical: there are 43 `console.*` calls in client code, many of them `.catch(console.error)` sitting on fetches to endpoints that carry assessor, reviewer, contributor and institution names. In a failure path, real people's names could land in a replay.

Meanwhile Sentry already captures errors properly — stack traces, source maps, grouping. The debugging value console capture would add is largely *already collected*, by a tool built for it. So the gap worth closing isn't "more data", it's the missing link between the two tools.

## What this does

One integration in `src/instrumentation-client.ts` (browser only — `posthog-js` means nothing in `sentry.server.config.ts` or `sentry.edge.config.ts`):

- Each Sentry issue gains a **`PostHog Person URL`** tag.
- When a replay is actually running it also gains a **`PostHog Recording URL`** tag, so you can watch the error happen.
- The error is mirrored into PostHog as an **`$exception`** event.

**The recording link is consent-gated with no code of ours.** The integration only adds that tag when `posthog.sessionRecordingStarted()` is true, which only happens for a signed-in user who opted in under #526.

Two details worth flagging for review:

- **The functional integration form is required.** PostHog's own docstring still shows `new posthog.SentryIntegration(posthog)` — the Sentry v7 class shape. `@sentry/nextjs` is on v10, where integrations are plain objects.
- **`projectId` is the numeric id from the DSN path** (`4511047064420432`), not the `redlist-dashboard` slug that `withSentryConfig` uses in `next.config.ts`. It only builds the PostHog→Sentry deep link.

Defaults left alone: `severityAllowList` is `['error']`, `sendExceptionsToPostHog` is `true`.

## Privacy policy

The policy said Sentry records "technical error reports", which reads as unlinked — no longer strictly true for someone who has opted into recording. It now says the reports are tied to your account and your recording if you turned recording on, and carry only a throwaway per-visit id if you did not.

**No `ANALYTICS_POLICY_VERSION` bump.** This describes existing processing more precisely rather than collecting a new category, so it does not invalidate consent already given under #526. Bumping it would re-ask everyone for no gain.

### The amended paragraph

![Privacy policy](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-528-sentry-posthog-link/01-privacy-policy.png)

## Test plan

- `tsc --noEmit` clean, `eslint` clean, **1,654 tests pass**.
- **Browser-verified** in real Chromium against the running app, throwing an uncaught error and intercepting **both** sides — PostHog's `/ingest` and Sentry's `/monitoring` tunnel — so no test error reached the real Sentry or PostHog projects:

  | run | Sentry event | `PostHog Person URL` | `PostHog Recording URL` | `$exception` in PostHog |
  |---|---|---|---|---|
  | signed out | 1 | ✅ | — (correct: no replay exists) | ✅ |
  | consented user | 1 | ✅ | ✅ | ✅ |

- Privacy page re-rendered and re-read after the edit; no console errors.

Note for anyone re-running this: PostHog silently drops every event from a WebDriver-controlled browser, so the verification masks the headless UA and `navigator.webdriver` — see `.claude/skills/verify-ui/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
