### PR TITLE
One sample of 300, trusted records first

### DIFF
--- a/app/src/app/api/occurrences/route.ts
+++ b/app/src/app/api/occurrences/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { CACHE_5M } from "@/lib/cache-headers";
 import { getQualityFlags } from "@/lib/mapping/coordinate-cleaning";
-import { GBIF_CHECKLIST_KEY, GBIF_GEOSPATIAL_ISSUES } from "@/lib/gbif";
+import { GBIF_CHECKLIST_KEY, GBIF_COORDINATE_NOTES, GBIF_GEOSPATIAL_ISSUES } from "@/lib/gbif";
 
 export const dynamic = "force-dynamic";
 
@@ -216,15 +216,96 @@ function classify(r: GbifRecord, geospatialIssues: string[]): CoordinateStatus {
   return geospatialIssues.length > 0 ? "issue" : "mapped";
 }
 
-/** Total matching records for a bucket, without transferring any of them. */
+/**
+ * One GBIF occurrence search, retried on the statuses worth retrying.
+ *
+ * Retried because this route fires several queries at once and pages some of
+ * them in a tight loop, and GBIF throttles the burst. Reproduced on every run
+ * of the browser check: the map for a species with 130,322 records 500s while
+ * the same requests issued sequentially by hand all return 200. Naming a
+ * non-default checklistKey appears to make each request more expensive for
+ * GBIF to answer, so this got easier to trigger after the Catalogue of Life
+ * migration.
+ *
+ * The status goes in the message because response.statusText is empty over
+ * HTTP/2, which is what Node's fetch negotiates — the original error read
+ * "GBIF API error: " with nothing after it, and hid the 429 for two rounds of
+ * debugging.
+ */
+async function gbifSearch(
+  params: URLSearchParams
+): Promise<{ count: number; results: GbifRecord[]; endOfRecords: boolean }> {
+  for (let attempt = 0; attempt <= GBIF_MAX_RETRIES; attempt++) {
+    const response = await fetch(`https://api.gbif.org/v1/occurrence/search?${params}`, {
+      cache: "no-store",
+    });
+    if (response.ok) return response.json();
+    const retryable = response.status === 429 || response.status >= 500;
+    if (!retryable || attempt === GBIF_MAX_RETRIES) {
+      throw new Error(`GBIF API error: HTTP ${response.status} ${response.statusText}`.trim());
+    }
+    await new Promise((r) => setTimeout(r, 2 ** attempt * GBIF_BACKOFF_MS));
+  }
+  throw new Error("GBIF API error: exhausted retries");
+}
+
+/**
+ * Total matching records for a bucket, without transferring any of them.
+ *
+ * Retried like every other query here rather than swallowing a failure as
+ * zero: this count is what the viewer reads "Loaded X of Y" from, and a
+ * throttled request returning 0 said a species with 230 flagged records had
+ * none — a wrong answer that looks exactly like a right one.
+ */
 async function countBucket(base: URLSearchParams, bucket: CoordinateStatus): Promise<number> {
   const params = bucketParams(base, bucket);
   params.set("limit", "0");
-  const response = await fetch(`https://api.gbif.org/v1/occurrence/search?${params}`, {
-    cache: "no-store",
-  });
-  if (!response.ok) return 0;
-  return (await response.json()).count ?? 0;
+  return (await gbifSearch(params)).count ?? 0;
+}
+
+/**
+ * Every record GBIF has coordinates for, as one list under one limit: the ones
+ * it vouches for first, then the ones it flags a geospatial issue against.
+ *
+ * Two queries, because GBIF has no single filter for "either" — but paged as
+ * though it were one list, with `offset` walking the concatenation. That is
+ * what makes a sample of 300 come back as 300 records rather than 300 of each:
+ * the flagged set is only reached once the trusted one is spent, so a species
+ * with thousands of good records never spends the sample on a suspect one,
+ * and a species with a handful still gets the rest of its budget filled.
+ *
+ * `issueTotal` is counted whether or not any flagged record is fetched — the
+ * viewer counts the two sets together in "Loaded X of Y records with
+ * coordinates", so it needs the total even on the pages that never reach them.
+ */
+async function fetchGeoreferenced(
+  base: URLSearchParams,
+  limit: number,
+  offset: number,
+  includeIssues: boolean
+): Promise<{ results: GbifRecord[]; mappedTotal: number; issueTotal: number }> {
+  const [mapped, issueTotal] = await Promise.all([
+    fetchPaginated(bucketParams(base, "mapped"), limit, offset),
+    countBucket(base, "issue"),
+  ]);
+
+  const remaining = includeIssues ? limit - mapped.results.length : 0;
+  if (remaining <= 0 || issueTotal === 0) {
+    return { results: mapped.results, mappedTotal: mapped.totalCount, issueTotal };
+  }
+
+  // Where this page falls inside the flagged set: at its start when the mapped
+  // set ran out mid-page, and further in on every page after that.
+  const issues = await fetchPaginated(
+    bucketParams(base, "issue"),
+    remaining,
+    Math.max(0, offset - mapped.totalCount)
+  );
+  return {
+    results: [...mapped.results, ...issues.results],
+    mappedTotal: mapped.totalCount,
+    issueTotal,
+  };
 }
 
 /**
@@ -246,32 +327,7 @@ async function fetchPaginated(
     params.set("limit", pageSize.toString());
     params.set("offset", offset.toString());
 
-    // Retried, because this pages in a tight loop and GBIF throttles the burst.
-    // Reproduced on every run of the browser check: the map for a species with
-    // 130,322 records 500s while the same requests issued sequentially by hand
-    // all return 200. Naming a non-default checklistKey appears to make each
-    // request more expensive for GBIF to answer, so this got easier to trigger
-    // after the Catalogue of Life migration.
-    //
-    // The status goes in the message because response.statusText is empty over
-    // HTTP/2, which is what Node's fetch negotiates — the original error read
-    // "GBIF API error: " with nothing after it, and hid the 429 for two rounds
-    // of debugging.
-    let response: Response | undefined;
-    for (let attempt = 0; attempt <= GBIF_MAX_RETRIES; attempt++) {
-      response = await fetch(`https://api.gbif.org/v1/occurrence/search?${params}`, {
-        cache: "no-store",
-      });
-      if (response.ok) break;
-      const retryable = response.status === 429 || response.status >= 500;
-      if (!retryable || attempt === GBIF_MAX_RETRIES) {
-        throw new Error(`GBIF API error: HTTP ${response.status} ${response.statusText}`.trim());
-      }
-      await new Promise((r) => setTimeout(r, 2 ** attempt * GBIF_BACKOFF_MS));
-    }
-    if (!response?.ok) throw new Error("GBIF API error: exhausted retries");
-
-    const data = await response.json();
+    const data = await gbifSearch(params);
     totalCount = data.count;
     results = results.concat(data.results);
     offset += pageSize;
@@ -304,8 +360,19 @@ function toFeatures(results: GbifRecord[]) {
     allResults.push(r);
   }
 
+  // Two readings of the same record. `geospatial` is what GBIF acts on, and so
+  // what decides which set the record belongs to; `shown` adds the notes it
+  // reports without acting on, which belong in the list's Flags column beside
+  // them. Keeping them apart is what stops a note demoting a record GBIF was
+  // happy with — see GBIF_COORDINATE_NOTES.
   const geospatialIssuesByKey = new Map<number, string[]>(
     allResults.map((r) => [r.key, (r.issues ?? []).filter((i) => GBIF_GEOSPATIAL_ISSUES.has(i))])
+  );
+  const shownIssuesByKey = new Map<number, string[]>(
+    allResults.map((r) => [
+      r.key,
+      (r.issues ?? []).filter((i) => GBIF_GEOSPATIAL_ISSUES.has(i) || GBIF_COORDINATE_NOTES.has(i)),
+    ])
   );
 
   // Coordinate-cleaning checks only mean anything for records that have a
@@ -358,7 +425,7 @@ function toFeatures(results: GbifRecord[]) {
       establishmentMeans: r.establishmentMeans,
       occurrenceID: r.occurrenceID,
       coordinateStatus: classify(r, geospatialIssuesByKey.get(r.key) ?? []),
-      gbifIssues: geospatialIssuesByKey.get(r.key) ?? [],
+      gbifIssues: shownIssuesByKey.get(r.key) ?? [],
       ...passThrough(r),
       images: imagesOf(r),
     },
@@ -454,34 +521,30 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Each requested set is fetched under its own bounded limit rather than by
-    // dropping the filters and taking whatever comes back, so a species with
-    // thousands of mapped records can't crowd out the handful of unmapped ones
-    // (or the reverse) inside a single sample.
-    const [mapped, issues, missing] = await Promise.all([
+    // Two lists, each under its own limit: the records GBIF has coordinates for
+    // (mapped then flagged, see fetchGeoreferenced) and the records it has none
+    // for. Separate because they are read in different places — the map draws
+    // the first, only the list can show the second — and a species with
+    // thousands of mapped records would otherwise crowd the handful of
+    // unlocalised ones out of the sample entirely, or the reverse.
+    const [georeferenced, missing] = await Promise.all([
       onlyMissing
-        ? Promise.resolve({ results: [] as GbifRecord[], totalCount: 0 })
-        : fetchPaginated(bucketParams(baseParams, "mapped"), limit, offset),
-      includeIssues && !onlyMissing
-        ? fetchPaginated(bucketParams(baseParams, "issue"), limit, offset)
-        : Promise.resolve(null),
+        // Paging the unmapped set alone. Its caller reads the features and none
+        // of the totals, so the counts aren't worth two more requests here.
+        ? Promise.resolve({ results: [] as GbifRecord[], mappedTotal: 0, issueTotal: 0 })
+        : fetchGeoreferenced(baseParams, limit, offset, includeIssues),
       includeMissing || onlyMissing
         ? fetchPaginated(bucketParams(baseParams, "missing"), limit, offset)
         : Promise.resolve(null),
     ]);
 
-    // Counts for the sets that weren't fetched, so the UI can offer them by name
+    // Count for the set that wasn't fetched, so the UI can offer it by name
     // ("Include 30 records without coordinates") before anyone opts in.
-    const [issueTotal, missingTotal] = await Promise.all([
-      issues ? Promise.resolve(issues.totalCount) : countBucket(baseParams, "issue"),
-      missing ? Promise.resolve(missing.totalCount) : countBucket(baseParams, "missing"),
-    ]);
+    const missingTotal = missing
+      ? missing.totalCount
+      : await countBucket(baseParams, "missing");
 
-    const features = toFeatures([
-      ...mapped.results,
-      ...(issues?.results ?? []),
-      ...(missing?.results ?? []),
-    ]);
+    const features = toFeatures([...georeferenced.results, ...(missing?.results ?? [])]);
 
     // Calculate bbox from the mapped features only. Flagged records are exactly
     // the ones whose coordinates can't be trusted — this species' single flagged
@@ -511,10 +574,10 @@ export async function GET(request: NextRequest) {
         count: features.length,
         // `total` stays the mapped set's total, which is what the "Loaded X of Y"
         // badge and every load-more control have always counted against.
-        total: onlyMissing ? (missing?.totalCount ?? 0) : mapped.totalCount,
+        total: onlyMissing ? (missing?.totalCount ?? 0) : georeferenced.mappedTotal,
         totals: {
-          mapped: mapped.totalCount,
-          issue: issueTotal,
+          mapped: georeferenced.mappedTotal,
+          issue: georeferenced.issueTotal,
           missing: missingTotal,
         },
         bbox: positionedCount > 0 ? [minLon, minLat, maxLon, maxLat] : null,

--- a/app/src/components/mapping/OccurrenceListTable.tsx
+++ b/app/src/components/mapping/OccurrenceListTable.tsx
@@ -699,6 +699,11 @@ interface OccurrenceListTableProps {
   onRowContextMenu?: (feature: OccurrenceFeature, at: { x: number; y: number }) => void;
   /** Drawn at the right of the footer — the save button, where there is one. */
   footerExtra?: React.ReactNode;
+  /** Drawn beside the row count, in the same "· clause" idiom: a word about
+   *  what isn't in the table yet. Beside the count rather than in footerExtra,
+   *  which sits among the save and export buttons and would make it read as a
+   *  tool rather than as a fact about the rows. */
+  footerCountExtra?: React.ReactNode;
   /** Scales the table, so more of it fits without shrinking the controls. */
   zoom?: number;
   /** Records struck out by hand, with the reason given for each. */
@@ -746,6 +751,7 @@ export default function OccurrenceListTable({
   onMarkDuplicate,
   onRowContextMenu,
   footerExtra,
+  footerCountExtra,
   zoom = 1,
   exclusions,
   onExclude,
@@ -2213,6 +2219,7 @@ export default function OccurrenceListTable({
               {showExcluded ? "" : " (hidden)"}
             </span>
           )}
+          {footerCountExtra}
         </span>
         {/* The rows the filters took out are greyed in place by default — a
             record you can't see is a record you can't reconsider — and this

--- a/app/src/components/mapping/OccurrenceMapRow.tsx
+++ b/app/src/components/mapping/OccurrenceMapRow.tsx
@@ -2000,11 +2000,11 @@ export default function OccurrenceMapRow({
         setTotalOccurrences(data.metadata?.total ?? null);
         setBbox(data.metadata?.bbox ?? null);
         setRecordSetTotals(data.metadata?.totals ?? null);
-        // Where each record set has been paged to, which is the sample size —
-        // not the number of records that came back. The route fetches the
-        // mapped, flagged and unmapped sets separately and merges them, so
-        // `features.length` counts up to three sets' worth and, used as an
-        // offset, skipped everything between here and there on the next page.
+        // How far the records-with-coordinates list has been paged, which is
+        // the sample size — not the number of records that came back. The
+        // unmapped set is fetched under its own limit and merged in, so
+        // `features.length` counts both lists' worth and, used as an offset,
+        // skipped everything between here and there on the next page.
         setGeneralOffset(sampleSize);
       })
       .catch(console.error)
@@ -2159,28 +2159,21 @@ export default function OccurrenceMapRow({
   // same reason (a record already pulled in by a per-category load may reappear here).
   const loadMoreOverall = useCallback(() => {
     setLoadingMoreOverall(true);
-    // The limit is per record set, and the route fetches each set it is asked
-    // for under it — so asking for 200 with both the mapped and the flagged set
-    // in play brought back 400. The southern elephant seal, whose records are
-    // mostly flagged, jumped by 400 on a button that said 200.
-    //
-    // Split between the sets that still have records to give, so the number on
-    // the button is what arrives either way: half each while both are running,
-    // and the whole batch from one once the other is spent — a species with no
-    // flagged records at all would otherwise get half of what it was promised.
-    const left = (total: number | undefined) => Math.max(0, (total ?? 0) - generalOffset);
-    const running = [recordSetTotals?.mapped, recordSetTotals?.issue].filter((t) => left(t) > 0).length;
-    const perSet = Math.ceil(OVERALL_LOAD_MORE_BATCH / Math.max(1, running));
+    // One batch, not one per record set: the route pages the mapped and flagged
+    // sets as a single list under a single limit (see fetchGeoreferenced), so
+    // asking for 200 brings back 200 however they divide. It used to bring back
+    // 400 — the southern elephant seal, whose records are mostly flagged,
+    // jumped by 400 on a button that said 200.
     const params = new URLSearchParams({
       speciesKey,
-      limit: perSet.toString(),
+      limit: OVERALL_LOAD_MORE_BATCH.toString(),
       offset: generalOffset.toString(),
     });
     if (countryCode) {
       params.set("country", countryCode);
     }
-    // The two sets this button's number is about: the ones GBIF has coordinates
-    // for, mapped and flagged. Records without coordinates have their own line
+    // The set this button's number is about: everything GBIF has coordinates
+    // for, flagged or not. Records without coordinates have their own clause
     // and their own button, which pages them from their own offset — asking for
     // them here moved a count this button says nothing about.
     params.set("includeIssues", "true");
@@ -2193,14 +2186,15 @@ export default function OccurrenceMapRow({
           const toAdd = newFeatures.filter((f) => !seen.has(f.properties.gbifID));
           return [...prev, ...toAdd];
         });
-        // By what each set was asked for, not by how many records the merge
-        // produced: they all page from the same offset.
-        setGeneralOffset((prev) => prev + perSet);
+        // By what the route returned rather than by what was asked for: the
+        // last page of a species is short, and walking the cursor past its end
+        // would ask GBIF for records that aren't there.
+        setGeneralOffset((prev) => prev + newFeatures.length);
         setTotalOccurrences(data.metadata?.total ?? null);
       })
       .catch(console.error)
       .finally(() => setLoadingMoreOverall(false));
-  }, [generalOffset, speciesKey, countryCode, recordSetTotals]);
+  }, [generalOffset, speciesKey, countryCode]);
 
   // Fetch breakdown data
   useEffect(() => {
@@ -2338,9 +2332,12 @@ export default function OccurrenceMapRow({
     }
     // 3. Coordinate-cleaning checks (zero/equal coords, GBIF HQ, duplicates)
     result = result.filter((o) => !o.properties.qualityFlags?.some((f) => appliedChecks[f as QualityFlag]));
-    // 3b. GBIF's own geospatial issues, treated as one more cleaning check
+    // 3b. GBIF's own verdict, treated as one more cleaning check. On
+    // coordinateStatus rather than on gbifIssues: the flags column also carries
+    // notes GBIF reports without excluding the record over, and a record is
+    // only in the flagged set if GBIF put it there.
     if (hideGbifFlagged) {
-      result = result.filter((o) => !(o.properties.gbifIssues?.length));
+      result = result.filter((o) => o.properties.coordinateStatus !== "issue");
     }
     // 4. Native range only — hide occurrences reported outside this species' native countries
     if (nativeRangeOnly) {
@@ -2617,7 +2614,7 @@ export default function OccurrenceMapRow({
   // (i.e. they pass every other active filter) — same "shown of loaded" reading
   // as the other cleaning rows.
   const gbifFlaggedCounts = useMemo(() => {
-    const flagged = occurrences.filter((o) => o.properties.gbifIssues?.length);
+    const flagged = occurrences.filter((o) => o.properties.coordinateStatus === "issue");
     const others = new Set(filteredOccurrences.map((o) => o.properties.gbifID));
     return {
       loaded: flagged.length,
@@ -4004,56 +4001,63 @@ export default function OccurrenceMapRow({
             map. One row, both record sets: the ones the map can draw, and
             the ones only the list can show. */}
         {!loadingOccurrences &&
-          ((!splitView && totalOccurrences != null) ||
-            (recordSetTotals?.missing ?? 0) > 0) &&
+          ((!splitView && totalOccurrences != null) || missingToLoad > 0) &&
           (countsOpen ? (
           <div className="shrink-0 flex flex-wrap items-center gap-x-3 gap-y-0.5 px-2 py-1 border-b border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/60 text-[11px]">
-            {!splitView && totalOccurrences != null && (
-              <div className="text-emerald-700 dark:text-emerald-400">
-                {isFullSample ? (
-                  <>All <strong>{(georeferencedTotal ?? 0).toLocaleString()}</strong> GBIF records with coordinates loaded.</>
+            {/* One sentence, both record sets. As two lines they said the same
+                thing twice — "Loaded", a count, a link reading "Click to load
+                N more" — and read as two facts about two things rather than
+                one fact about this species. The links go in brackets, where a
+                parenthetical belongs, instead of ending the sentence and
+                starting the next one without a full stop between them. */}
+            <div className="text-emerald-700 dark:text-emerald-400">
+              {!splitView && totalOccurrences != null && (
+                isFullSample ? (
+                  <>All <strong>{(georeferencedTotal ?? 0).toLocaleString()}</strong> GBIF records with coordinates loaded</>
                 ) : (
-                  <>Loaded <strong>{georeferencedLoadedCount.toLocaleString()}</strong> of <strong>{(georeferencedTotal ?? 0).toLocaleString()}</strong> GBIF records with coordinates.</>
-                )}
-                {!isFullSample && (
                   <>
-                    {" "}
+                    Loaded <strong>{georeferencedLoadedCount.toLocaleString()}</strong> of{" "}
+                    <strong>{(georeferencedTotal ?? 0).toLocaleString()}</strong> GBIF records with coordinates{" "}
+                    (
                     <button
                       onClick={loadMoreOverall}
                       disabled={loadingMoreOverall}
                       className="underline decoration-dotted hover:decoration-solid disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {loadingMoreOverall
-                        ? "Loading…"
-                        : `Click to load ${Math.min(OVERALL_LOAD_MORE_BATCH, (georeferencedTotal ?? 0) - georeferencedLoadedCount).toLocaleString()} more`}
+                        ? "loading…"
+                        : `click to load ${Math.min(OVERALL_LOAD_MORE_BATCH, (georeferencedTotal ?? 0) - georeferencedLoadedCount).toLocaleString()} more`}
                     </button>
+                    )
                   </>
-                )}
-                {georeferencedFilteredCount < georeferencedLoadedCount && (
-                  <> Showing <strong>{georeferencedFilteredCount.toLocaleString()}</strong> after filters.</>
-                )}
-              </div>
-            )}
-            {/* Records with no coordinates only get a line when there are
-                more to fetch. "All N loaded" was a fact with nothing to do
-                about it — they're in the table either way. */}
-            {missingLoadedCount < (recordSetTotals?.missing ?? 0) && (
-              <div className="text-amber-700 dark:text-amber-400">
-                <>
-                    Loaded <strong>{missingLoadedCount.toLocaleString()}</strong> of{" "}
-                    <strong>{(recordSetTotals?.missing ?? 0).toLocaleString()}</strong> without coordinates.{" "}
-                    <button
-                      onClick={loadMoreMissing}
-                      disabled={loadingMoreMissing}
-                      className="underline decoration-dotted hover:decoration-solid disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {loadingMoreMissing
-                        ? "Loading…"
-                        : `Click to load ${Math.min(sampleSize, (recordSetTotals?.missing ?? 0) - missingLoadedCount).toLocaleString()} more`}
-                    </button>
-                </>
-              </div>
-            )}
+                )
+              )}
+              {missingToLoad > 0 && (
+                <span className="text-amber-700 dark:text-amber-400">
+                  {!splitView && totalOccurrences != null ? ", and " : "Loaded "}
+                  <strong>{missingLoadedCount.toLocaleString()}</strong> of{" "}
+                  <strong>{(recordSetTotals?.missing ?? 0).toLocaleString()}</strong> without coordinates{" "}
+                  (
+                  <button
+                    onClick={loadMoreMissing}
+                    disabled={loadingMoreMissing}
+                    className="underline decoration-dotted hover:decoration-solid disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {loadingMoreMissing
+                      ? "loading…"
+                      : `click to load ${Math.min(sampleSize, missingToLoad).toLocaleString()} more`}
+                  </button>
+                  )
+                </span>
+              )}
+              .
+              {/* Kept, and kept last: with the flagged records hidden by
+                  default this is often the only line saying that what the map
+                  draws is smaller than what was loaded. */}
+              {georeferencedFilteredCount < georeferencedLoadedCount && (
+                <> Showing <strong>{georeferencedFilteredCount.toLocaleString()}</strong> after filters.</>
+              )}
+            </div>
             {/* Rolled away once it has been read. How much of a species is
                 loaded is a line you read at the start and then keep looking
                 past, and on a short map it was a line of the map. The chevron
@@ -5753,6 +5757,10 @@ export default function OccurrenceMapRow({
     () => occurrences.filter((o) => o.properties.coordinateStatus === "missing").length,
     [occurrences]
   );
+  /** Records with no coordinates still to fetch. The counts line only names
+   *  that set when there are some: "all N loaded" was a fact with nothing to
+   *  do about it, and they are in the table either way. */
+  const missingToLoad = Math.max(0, (recordSetTotals?.missing ?? 0) - missingLoadedCount);
   const georeferencedTotal = recordSetTotals
     ? recordSetTotals.mapped + recordSetTotals.issue
     : totalOccurrences;

--- a/app/src/components/mapping/OccurrenceMapRow.tsx
+++ b/app/src/components/mapping/OccurrenceMapRow.tsx
@@ -898,11 +898,13 @@ export default function OccurrenceMapRow({
     document.addEventListener("click", close, true);
     return () => document.removeEventListener("click", close, true);
   }, [gbifOptionsOpen]);
-  // Hybrid by default: imagery with the place names still on it. A record's
-  // position is judged against what is actually on the ground — the plantation,
-  // the river, the edge of the forest — and the street map draws none of it,
-  // while bare satellite leaves nothing to say where you are looking.
-  const [basemap, setBasemap] = useState<BasemapKey>("hybrid");
+  // The street map by default. Imagery answers a question you ask about one
+  // record — what is on the ground where this point sits — and the map opens
+  // on a species' whole range, where the question is where the records are at
+  // all. Coastlines, borders and place names answer that at a glance and a
+  // satellite mosaic doesn't; hybrid is one click away for the moment the
+  // question changes.
+  const [basemap, setBasemap] = useState<BasemapKey>("streets");
   // Overlays — informational map layers, independent of the "Native range only"
   // occurrence filter above: shading which countries a source considers native,
   // regardless of whether occurrences are being filtered by it.
@@ -2090,6 +2092,34 @@ export default function OccurrenceMapRow({
   // is fetching the next unfiltered batch — separate from loadingMoreCategory since
   // this isn't scoped to one basis-of-record category.
   const [loadingMoreOverall, setLoadingMoreOverall] = useState(false);
+  const [loadingMoreMissing, setLoadingMoreMissing] = useState(false);
+
+  // Records with no coordinates arrive as their own bounded sample, so a
+  // species with hundreds of unlocalised sheets doesn't stall the first paint.
+  // This pages that set alone, from however many are already loaded — driven
+  // from the record list's footer, which is the only place they can be read.
+  const loadMoreMissing = useCallback(() => {
+    setLoadingMoreMissing(true);
+    const loaded = occurrences.filter((o) => o.properties.coordinateStatus === "missing").length;
+    const params = new URLSearchParams({
+      speciesKey,
+      limit: sampleSize.toString(),
+      offset: loaded.toString(),
+      onlyMissing: "true",
+    });
+    if (countryCode) params.set("country", countryCode);
+    fetch(`/api/occurrences?${params}`)
+      .then((res) => res.json())
+      .then((data) => {
+        const next: OccurrenceFeature[] = data.features || [];
+        setOccurrences((prev) => {
+          const seen = new Set(prev.map((o) => o.properties.gbifID));
+          return [...prev, ...next.filter((f) => !seen.has(f.properties.gbifID))];
+        });
+      })
+      .catch(console.error)
+      .finally(() => setLoadingMoreMissing(false));
+  }, [occurrences, speciesKey, countryCode, sampleSize]);
 
   // Load another batch of just one basis-of-record category (e.g. "load 200 more
   // Preserved specimen records"), independent of the overall sample-size selector —
@@ -4885,8 +4915,8 @@ export default function OccurrenceMapRow({
                   <Layer id={`eoo-fill-${panelId}`} type="fill" paint={{ "fill-color": "#0ea5e9", "fill-opacity": 0.12 }} />
                   {/* A white casing under the hull, as the protected-area
                       highlights use: a dark blue line on dark imagery was a
-                      line you had to know was there to find, and the hybrid
-                      basemap is now the one people start on. */}
+                      line you had to know was there to find, and imagery is a
+                      click away whatever the map opens on. */}
                   <Layer
                     id={`eoo-casing-${panelId}`}
                     type="line"
@@ -5702,6 +5732,14 @@ export default function OccurrenceMapRow({
     () => occurrences.filter(hasPosition).length,
     [occurrences]
   );
+  const missingLoadedCount = useMemo(
+    () => occurrences.filter((o) => o.properties.coordinateStatus === "missing").length,
+    [occurrences]
+  );
+  /** Records with no coordinates still to fetch. Named in the list's footer
+   *  only when there are some — "all N loaded" is a fact with nothing to do
+   *  about it, and they are in the table either way. */
+  const missingToLoad = Math.max(0, (recordSetTotals?.missing ?? 0) - missingLoadedCount);
   const georeferencedTotal = recordSetTotals
     ? recordSetTotals.mapped + recordSetTotals.issue
     : totalOccurrences;
@@ -8975,6 +9013,23 @@ export default function OccurrenceMapRow({
                       )}
                       {EDIT_TOOLS}
                     </>
+                  }
+                  footerCountExtra={
+                    listTab === "gbif" && missingToLoad > 0 ? (
+                      <>
+                        {" "}·{" "}
+                        <button
+                          onClick={loadMoreMissing}
+                          disabled={loadingMoreMissing}
+                          title={`GBIF has no coordinates for ${(recordSetTotals?.missing ?? 0).toLocaleString()} records of this species — a locality description and nothing to map. ${missingLoadedCount.toLocaleString()} are in this table; the rest are a click away.`}
+                          className="underline decoration-dotted hover:decoration-solid disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {loadingMoreMissing
+                            ? "Loading…"
+                            : `Load ${Math.min(sampleSize, missingToLoad).toLocaleString()} more without coordinates`}
+                        </button>
+                      </>
+                    ) : undefined
                   }
                   excludedIds={excludedIds}
                   exclusions={exclusions}

--- a/app/src/components/mapping/OccurrenceMapRow.tsx
+++ b/app/src/components/mapping/OccurrenceMapRow.tsx
@@ -18,6 +18,7 @@ import {
   type EditsBackup,
 } from "@/lib/mapping/edits-backup";
 import { duplicatesByPrimary as groupDuplicates, keepRecord as keepRecordIn } from "@/lib/mapping/duplicates";
+import { taxonGroupCountsPreservedSpecimens } from "@/lib/gbif";
 import { CATEGORY_COLORS, normalizeCategory } from "@/config/taxa";
 import { FaInfoCircle } from "react-icons/fa";
 import booleanPointInPolygon from "@turf/boolean-point-in-polygon";
@@ -675,22 +676,30 @@ interface OccurrenceMapRowProps {
 /**
  * Which record types are selected when the viewer opens.
  *
- * Every kingdom now starts with every record type but two, rather than only
- * plants and fungi: a herbarium sheet, a museum skin or a literature citation
- * is evidence of where the species was, and a default that quietly drops
- * record types hides the very evidence an assessment gets written from.
+ * Every record type but three: a literature citation or a bare "occurrence"
+ * record is evidence of where the species was, and a default that quietly
+ * drops record types hides the very evidence an assessment gets written from.
  *
- * The two exceptions are the ones that say where an individual *ended up*
- * rather than where the species lives: a living specimen is a zoo or botanic
+ * Two of the three say where an individual *ended up* rather than where the
+ * species lives, whatever the kingdom: a living specimen is a zoo or botanic
  * garden animal or plant, and a fossil specimen is a range from a different
  * epoch. Both are off until asked for.
+ *
+ * The third, preserved specimens, follows the taxon — on for plants and fungi
+ * (and the brown algae filed with them), off for animals. It is the same rule
+ * `taxonGroupCountsPreservedSpecimens` applies to the dashboard's own GBIF
+ * counts, and the viewer opening on a different record set from the count that
+ * sent you to it is the confusion worth avoiding: a plant is known mostly from
+ * collected, preserved material, an animal mostly from observation, and a
+ * mammal's herbarium-equivalent museum skins are a small tail of records whose
+ * localities are the oldest and vaguest in the set.
  */
-export function defaultCheckedTypes() {
+export function defaultCheckedTypes(taxonGroup?: string) {
   return {
     humanObservation: true,
     machineObservation: true,
     observation: true,
-    preservedSpecimen: true,
+    preservedSpecimen: taxonGroupCountsPreservedSpecimens(taxonGroup),
     fossilSpecimen: false,
     livingSpecimen: false,
     materialSample: true,
@@ -833,7 +842,7 @@ export default function OccurrenceMapRow({
   const [loadingOccurrences, setLoadingOccurrences] = useState(true);
   const [loadingBreakdown, setLoadingBreakdown] = useState(true);
 
-  const [checkedTypes, setCheckedTypes] = useState(() => defaultCheckedTypes());
+  const [checkedTypes, setCheckedTypes] = useState(() => defaultCheckedTypes(taxonGroup));
 
   // Advanced filter state
   const [maxUncertainty, setMaxUncertainty] = useState<number | null>(null);
@@ -1937,22 +1946,19 @@ export default function OccurrenceMapRow({
   // unfiltered ordering actually considers "next" if reused here.
   const [generalOffset, setGeneralOffset] = useState(0);
 
-  // Opt-in record sets the viewer has always filtered out: records GBIF has no
-  // coordinates for, and records whose coordinates GBIF flags. Both are only
-  // useful in the list (one can't be drawn at all, the other shouldn't be
-  // trusted where it's drawn), and both are what an assessor georeferences by
-  // hand — so they're off until asked for, and their totals are always fetched
-  // so the toggles can name what's being hidden.
-  // Fetched automatically in fullscreen — the list is the only place they can
-  // be read, and it's the whole point of that page. Off elsewhere, where
-  // there's no list to put them in.
-  const includeMissing = !!fullscreenProp;
-  // Records GBIF flags are always fetched now: they have coordinates, so they
+  // Records GBIF flags are always fetched: they have coordinates, so they
   // belong with the rest and are hidden (or not) by a coordinate-cleaning check
   // like any other suspect point, rather than by a separate opt-in.
-  // Off by default — the same rule the other cleaning checks follow, since
-  // this is now one of them.
-  const [hideGbifFlagged, setHideGbifFlagged] = useState(false);
+  //
+  // On by default, unlike the other cleaning checks. Those are this project's
+  // own plausibility heuristics with real false-positive rates, so they stay
+  // opt-in; this one is GBIF's verdict on its own record — a zero coordinate, a
+  // country that doesn't match the point, a swapped latitude — and a map an
+  // assessor reads a range off shouldn't open on positions the aggregator that
+  // published them won't vouch for. Unchecking it puts them back on the map in
+  // amber, and they are in the list either way: greyed, and counted in the
+  // footer's "N removed by your filters".
+  const [hideGbifFlagged, setHideGbifFlagged] = useState(true);
   const [recordSetTotals, setRecordSetTotals] = useState<{ mapped: number; issue: number; missing: number } | null>(null);
 
   /**
@@ -1979,7 +1985,12 @@ export default function OccurrenceMapRow({
     if (countryCode) {
       params.set("country", countryCode);
     }
-    if (includeMissing) params.set("includeMissing", "true");
+    // Both of the sets that aren't plain mapped points: the ones GBIF flags,
+    // and the ones it has no coordinates for at all. Fetched in both modes —
+    // the record panel exists on the dashboard as well as fullscreen, and a
+    // herbarium sheet waiting to be georeferenced is exactly as readable in
+    // one as in the other.
+    params.set("includeMissing", "true");
     params.set("includeIssues", "true");
     fetch(`/api/occurrences?${params}`)
       .then((res) => res.json())
@@ -1998,7 +2009,7 @@ export default function OccurrenceMapRow({
       })
       .catch(console.error)
       .finally(() => setLoadingOccurrences(false));
-  }, [speciesKey, countryCode, sampleSize, includeMissing]);
+  }, [speciesKey, countryCode, sampleSize]);
 
   /**
    * The records this assessor has edited, whether or not the sample holds them.
@@ -3994,7 +4005,7 @@ export default function OccurrenceMapRow({
             the ones only the list can show. */}
         {!loadingOccurrences &&
           ((!splitView && totalOccurrences != null) ||
-            (fullscreen && (recordSetTotals?.missing ?? 0) > 0)) &&
+            (recordSetTotals?.missing ?? 0) > 0) &&
           (countsOpen ? (
           <div className="shrink-0 flex flex-wrap items-center gap-x-3 gap-y-0.5 px-2 py-1 border-b border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/60 text-[11px]">
             {!splitView && totalOccurrences != null && (
@@ -4026,7 +4037,7 @@ export default function OccurrenceMapRow({
             {/* Records with no coordinates only get a line when there are
                 more to fetch. "All N loaded" was a fact with nothing to do
                 about it — they're in the table either way. */}
-            {fullscreen && missingLoadedCount < (recordSetTotals?.missing ?? 0) && (
+            {missingLoadedCount < (recordSetTotals?.missing ?? 0) && (
               <div className="text-amber-700 dark:text-amber-400">
                 <>
                     Loaded <strong>{missingLoadedCount.toLocaleString()}</strong> of{" "}

--- a/app/src/components/mapping/OccurrenceMapRow.tsx
+++ b/app/src/components/mapping/OccurrenceMapRow.tsx
@@ -2090,33 +2090,6 @@ export default function OccurrenceMapRow({
   // is fetching the next unfiltered batch — separate from loadingMoreCategory since
   // this isn't scoped to one basis-of-record category.
   const [loadingMoreOverall, setLoadingMoreOverall] = useState(false);
-  const [loadingMoreMissing, setLoadingMoreMissing] = useState(false);
-
-  // Records with no coordinates arrive as their own bounded sample, so a
-  // species with hundreds of unlocalised sheets doesn't stall the first paint.
-  // This pages that set alone, from however many are already loaded.
-  const loadMoreMissing = useCallback(() => {
-    setLoadingMoreMissing(true);
-    const loaded = occurrences.filter((o) => o.properties.coordinateStatus === "missing").length;
-    const params = new URLSearchParams({
-      speciesKey,
-      limit: sampleSize.toString(),
-      offset: loaded.toString(),
-      onlyMissing: "true",
-    });
-    if (countryCode) params.set("country", countryCode);
-    fetch(`/api/occurrences?${params}`)
-      .then((res) => res.json())
-      .then((data) => {
-        const next: OccurrenceFeature[] = data.features || [];
-        setOccurrences((prev) => {
-          const seen = new Set(prev.map((o) => o.properties.gbifID));
-          return [...prev, ...next.filter((f) => !seen.has(f.properties.gbifID))];
-        });
-      })
-      .catch(console.error)
-      .finally(() => setLoadingMoreMissing(false));
-  }, [occurrences, speciesKey, countryCode, sampleSize]);
 
   // Load another batch of just one basis-of-record category (e.g. "load 200 more
   // Preserved specimen records"), independent of the overall sample-size selector —
@@ -3998,59 +3971,35 @@ export default function OccurrenceMapRow({
             on top of it. It is a fact about the record set, not about any
             place on the map — and as an overlay it covered whatever tiles it
             landed on, in the same corner as the controls that do act on the
-            map. One row, both record sets: the ones the map can draw, and
-            the ones only the list can show. */}
-        {!loadingOccurrences &&
-          ((!splitView && totalOccurrences != null) || missingToLoad > 0) &&
+            map.
+
+            The records the map can draw, and only those. The ones GBIF has no
+            coordinates for are in the list either way, and a second count and
+            a second link for a set this row's own number says nothing about
+            made the line read as two facts about two things. */}
+        {!loadingOccurrences && !splitView && totalOccurrences != null &&
           (countsOpen ? (
           <div className="shrink-0 flex flex-wrap items-center gap-x-3 gap-y-0.5 px-2 py-1 border-b border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/60 text-[11px]">
-            {/* One sentence, both record sets. As two lines they said the same
-                thing twice — "Loaded", a count, a link reading "Click to load
-                N more" — and read as two facts about two things rather than
-                one fact about this species. The links go in brackets, where a
-                parenthetical belongs, instead of ending the sentence and
-                starting the next one without a full stop between them. */}
             <div className="text-emerald-700 dark:text-emerald-400">
-              {!splitView && totalOccurrences != null && (
-                isFullSample ? (
-                  <>All <strong>{(georeferencedTotal ?? 0).toLocaleString()}</strong> GBIF records with coordinates loaded</>
-                ) : (
-                  <>
-                    Loaded <strong>{georeferencedLoadedCount.toLocaleString()}</strong> of{" "}
-                    <strong>{(georeferencedTotal ?? 0).toLocaleString()}</strong> GBIF records with coordinates{" "}
-                    (
-                    <button
-                      onClick={loadMoreOverall}
-                      disabled={loadingMoreOverall}
-                      className="underline decoration-dotted hover:decoration-solid disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {loadingMoreOverall
-                        ? "loading…"
-                        : `click to load ${Math.min(OVERALL_LOAD_MORE_BATCH, (georeferencedTotal ?? 0) - georeferencedLoadedCount).toLocaleString()} more`}
-                    </button>
-                    )
-                  </>
-                )
+              {isFullSample ? (
+                <>All <strong>{(georeferencedTotal ?? 0).toLocaleString()}</strong> GBIF records with coordinates loaded.</>
+              ) : (
+                <>Loaded <strong>{georeferencedLoadedCount.toLocaleString()}</strong> of <strong>{(georeferencedTotal ?? 0).toLocaleString()}</strong> GBIF records with coordinates.</>
               )}
-              {missingToLoad > 0 && (
-                <span className="text-amber-700 dark:text-amber-400">
-                  {!splitView && totalOccurrences != null ? ", and " : "Loaded "}
-                  <strong>{missingLoadedCount.toLocaleString()}</strong> of{" "}
-                  <strong>{(recordSetTotals?.missing ?? 0).toLocaleString()}</strong> without coordinates{" "}
-                  (
+              {!isFullSample && (
+                <>
+                  {" "}
                   <button
-                    onClick={loadMoreMissing}
-                    disabled={loadingMoreMissing}
+                    onClick={loadMoreOverall}
+                    disabled={loadingMoreOverall}
                     className="underline decoration-dotted hover:decoration-solid disabled:opacity-50 disabled:cursor-not-allowed"
                   >
-                    {loadingMoreMissing
-                      ? "loading…"
-                      : `click to load ${Math.min(sampleSize, missingToLoad).toLocaleString()} more`}
+                    {loadingMoreOverall
+                      ? "Loading…"
+                      : `Click to load ${Math.min(OVERALL_LOAD_MORE_BATCH, (georeferencedTotal ?? 0) - georeferencedLoadedCount).toLocaleString()} more`}
                   </button>
-                  )
-                </span>
+                </>
               )}
-              .
               {/* Kept, and kept last: with the flagged records hidden by
                   default this is often the only line saying that what the map
                   draws is smaller than what was loaded. */}
@@ -5753,14 +5702,6 @@ export default function OccurrenceMapRow({
     () => occurrences.filter(hasPosition).length,
     [occurrences]
   );
-  const missingLoadedCount = useMemo(
-    () => occurrences.filter((o) => o.properties.coordinateStatus === "missing").length,
-    [occurrences]
-  );
-  /** Records with no coordinates still to fetch. The counts line only names
-   *  that set when there are some: "all N loaded" was a fact with nothing to
-   *  do about it, and they are in the table either way. */
-  const missingToLoad = Math.max(0, (recordSetTotals?.missing ?? 0) - missingLoadedCount);
   const georeferencedTotal = recordSetTotals
     ? recordSetTotals.mapped + recordSetTotals.issue
     : totalOccurrences;

--- a/app/src/components/mapping/__tests__/occurrenceDefaults.test.ts
+++ b/app/src/components/mapping/__tests__/occurrenceDefaults.test.ts
@@ -1,31 +1,43 @@
 /**
  * What the occurrence viewer shows before anyone touches a filter.
  *
- * These defaults decide what an assessor sees first, and the old ones hid most
- * of the evidence for everything but plants and fungi: specimens and citations
- * off, and cleaning checks trimming points on plausibility heuristics. The
- * viewer now opens on everything GBIF holds, for every kingdom, bar the two
- * record types that describe where an individual ended up rather than where the
- * species lives. Worth pinning down.
+ * These defaults decide what an assessor sees first, so they are worth pinning
+ * down: every record type bar the two that say where an individual ended up
+ * rather than where the species lives, no cleaning check applied, and
+ * preserved specimens following the taxon — the same rule the dashboard's own
+ * GBIF counts use.
  */
 import { describe, it, expect } from "vitest";
 import { defaultCheckedTypes, defaultAppliedChecks } from "../OccurrenceMapRow";
 
 describe("defaultCheckedTypes", () => {
-  it("selects every record type but living and fossil specimens", () => {
-    const types = defaultCheckedTypes();
-    expect(types.livingSpecimen).toBe(false);
-    expect(types.fossilSpecimen).toBe(false);
-    const { livingSpecimen: _l, fossilSpecimen: _f, ...rest } = types;
-    expect(Object.values(rest).every(Boolean)).toBe(true);
+  it("leaves living and fossil specimens off for every taxon", () => {
+    for (const group of [undefined, "mammals", "beetles", "flowering_plants", "mushrooms"]) {
+      const types = defaultCheckedTypes(group);
+      expect(types.livingSpecimen).toBe(false);
+      expect(types.fossilSpecimen).toBe(false);
+    }
   });
 
-  it("keeps specimens, citations and field observations on", () => {
-    const types = defaultCheckedTypes();
-    expect(types.preservedSpecimen).toBe(true);
+  it("keeps citations, field observations and material samples on", () => {
+    const types = defaultCheckedTypes("mammals");
     expect(types.materialCitation).toBe(true);
     expect(types.humanObservation).toBe(true);
     expect(types.machineObservation).toBe(true);
+    expect(types.observation).toBe(true);
+    expect(types.materialSample).toBe(true);
+    expect(types.occurrence).toBe(true);
+  });
+
+  // The dashboard's counts for a plant include its herbarium sheets and an
+  // animal's exclude its museum skins; the viewer has to open on the same set,
+  // or the count that sent you here describes different records from the map.
+  it("starts preserved specimens on for plants and fungi, off for animals", () => {
+    expect(defaultCheckedTypes("flowering_plants").preservedSpecimen).toBe(true);
+    expect(defaultCheckedTypes("mushrooms").preservedSpecimen).toBe(true);
+    expect(defaultCheckedTypes("mammals").preservedSpecimen).toBe(false);
+    expect(defaultCheckedTypes("beetles").preservedSpecimen).toBe(false);
+    expect(defaultCheckedTypes(undefined).preservedSpecimen).toBe(false);
   });
 });
 

--- a/app/src/lib/__tests__/gbif.test.ts
+++ b/app/src/lib/__tests__/gbif.test.ts
@@ -7,6 +7,8 @@ import {
   includedBasisOfRecord,
   kingdomCountsPreservedSpecimens,
   taxonGroupCountsPreservedSpecimens,
+  GBIF_GEOSPATIAL_ISSUES,
+  GBIF_COORDINATE_NOTES,
 } from "../gbif";
 import { TAXA } from "@/config/taxa";
 import { TAXA_DEFINITIONS } from "../../../scripts/taxa";
@@ -105,6 +107,45 @@ describe("preserved specimens", () => {
         kingdomCountsPreservedSpecimens(taxon.kingdomKey),
         `"${taxon.id}" (kingdom ${taxon.kingdomKey}) disagrees between the kingdom and group rules`,
       ).toBe(taxonGroupCountsPreservedSpecimens(taxon.id));
+    }
+  });
+});
+
+describe("GBIF_GEOSPATIAL_ISSUES", () => {
+  /**
+   * The viewer fetches the two sides of GBIF's `hasGeospatialIssue` filter
+   * separately and in order: everything it returns for `false`, then the
+   * records it excludes. This set is how the response is read back, so it has
+   * to be exactly what GBIF acts on — anything extra puts records the trusted
+   * query already returned into the flagged bucket, where they are painted as
+   * suspect and hidden by a check nobody aimed at them.
+   *
+   * Verified against the live API, not the docs, with
+   * `issue=<code>&hasGeospatialIssue=false`: nothing comes back for any code in
+   * the set, and records come back for both of the notes.
+   */
+  it("holds no code GBIF reports without excluding the record over", () => {
+    for (const note of GBIF_COORDINATE_NOTES) {
+      expect(GBIF_GEOSPATIAL_ISSUES.has(note), `${note} is a note, not a flag`).toBe(false);
+    }
+  });
+
+  it("names the two that GBIF reports but does not act on", () => {
+    expect([...GBIF_COORDINATE_NOTES].sort()).toEqual([
+      "COORDINATE_REPROJECTION_SUSPICIOUS",
+      "GEODETIC_DATUM_INVALID",
+    ]);
+  });
+
+  it("keeps the ones GBIF does exclude records over", () => {
+    for (const code of [
+      "ZERO_COORDINATE",
+      "COORDINATE_INVALID",
+      "COUNTRY_COORDINATE_MISMATCH",
+      "CONTINENT_COORDINATE_MISMATCH",
+      "PRESUMED_SWAPPED_COORDINATE",
+    ]) {
+      expect(GBIF_GEOSPATIAL_ISSUES.has(code), `${code} should be a flag`).toBe(true);
     }
   });
 });

--- a/app/src/lib/gbif.ts
+++ b/app/src/lib/gbif.ts
@@ -86,28 +86,53 @@ export function includedBasisOfRecord(includePreservedSpecimens: boolean): reado
 }
 
 /**
- * The GBIF occurrence issues that concern a record's position — the set behind
- * GBIF's own `hasGeospatialIssue` filter (https://techdocs.gbif.org/en/openapi/,
- * OccurrenceIssue). A record carrying one of these still has coordinates; GBIF
- * just doesn't trust them, which is exactly what makes it a candidate for
- * manual re-georeferencing rather than something to silently drop.
+ * The GBIF occurrence issues that make `hasGeospatialIssue` true — the ones
+ * GBIF distrusts a record's position enough to exclude it over. A record
+ * carrying one still has coordinates; GBIF just doesn't trust them, which is
+ * exactly what makes it a candidate for manual re-georeferencing rather than
+ * something to silently drop.
  *
- * Occurrence records also carry non-geospatial issues (fuzzy taxon matches,
- * invalid dates); those are filtered out rather than shipped to the client,
- * since nothing in the occurrence viewer acts on them.
+ * This set has to be exactly GBIF's, because the viewer fetches the two sides
+ * of that filter separately and in order — every record `hasGeospatialIssue=false`
+ * returns, then the ones it excludes. A code in here that GBIF does not act on
+ * puts records the "trusted" query already returned into the flagged bucket,
+ * where they get painted as suspect and hidden by a check the assessor never
+ * aimed at them.
+ *
+ * Two used to be in here that GBIF doesn't act on — see GBIF_COORDINATE_NOTES.
+ * Membership was checked against the API rather than read off the docs, per
+ * code: `issue=<code>&hasGeospatialIssue=false` returns nothing for every code
+ * below, and returns records for both of the two.
+ *
+ * Occurrence records also carry issues with nothing to do with position (fuzzy
+ * taxon matches, invalid dates); those are filtered out rather than shipped to
+ * the client, since nothing in the occurrence viewer acts on them.
  */
 export const GBIF_GEOSPATIAL_ISSUES = new Set([
   "ZERO_COORDINATE",
   "COORDINATE_INVALID",
   "COORDINATE_OUT_OF_RANGE",
   "COORDINATE_REPROJECTION_FAILED",
-  "COORDINATE_REPROJECTION_SUSPICIOUS",
   "COUNTRY_COORDINATE_MISMATCH",
   "CONTINENT_COORDINATE_MISMATCH",
-  "GEODETIC_DATUM_INVALID",
   "PRESUMED_NEGATED_LATITUDE",
   "PRESUMED_NEGATED_LONGITUDE",
   "PRESUMED_SWAPPED_COORDINATE",
+]);
+
+/**
+ * Position-related issues GBIF reports but does not exclude a record over: an
+ * unparseable datum string (GBIF reads the coordinates as WGS84 and says so),
+ * and a reprojection that moved the point further than expected.
+ *
+ * Shown in the record list's Flags column, because they are worth knowing when
+ * you are reading a locality — but not treated as GBIF flagging the record,
+ * because GBIF didn't. Seven of the cheetah's first page carried the datum one
+ * and were being hidden as flagged while sitting in the trusted set.
+ */
+export const GBIF_COORDINATE_NOTES = new Set([
+  "GEODETIC_DATUM_INVALID",
+  "COORDINATE_REPROJECTION_SUSPICIOUS",
 ]);
 
 /** Human-readable label for a GBIF issue code, e.g. "Country coordinate mismatch". */


### PR DESCRIPTION
## Summary

Changes to what the occurrence viewer loads and what it shows before anyone touches a filter. Nothing stops being fetched — everything hidden is still in the record list, greyed and counted in *"N removed by your filters"*.

### One sample of 300, trusted records first

The route paged the two georeferenced sets under **separate** limits, so a "300-record sample" was two queries and up to 600 records, and Load more had to halve its batch to keep its own promise. `fetchGeoreferenced` now pages them as **one list under one limit** — every record `hasGeospatialIssue=false` returns, then the ones it excludes — with `offset` walking the concatenation. A species with thousands of good records never spends its sample on a suspect one; a species with a handful still gets the rest of its budget filled.

Two things had to be fixed for that ordering to actually hold:

- **`GBIF_GEOSPATIAL_ISSUES` is now exactly the set GBIF acts on.** It held two codes that don't make `hasGeospatialIssue` true — `GEODETIC_DATUM_INVALID` and `COORDINATE_REPROJECTION_SUSPICIOUS` — so nine of the cheetah's records came back from the *trusted* query and were then classified as flagged, painted amber and hidden by a check nobody aimed at them. Membership was checked against the live API per code (`issue=<code>&hasGeospatialIssue=false`), not read off the docs. The two move to `GBIF_COORDINATE_NOTES` and still appear in the list's Flags column — an unparseable datum is worth knowing when you're reading a locality — they just aren't GBIF flagging the record. The "Flagged by GBIF" filter and its count now read `coordinateStatus`, which is what the map has always painted from; they read `gbifIssues`, and the three could disagree.
- **`countBucket` is retried like every other query.** It swallowed a failure as zero, and with the count now on the hot path a throttled request said the fur seal had *no* flagged records — a wrong answer that looks exactly like a right one. The retry loop moves out of `fetchPaginated` into a shared `gbifSearch`.

### The counts line is about the records the map can draw

It named two record sets and offered a link for each:

> Loaded 300 of 8,916 GBIF records with coordinates (click to load 200 more), and 300 of 1,290 without coordinates (click to load 300 more). Showing 297 after filters.

The second half is a different subject. The row sits above the map and its number is what the map draws; records with no coordinates aren't on it, can't be, and are in the record list either way. So the row is the records with coordinates, and the link stays where it was, outside brackets:

> Loaded 300 of 8,916 GBIF records with coordinates. Click to load 200 more Showing 297 after filters.

*"Showing N after filters"* is kept, and kept last — with flagged records hidden by default it's often the only thing saying the map draws less than was loaded.

Paging that set moved with the clause, into the record list's own footer, in the same "· clause" idiom as the row count beside it — which is where it belonged anyway, since those records are only ever read in the table:

> 600 records · 256 removed by your filters · **Load 300 more without coordinates**

Shown only while there are more to fetch, and only on the GBIF records tab; the totals are in its tooltip rather than in a second clause.

### The street map is the default basemap again

Imagery answers a question you ask about one record — what is on the ground where this point sits — and the map opens on a species' whole range, where the question is where the records are at all. Coastlines, borders and place names answer that at a glance and a satellite mosaic doesn't. Hybrid is one click away for the moment the question changes.

### Defaults

- **"Flagged by GBIF" is on by default.** The other cleaning checks are this project's own plausibility heuristics with real false-positive rates, so they stay opt-in; this one is GBIF's verdict on its own record, and a map someone reads a range off shouldn't open on positions the aggregator that published them won't vouch for. Unchecking it puts them back in amber.
- **Preserved specimens follow the taxon again** — on for plants and fungi, off for animals. That's the rule `taxonGroupCountsPreservedSpecimens` already applies to the dashboard's own GBIF counts, so the viewer opens on the record set the count that sent you there described. Living and fossil specimens stay off for everyone; every other type stays on.
- **Records with no coordinates load on the dashboard row too**, not just in fullscreen — the record panel is in both, and a herbarium sheet waiting to be georeferenced is as readable in one as the other.

## Test plan

`npm test` — 1733 tests, 93 files, all passing (the geospatial-issue set and the per-taxon defaults are pinned by new tests). `tsc --noEmit` and `eslint` clean. No console errors in any browser run.

**Paging, walked across the seam** — the cheetah, whose trusted set ends at 8,901 and whose flagged set is 15, in pages of 200 from offset 8,600:

| page | offset | asked | got | of which |
| --- | --- | --- | --- | --- |
| 1 | 8,600 | 200 | 200 | 200 trusted |
| 2 | 8,800 | 200 | 116 | 101 trusted + 15 flagged |
| 3 | 8,916 | 200 | 0 | — |

316 distinct records, no repeats, and every trusted record before every flagged one.

**The sample itself**: `limit=300` returns exactly 300 for both the fur seal (239,191 trusted) and the cheetah (8,901) — all trusted, none flagged. For *Dioscorea biplicata*, which has only 27 trusted records, it returns 28: the 27, then the 1 flagged one.

**In the browser**: the fur seal at 300, then 500 after one click of a button that said 200, then the unmapped clause disappearing once all 367 are in — 867 rows in the list.

### The counts line, and the footer's pager for the unmapped set

![Counts line and footer pager](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-533-one-sample-trusted-first/01-counts-line-and-footer-pager-v3.png)

### The pager, used: 600 rows become 900

![Pager used](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-533-one-sample-trusted-first/02-footer-pager-used-v3.png)

### For a well-collected species the sample never reaches the flagged set at all

*The fur seal has 230 flagged records and 239,191 trusted ones, so none of the flagged are loaded and the row sits greyed at "0 records" — which is the ordering doing its job.*

![Fur seal](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-533-one-sample-trusted-first/03-sample-never-reaches-flagged-v3.png)

### Load more delivers the 200 it promises: 300 → 500

![Load more](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-533-one-sample-trusted-first/04-load-more-delivers-200-v3.png)

### Flagged records hidden by default, and still in the list

*Dioscorea biplicata — the flagged set fits inside the sample here, so the row has something to hide: "1 record hidden", and the footer counts it.*

![Flagged hidden](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-533-one-sample-trusted-first/05-flagged-hidden-by-default-v3.png)

### Uncheck it and the record is back — 27 points become 28, nothing removed by filters

![Flagged shown](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-533-one-sample-trusted-first/06-flagged-shown-v3.png)

### Preserved specimens: on for a plant…

![Plant basis of record](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-533-one-sample-trusted-first/07-plant-preserved-specimens-on-v3.png)

### …off for an animal

![Animal basis of record](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-533-one-sample-trusted-first/08-animal-preserved-specimens-off-v3.png)

### The dashboard row, which loads the unmapped records too

![Dashboard row](https://pub-705b7e62dbf7494db65d38a97f0621b1.r2.dev/pr-533-one-sample-trusted-first/09-dashboard-row-v3.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
